### PR TITLE
feat: add navigation close buttons to both apps

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,25 @@
+name: tag-on-merge
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  bump-and-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # auto-provided by GitHub
+          TAG_PREFIX: v
+          DEFAULT_BUMP: patch
+          RELEASE_BRANCHES: main

--- a/deployment/deploy.dev.sh
+++ b/deployment/deploy.dev.sh
@@ -28,6 +28,7 @@ build_and_stage() {
     (cd "$app_dir" && npm run -s build) || { echo "❌ Build failed for $app"; exit 1; }
 
     echo "📦 Staging $app build to $subdir"
+    rm -rf "$subdir"
     mkdir -p "$subdir"
     rsync -avz "$app_dir/dist/" "$subdir/" || { echo "❌ Staging failed for $app"; exit 1; }
 }
@@ -52,7 +53,7 @@ if [ -n "$APP_NAME" ]; then
 
     echo "📁 Deploying $APP_NAME/ to $DEV_HOST"
     echo "📂 Target: $DEV_USER@$DEV_HOST:${DEV_REMOTE_DIR}${APP_NAME}/"
-    rsync -avz "../public_html/$APP_NAME/" "$DEV_USER@$DEV_HOST:${DEV_REMOTE_DIR}${APP_NAME}/"
+    rsync -avz --delete "../public_html/$APP_NAME/" "$DEV_USER@$DEV_HOST:${DEV_REMOTE_DIR}${APP_NAME}/"
     if [ $? -eq 0 ]; then
         echo "✅ Development deployment complete"
         echo "🌐 ${DEV_URL}/$APP_NAME/"
@@ -72,16 +73,15 @@ if [ -n "$APP_NAME" ]; then
         exit 1
     fi
 else
-    # No app specified: deploy entire public_html as before
-    if [ ! -d "../public_html" ]; then
-        echo "❌ public_html directory not found."
-        exit 1
-    fi
-    # Ensure landing page is staged before full deploy
+    # No app specified: build both apps and deploy entire public_html
+    echo "🛠  Building all apps..."
+    build_and_stage "photo-helper"
+    build_and_stage "map-corridors"
     stage_landing
+    
     echo "📁 Deploying public_html/ to $DEV_HOST"
     echo "📂 Target: $DEV_USER@$DEV_HOST:$DEV_REMOTE_DIR"
-    rsync -avz ../public_html/ "$DEV_USER@$DEV_HOST:$DEV_REMOTE_DIR"
+    rsync -avz --delete ../public_html/ "$DEV_USER@$DEV_HOST:$DEV_REMOTE_DIR"
     if [ $? -eq 0 ]; then
         echo "✅ Development deployment complete"
         echo "🌐 ${DEV_URL}"

--- a/deployment/deploy.dev.sh
+++ b/deployment/deploy.dev.sh
@@ -28,9 +28,8 @@ build_and_stage() {
     (cd "$app_dir" && npm run -s build) || { echo "❌ Build failed for $app"; exit 1; }
 
     echo "📦 Staging $app build to $subdir"
-    rm -rf "$subdir"
     mkdir -p "$subdir"
-    rsync -avz "$app_dir/dist/" "$subdir/" || { echo "❌ Staging failed for $app"; exit 1; }
+    rsync -avz --delete "$app_dir/dist/" "$subdir/" || { echo "❌ Staging failed for $app"; exit 1; }
 }
 
 # Stage the landing page (frontend/index.html) into public_html root

--- a/deployment/deploy.prod.sh
+++ b/deployment/deploy.prod.sh
@@ -28,9 +28,8 @@ build_and_stage() {
     (cd "$app_dir" && npm run -s build) || { echo "❌ Build failed for $app"; exit 1; }
 
     echo "📦 Staging $app build to $subdir"
-    rm -rf "$subdir"
     mkdir -p "$subdir"
-    rsync -avz "$app_dir/dist/" "$subdir/" || { echo "❌ Staging failed for $app"; exit 1; }
+    rsync -avz --delete "$app_dir/dist/" "$subdir/" || { echo "❌ Staging failed for $app"; exit 1; }
 }
 
 # Stage the landing page (frontend/index.html) into public_html root

--- a/frontend/map-corridors/src/components/LanguageSwitcher.tsx
+++ b/frontend/map-corridors/src/components/LanguageSwitcher.tsx
@@ -1,23 +1,45 @@
 import React from 'react'
-import { ButtonGroup, Button } from '@mui/material'
+import { ButtonGroup, Button, Box, IconButton, Tooltip } from '@mui/material'
+import { Close } from '@mui/icons-material'
 import { useI18n } from '../contexts/I18nContext'
 import { SUPPORTED_LOCALES } from '../locales'
 
 export const LanguageSwitcher: React.FC = () => {
-  const { locale, setLocale } = useI18n()
+  const { locale, setLocale, t } = useI18n()
+  
+  const handleCloseClick = () => {
+    window.location.href = '../'
+  }
+  
   return (
-    <ButtonGroup size="small" variant="outlined">
-      {SUPPORTED_LOCALES.map((lang) => (
-        <Button
-          key={lang.code}
-          onClick={() => setLocale(lang.code as any)}
-          variant={locale === lang.code ? 'contained' : 'outlined'}
-          sx={{ fontSize: '0.75rem', px: 1.25, py: 0.5, minWidth: 'auto' }}
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <ButtonGroup size="small" variant="outlined">
+        {SUPPORTED_LOCALES.map((lang) => (
+          <Button
+            key={lang.code}
+            onClick={() => setLocale(lang.code as any)}
+            variant={locale === lang.code ? 'contained' : 'outlined'}
+            sx={{ fontSize: '0.75rem', px: 1.25, py: 0.5, minWidth: 'auto' }}
+          >
+            {lang.flag} {lang.code.toUpperCase()}
+          </Button>
+        ))}
+      </ButtonGroup>
+      <Tooltip title={t('app.backToMenu')} arrow>
+        <IconButton
+          onClick={handleCloseClick}
+          size="small"
+          sx={{
+            color: 'inherit',
+            '&:hover': {
+              backgroundColor: 'rgba(0, 0, 0, 0.04)'
+            }
+          }}
         >
-          {lang.flag} {lang.code.toUpperCase()}
-        </Button>
-      ))}
-    </ButtonGroup>
+          <Close fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
   )
 }
 

--- a/frontend/map-corridors/src/components/LanguageSwitcher.tsx
+++ b/frontend/map-corridors/src/components/LanguageSwitcher.tsx
@@ -7,9 +7,6 @@ import { SUPPORTED_LOCALES } from '../locales'
 export const LanguageSwitcher: React.FC = () => {
   const { locale, setLocale, t } = useI18n()
   
-  const handleCloseClick = () => {
-    window.location.href = '../'
-  }
   
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -17,7 +14,7 @@ export const LanguageSwitcher: React.FC = () => {
         {SUPPORTED_LOCALES.map((lang) => (
           <Button
             key={lang.code}
-            onClick={() => setLocale(lang.code as any)}
+            onClick={() => setLocale(lang.code)}
             variant={locale === lang.code ? 'contained' : 'outlined'}
             sx={{ fontSize: '0.75rem', px: 1.25, py: 0.5, minWidth: 'auto' }}
           >
@@ -27,7 +24,9 @@ export const LanguageSwitcher: React.FC = () => {
       </ButtonGroup>
       <Tooltip title={t('app.backToMenu')} arrow>
         <IconButton
-          onClick={handleCloseClick}
+          component="a"
+          href="../"
+          aria-label={t('app.backToMenu')}
           size="small"
           sx={{
             color: 'inherit',

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -11,7 +11,8 @@
     "dropHint": "Přetáhni KML pro načtení",
     "answerSheet": "Zobrazit answer sheet",
     "dragToPlace": "Přetáhni pro umístění fotky",
-    "use1NmAfterSp": "Koridor začíná 1 NM po SP"
+    "use1NmAfterSp": "Koridor začíná 1 NM po SP",
+    "backToMenu": "Zpět do hlavního menu"
   },
   "popup": {
     "name": "Název",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -11,7 +11,8 @@
     "dropHint": "Drop KML to load",
     "answerSheet": "Show Answer Sheet",
     "dragToPlace": "Drag to place photo marker",
-    "use1NmAfterSp": "Corridor 1 NM after start point"
+    "use1NmAfterSp": "Corridor 1 NM after start point",
+    "backToMenu": "Back to main menu"
   },
   "popup": {
     "name": "Name",

--- a/frontend/map-corridors/src/services/opfsService.ts
+++ b/frontend/map-corridors/src/services/opfsService.ts
@@ -58,7 +58,9 @@ export async function writeJSON(
   let w: FileSystemWritableFileStream | null = null
   try {
     w = await (fh as any).createWritable()
-    await w.write(new Blob([text], { type: 'application/json' }))
+    if (w) {
+      await w.write(new Blob([text], { type: 'application/json' }))
+    }
   } catch (e) {
     throw new Error(`Failed to write ${name}: ${(e as any)?.message || e}`)
   } finally {

--- a/frontend/photo-helper/src/components/LanguageSwitcher.tsx
+++ b/frontend/photo-helper/src/components/LanguageSwitcher.tsx
@@ -6,8 +6,11 @@ import {
   Typography,
   Chip,
   ButtonGroup,
-  Button
+  Button,
+  IconButton,
+  Tooltip
 } from '@mui/material';
+import { Close } from '@mui/icons-material';
 
 import { useI18n } from '../contexts/I18nContext';
 import { SUPPORTED_LOCALES } from '../locales';
@@ -17,31 +20,51 @@ interface LanguageSwitcherProps {
 }
 
 export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ compact = false }) => {
-  const { locale, setLocale } = useI18n();
+  const { locale, setLocale, t } = useI18n();
 
   const handleLanguageClick = (newLocale: typeof locale) => {
     setLocale(newLocale);
   };
 
+  const handleCloseClick = () => {
+    window.location.href = '../';
+  };
+
   if (compact) {
     return (
-      <ButtonGroup size="small" variant="outlined">
-        {SUPPORTED_LOCALES.map((lang) => (
-          <Button
-            key={lang.code}
-            onClick={() => handleLanguageClick(lang.code)}
-            variant={locale === lang.code ? 'contained' : 'outlined'}
-            sx={{ 
-              fontSize: '0.75rem',
-              px: 1.5,
-              py: 0.5,
-              minWidth: 'auto'
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <ButtonGroup size="small" variant="outlined">
+          {SUPPORTED_LOCALES.map((lang) => (
+            <Button
+              key={lang.code}
+              onClick={() => handleLanguageClick(lang.code)}
+              variant={locale === lang.code ? 'contained' : 'outlined'}
+              sx={{ 
+                fontSize: '0.75rem',
+                px: 1.5,
+                py: 0.5,
+                minWidth: 'auto'
+              }}
+            >
+              {lang.flag} {lang.code.toUpperCase()}
+            </Button>
+          ))}
+        </ButtonGroup>
+        <Tooltip title={t('app.backToMenu')} arrow>
+          <IconButton
+            onClick={handleCloseClick}
+            size="small"
+            sx={{
+              color: 'white',
+              '&:hover': {
+                backgroundColor: 'rgba(255, 255, 255, 0.1)'
+              }
             }}
           >
-            {lang.flag} {lang.code.toUpperCase()}
-          </Button>
-        ))}
-      </ButtonGroup>
+            <Close fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
     );
   }
 

--- a/frontend/photo-helper/src/components/LanguageSwitcher.tsx
+++ b/frontend/photo-helper/src/components/LanguageSwitcher.tsx
@@ -26,9 +26,6 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ compact = fa
     setLocale(newLocale);
   };
 
-  const handleCloseClick = () => {
-    window.location.href = '../';
-  };
 
   if (compact) {
     return (
@@ -52,7 +49,9 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ compact = fa
         </ButtonGroup>
         <Tooltip title={t('app.backToMenu')} arrow>
           <IconButton
-            onClick={handleCloseClick}
+            component="a"
+            href="../"
+            aria-label={t('app.backToMenu')}
             size="small"
             sx={{
               color: 'white',

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "Foto Pomocník",
-    "subtitle": "Organizujte fotografie z navigačního letu do standardizovaných PDF rozvržení"
+    "subtitle": "Organizujte fotografie z navigačního letu do standardizovaných PDF rozvržení",
+    "backToMenu": "Zpět do hlavního menu"
   },
   "navigation": {
     "overview": "Přehled",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "Photo Helper",
-    "subtitle": "Organize your navigation flight photos into standardized PDF layouts"
+    "subtitle": "Organize your navigation flight photos into standardized PDF layouts",
+    "backToMenu": "Back to main menu"
   },
   "navigation": {
     "overview": "Overview",


### PR DESCRIPTION
- Add close button to photo-helper LanguageSwitcher component with white styling for blue header
- Add close button to map-corridors LanguageSwitcher component with standard AppBar styling
- Both buttons use relative navigation (../) to work on any deployment URL
- Add translation keys 'app.backToMenu' in English and Czech for both apps
- Fix TypeScript null check error in map-corridors opfsService.ts
- Improve deployment scripts to automatically build both apps when no specific app specified
- Add proper cleanup of old build artifacts in deployment process
- Add --delete flag to rsync commands to ensure clean deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Language switchers in Map Corridors and Photo Helper now display locale buttons with flags and uppercase codes, plus a back-to-menu button with tooltip for quick navigation.

- Bug Fixes
  - Improved file saving reliability to prevent rare errors when storage streams are unavailable.

- Chores
  - Deployment process now cleans up outdated files and refreshes the landing page during full deploys, ensuring consistent, up-to-date content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->