### PR TITLE
feat(map-corridors): add OPFS persistence for KML, GeoJSON, corridors…

### DIFF
--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { GeoJSON } from 'geojson'
+import {
+  detectOPFSWriteSupport,
+  ensureSessionDir,
+  initOPFS,
+  loadOrCreateSessionId,
+  readJSON,
+  readTextFile,
+  writeJSON,
+  writeTextFile,
+} from '../services/opfsService'
+
+type BaseStyle = 'streets' | 'satellite'
+
+export type CorridorsSession = {
+  id: string
+  version: number
+  createdAt: string
+  updatedAt: string
+  baseStyle: BaseStyle
+  use1NmAfterSp: boolean
+  // Persisted artifacts
+  geojson: GeoJSON | null
+  leftSegments: GeoJSON | null
+  rightSegments: GeoJSON | null
+  gates: GeoJSON | null
+  points: GeoJSON | null
+  exactPoints: GeoJSON | null
+  // UI data
+  markers: { id: string; lng: number; lat: number; name: string; label?: 'A'|'B'|'C'|'D'|'E'|'F'|'G'|'H'|'I'|'J'|'K'|'L'|'M'|'N'|'O'|'P'|'Q'|'R'|'S'|'T' }[]
+}
+
+const defaultSession = (id: string): CorridorsSession => ({
+  id,
+  version: 1,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  baseStyle: 'streets',
+  use1NmAfterSp: false,
+  geojson: null,
+  leftSegments: null,
+  rightSegments: null,
+  gates: null,
+  points: null,
+  exactPoints: null,
+  markers: [],
+})
+
+export function useCorridorSessionOPFS() {
+  const [session, setSession] = useState<CorridorsSession | null>(null)
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [opfsAvailable, setOpfsAvailable] = useState<boolean | null>(null)
+
+  const handlesRef = useRef<{ sessionsDir?: FileSystemDirectoryHandle; sessionDir?: FileSystemDirectoryHandle }>({})
+
+  useEffect(() => {
+    (async () => {
+      setOpfsAvailable(null)
+      const ok = await detectOPFSWriteSupport()
+      setOpfsAvailable(ok)
+      const id = loadOrCreateSessionId()
+      setSessionId(id)
+      if (!ok) {
+        setSession(defaultSession(id))
+        return
+      }
+      try {
+        const { sessions } = await initOPFS()
+        const { dir } = await ensureSessionDir({ root: {} as any, sessions }, id)
+        handlesRef.current = { sessionsDir: sessions, sessionDir: dir }
+        const existing = await readJSON<CorridorsSession>(dir, 'session.json')
+        if (existing) {
+          const withDefaults: CorridorsSession = {
+            ...defaultSession(id),
+            ...existing,
+            baseStyle: (existing as any).baseStyle || 'streets',
+          }
+          setSession(withDefaults)
+        } else {
+          const fresh = defaultSession(id)
+          await writeJSON(dir, 'session.json', fresh)
+          setSession(fresh)
+        }
+      } catch (e) {
+        console.error(e)
+        setError('Failed to initialize OPFS')
+        setSession(defaultSession(id))
+      }
+    })()
+  }, [])
+
+  const persistSession = useCallback(async (next: CorridorsSession) => {
+    setSession(next)
+    if (handlesRef.current.sessionDir) {
+      try { await writeJSON(handlesRef.current.sessionDir, 'session.json', next) } catch {}
+    }
+  }, [])
+
+  const setBaseStyle = useCallback(async (style: BaseStyle) => {
+    if (!session) return
+    const next: CorridorsSession = { ...session, baseStyle: style, version: session.version + 1, updatedAt: new Date().toISOString() }
+    await persistSession(next)
+  }, [session, persistSession])
+
+  const setUse1NmAfterSp = useCallback(async (use1: boolean) => {
+    if (!session) return
+    const next: CorridorsSession = { ...session, use1NmAfterSp: use1, version: session.version + 1, updatedAt: new Date().toISOString() }
+    await persistSession(next)
+  }, [session, persistSession])
+
+  const setMarkers = useCallback(async (updater: (prev: CorridorsSession['markers']) => CorridorsSession['markers']) => {
+    if (!session) return
+    const next: CorridorsSession = { ...session, markers: updater(session.markers), version: session.version + 1, updatedAt: new Date().toISOString() }
+    await persistSession(next)
+  }, [session, persistSession])
+
+  const saveOriginalKmlText = useCallback(async (text: string | null) => {
+    if (!session) return
+    const dir = handlesRef.current.sessionDir
+    if (dir) {
+      if (text == null) {
+        // overwrite with empty file for clarity
+        await writeTextFile(dir, 'original.kml', '')
+      } else {
+        await writeTextFile(dir, 'original.kml', text, 'application/vnd.google-earth.kml+xml')
+      }
+    }
+  }, [session])
+
+  const loadOriginalKmlText = useCallback(async (): Promise<string | null> => {
+    const dir = handlesRef.current.sessionDir
+    if (!dir) return null
+    return await readTextFile(dir, 'original.kml')
+  }, [])
+
+  const setComputedData = useCallback(async (payload: {
+    geojson: GeoJSON | null
+    leftSegments: GeoJSON | null
+    rightSegments: GeoJSON | null
+    gates: GeoJSON | null
+    points: GeoJSON | null
+    exactPoints: GeoJSON | null
+  }) => {
+    if (!session) return
+    const next: CorridorsSession = {
+      ...session,
+      ...payload,
+      version: session.version + 1,
+      updatedAt: new Date().toISOString(),
+    }
+    await persistSession(next)
+  }, [session, persistSession])
+
+  return {
+    // state
+    session,
+    sessionId,
+    loading,
+    error,
+    backendAvailable: opfsAvailable,
+    // actions
+    setBaseStyle,
+    setUse1NmAfterSp,
+    setMarkers,
+    setComputedData,
+    saveOriginalKmlText,
+    loadOriginalKmlText,
+    // utils
+    clearError: () => setError(null),
+  }
+}
+
+

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -34,6 +34,10 @@
     "setToken": "Nastavte VITE_MAPBOX_TOKEN v frontend/map-corridors/.env a restartujte dev server.",
     "noOriginalKml": "Původní KML není k dispozici pro export"
   }
+  ,
+  "opfs": {
+    "warning": "Váš prohlížeč nepodporuje plně lokální úložiště (OPFS). Změny se po obnovení ztratí. Zvažte použití Chrome nebo Edge."
+  }
 }
 
 

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -34,6 +34,10 @@
     "setToken": "Set VITE_MAPBOX_TOKEN in frontend/map-corridors/.env and restart the dev server.",
     "noOriginalKml": "Original KML file not available for export"
   }
+  ,
+  "opfs": {
+    "warning": "Your browser does not fully support local storage (OPFS). Changes will not persist after refresh. Consider using Chrome or Edge."
+  }
 }
 
 

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -411,3 +411,4 @@ export function MapProviderView(props: {
 }
 
 
+

--- a/frontend/map-corridors/src/parsers/detect.ts
+++ b/frontend/map-corridors/src/parsers/detect.ts
@@ -3,6 +3,10 @@ import type { GeoJSON } from 'geojson'
 
 export async function parseFileToGeoJSON(file: File): Promise<GeoJSON> {
   const text = await file.text()
+  return parseTextToGeoJSON(text, file.name)
+}
+
+export function parseTextToGeoJSON(text: string, fileNameHint?: string): GeoJSON {
   const parser = new DOMParser()
   const xml = parser.parseFromString(text, 'application/xml')
   // Detect XML parse errors
@@ -12,7 +16,7 @@ export async function parseFileToGeoJSON(file: File): Promise<GeoJSON> {
     throw new Error(`XML parse error: ${msg}`)
   }
 
-  const name = file.name.toLowerCase()
+  const name = (fileNameHint || '').toLowerCase()
   const rootTag = xml.documentElement?.nodeName?.toLowerCase?.() || ''
   const tryParseKml = () => kmlToGeoJSON(xml) as unknown as GeoJSON
   const tryParseGpx = () => gpxToGeoJSON(xml) as unknown as GeoJSON

--- a/frontend/map-corridors/src/services/opfsService.ts
+++ b/frontend/map-corridors/src/services/opfsService.ts
@@ -1,0 +1,113 @@
+const SESSION_STORAGE_KEY = 'airq-corridors-session-id'
+
+export type OPFSHandles = {
+  root: FileSystemDirectoryHandle
+  sessions: FileSystemDirectoryHandle
+}
+
+export async function detectOPFSWriteSupport(): Promise<boolean> {
+  try {
+    const storage: any = (navigator as any).storage
+    if (!storage || typeof storage.getDirectory !== 'function') return false
+    const root: any = await storage.getDirectory?.()
+    if (!root?.getFileHandle || !root?.getDirectoryHandle) return false
+    const test = await root.getFileHandle('opfs-test.tmp', { create: true })
+    if (!test?.createWritable) return false
+    const w = await test.createWritable()
+    await w.write(new Blob([new Uint8Array([1, 2, 3])]))
+    await w.close()
+    try {
+      await root.removeEntry('opfs-test.tmp')
+    } catch {}
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function initOPFS(): Promise<OPFSHandles> {
+  const storage: any = (navigator as any).storage
+  if (!storage || typeof storage.getDirectory !== 'function') {
+    throw new Error('OPFS not supported')
+  }
+  const root: FileSystemDirectoryHandle = await storage.getDirectory()
+  const sessions = await root.getDirectoryHandle('sessions', { create: true })
+  return { root, sessions }
+}
+
+export async function ensureSessionDir(
+  handles: OPFSHandles,
+  sessionId: string
+): Promise<{ dir: FileSystemDirectoryHandle }> {
+  const dir = await handles.sessions.getDirectoryHandle(sessionId, { create: true })
+  return { dir }
+}
+
+export async function writeJSON(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  data: any
+) {
+  const fh = await dir.getFileHandle(name, { create: true })
+  const w = await fh.createWritable()
+  await w.write(new Blob([JSON.stringify(data)], { type: 'application/json' }))
+  await w.close()
+}
+
+export async function readJSON<T>(dir: FileSystemDirectoryHandle, name: string): Promise<T | null> {
+  try {
+    const fh = await dir.getFileHandle(name, { create: false })
+    const file = await fh.getFile()
+    const text = await file.text()
+    return JSON.parse(text) as T
+  } catch {
+    return null
+  }
+}
+
+export async function writeTextFile(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  text: string,
+  mime: string = 'text/plain'
+) {
+  const fh = await dir.getFileHandle(name, { create: true })
+  const w = await fh.createWritable()
+  await w.write(new Blob([text], { type: mime }))
+  await w.close()
+}
+
+export async function readTextFile(
+  dir: FileSystemDirectoryHandle,
+  name: string
+): Promise<string | null> {
+  try {
+    const fh = await dir.getFileHandle(name, { create: false })
+    const file = await fh.getFile()
+    return await file.text()
+  } catch {
+    return null
+  }
+}
+
+export function loadOrCreateSessionId(): string {
+  const existing = localStorage.getItem(SESSION_STORAGE_KEY)
+  if (existing) return existing
+  const id = `corridors-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  localStorage.setItem(SESSION_STORAGE_KEY, id)
+  return id
+}
+
+export async function deleteSessionDir(
+  sessionsDir: FileSystemDirectoryHandle,
+  sessionId: string
+) {
+  const anyDir: any = sessionsDir as any
+  if (typeof anyDir.removeEntry === 'function') {
+    await anyDir.removeEntry(sessionId, { recursive: true })
+  } else {
+    await (sessionsDir as any).removeEntry(sessionId)
+  }
+}
+
+


### PR DESCRIPTION
… and markers

Add OPFS service (services/opfsService.ts) with write support detection, session directory management, JSON/text read/write, and session id handling.

Add useCorridorSessionOPFS hook to manage session state in OPFS: baseStyle, use1NmAfterSp, geojson, computed corridors, and markers.

Persist original KML as original.kml and session.json containing session state; load on startup and recompute corridors as needed.

Integrate hook into App.tsx: wire persistence for baseStyle, SP-after setting, markers; export reads original.kml; show Safari/unsupported OPFS warning.

Add opfs.warning i18n keys in locales (en/cs).

Extend parser with parseTextToGeoJSON(text, fileNameHint).

Fix maximum update depth by guarding recompute effect; recompute only when geojson/SP-after changes.

Fix marker label selection to persist and render on the map; overlays now read from session state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added persistent local storage for corridor data and markers when supported by your browser (OPFS).
  - Displays a warning banner if persistence isn’t supported; advises using Chrome or Edge.
  - Import/export now uses session data for corridors, gates, points, and markers.
- Bug Fixes
  - More robust file import handling, improving parsing of uploaded map files.
- Documentation
  - Added English and Czech warning messages about limited local storage support.
- Style
  - Minor formatting cleanup with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->