### PR TITLE
feat: improve UX with language persistence and unified homepage

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -51,28 +51,41 @@ jobs:
           VITE_DESKTOP_BUILD: 'true'
         run: npm run build
 
-      - name: Update version (if provided)
-        if: ${{ github.event.inputs.version != '' }}
-        working-directory: frontend/desktop
+      - name: Get version
+        id: get_version
+        shell: pwsh
         run: |
-          $json = Get-Content package.json | ConvertFrom-Json
-          $json.version = "${{ github.event.inputs.version }}"
-          $json | ConvertTo-Json -Depth 100 | Set-Content package.json
-
-      - name: Extract version from tag
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
-        id: tag_version
-        run: |
-          $version = "${{ github.ref_name }}" -replace '^desktop-v', ''
+          if ("${{ github.event.inputs.version }}" -ne "") {
+            # Manual input takes priority
+            $version = "${{ github.event.inputs.version }}"
+          } elseif ("${{ github.ref_name }}".StartsWith("desktop-v")) {
+            # Extract from desktop tag
+            $version = "${{ github.ref_name }}" -replace '^desktop-v', ''
+          } else {
+            # Get latest tag from repo
+            git fetch --tags --quiet
+            try {
+              $latestTag = git tag --sort=-v:refname | Select-Object -First 1
+              if ($latestTag) {
+                $version = $latestTag -replace '^v', '' -replace '^desktop-v', ''
+              } else {
+                $version = "1.0.0"
+              }
+            } catch {
+              $version = "1.0.0"
+            }
+          }
           echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          Write-Host "Using version: $version"
 
-      - name: Update version from tag
-        if: startsWith(github.ref, 'refs/tags/desktop-v')
+      - name: Update package.json version
         working-directory: frontend/desktop
+        shell: pwsh
         run: |
           $json = Get-Content package.json | ConvertFrom-Json
-          $json.version = "${{ steps.tag_version.outputs.VERSION }}"
+          $json.version = "${{ steps.get_version.outputs.VERSION }}"
           $json | ConvertTo-Json -Depth 100 | Set-Content package.json
+          Write-Host "Set version to: ${{ steps.get_version.outputs.VERSION }}"
 
       - name: Build Windows executables
         working-directory: frontend/desktop
@@ -120,3 +133,6 @@ jobs:
 
             ### System Requirements
             - Windows 10/11 (64-bit)
+
+            ### Changes
+            See [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -226,6 +226,15 @@ ipcMain.handle('open-mapbox-settings', () => {
   showMapboxTokenDialog();
 });
 
+// Update menu language
+ipcMain.handle('set-menu-locale', (event, locale) => {
+  // Map 'cz' to 'cs' for internal use
+  const menuLocale = locale === 'cz' ? 'cs' : locale;
+  if (menuLocale !== currentMenuLocale) {
+    createMenu(menuLocale);
+  }
+});
+
 // Show Mapbox token dialog - single window with input field
 async function showMapboxTokenDialog() {
   const currentToken = getConfigValue('mapboxToken') || '';
@@ -299,23 +308,64 @@ async function showMapboxTokenDialog() {
   inputWindow.setMenu(null);
 }
 
+// Menu translations
+const menuTranslations = {
+  en: {
+    navigation: 'Navigation',
+    home: 'Home',
+    photoHelper: 'Photo Helper',
+    mapCorridors: 'Map Corridors',
+    back: 'Back',
+    forward: 'Forward',
+    reload: 'Reload',
+    view: 'View',
+    toggleFullScreen: 'Toggle Full Screen',
+    toggleDevTools: 'Toggle Developer Tools',
+    zoomIn: 'Zoom In',
+    zoomOut: 'Zoom Out',
+    resetZoom: 'Reset Zoom',
+    settings: 'Settings',
+    mapboxToken: 'Mapbox Token...',
+    help: 'Help',
+    about: 'About',
+    aboutDetail: 'Desktop application for FAI Rally Flying competitions.'
+  },
+  cs: {
+    navigation: 'Navigace',
+    home: 'Domů',
+    photoHelper: 'Foto pomocník',
+    mapCorridors: 'Foto koridory',
+    back: 'Zpět',
+    forward: 'Vpřed',
+    reload: 'Obnovit',
+    view: 'Zobrazení',
+    toggleFullScreen: 'Celá obrazovka',
+    toggleDevTools: 'Vývojářské nástroje',
+    zoomIn: 'Přiblížit',
+    zoomOut: 'Oddálit',
+    resetZoom: 'Obnovit zvětšení',
+    settings: 'Nastavení',
+    mapboxToken: 'Mapbox Token...',
+    help: 'Nápověda',
+    about: 'O aplikaci',
+    aboutDetail: 'Desktopová aplikace pro soutěže FAI Rally Flying.'
+  }
+};
+
+// Current menu locale
+let currentMenuLocale = 'cs';
+
 // Create application menu
-function createMenu() {
+function createMenu(locale = 'cs') {
+  currentMenuLocale = locale;
+  const t = menuTranslations[locale] || menuTranslations.cs;
+
   const template = [
     {
-      label: 'Settings',
+      label: t.navigation,
       submenu: [
         {
-          label: 'Mapbox Token...',
-          click: () => showMapboxTokenDialog()
-        }
-      ]
-    },
-    {
-      label: 'Navigation',
-      submenu: [
-        {
-          label: 'Home',
+          label: t.home,
           accelerator: 'Alt+Home',
           click: () => {
             if (mainWindow) {
@@ -324,7 +374,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Photo Helper',
+          label: t.photoHelper,
           accelerator: 'Alt+1',
           click: () => {
             if (mainWindow) {
@@ -333,7 +383,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Map Corridors',
+          label: t.mapCorridors,
           accelerator: 'Alt+2',
           click: () => {
             if (mainWindow) {
@@ -343,7 +393,7 @@ function createMenu() {
         },
         { type: 'separator' },
         {
-          label: 'Back',
+          label: t.back,
           accelerator: 'Alt+Left',
           click: () => {
             if (mainWindow && mainWindow.webContents.canGoBack()) {
@@ -352,7 +402,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Forward',
+          label: t.forward,
           accelerator: 'Alt+Right',
           click: () => {
             if (mainWindow && mainWindow.webContents.canGoForward()) {
@@ -362,7 +412,7 @@ function createMenu() {
         },
         { type: 'separator' },
         {
-          label: 'Reload',
+          label: t.reload,
           accelerator: 'CmdOrCtrl+R',
           click: () => {
             if (mainWindow) {
@@ -373,10 +423,10 @@ function createMenu() {
       ]
     },
     {
-      label: 'View',
+      label: t.view,
       submenu: [
         {
-          label: 'Toggle Full Screen',
+          label: t.toggleFullScreen,
           accelerator: 'F11',
           click: () => {
             if (mainWindow) {
@@ -385,7 +435,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Toggle Developer Tools',
+          label: t.toggleDevTools,
           accelerator: 'CmdOrCtrl+Shift+I',
           click: () => {
             if (mainWindow) {
@@ -395,7 +445,7 @@ function createMenu() {
         },
         { type: 'separator' },
         {
-          label: 'Zoom In',
+          label: t.zoomIn,
           accelerator: 'CmdOrCtrl+Plus',
           click: () => {
             if (mainWindow) {
@@ -405,7 +455,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Zoom Out',
+          label: t.zoomOut,
           accelerator: 'CmdOrCtrl+-',
           click: () => {
             if (mainWindow) {
@@ -415,7 +465,7 @@ function createMenu() {
           }
         },
         {
-          label: 'Reset Zoom',
+          label: t.resetZoom,
           accelerator: 'CmdOrCtrl+0',
           click: () => {
             if (mainWindow) {
@@ -426,17 +476,26 @@ function createMenu() {
       ]
     },
     {
-      label: 'Help',
+      label: t.settings,
       submenu: [
         {
-          label: 'About',
+          label: t.mapboxToken,
+          click: () => showMapboxTokenDialog()
+        }
+      ]
+    },
+    {
+      label: t.help,
+      submenu: [
+        {
+          label: t.about,
           click: () => {
             const { dialog } = require('electron');
             dialog.showMessageBox(mainWindow, {
               type: 'info',
-              title: 'About',
+              title: t.about,
               message: 'AirQ Competition Helpers',
-              detail: `Desktop application for FAI Rally Flying competitions.\n\nVersion: ${app.getVersion()}\n\nTools:\n- Photo Helper\n- Map Corridors`
+              detail: `${t.aboutDetail}\n\nVersion: ${app.getVersion()}\n\nTools:\n- ${t.photoHelper}\n- ${t.mapCorridors}`
             });
           }
         }

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -19,6 +19,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Open Mapbox token settings dialog
   openMapboxSettings: () => ipcRenderer.invoke('open-mapbox-settings'),
 
+  // Update menu language
+  setMenuLocale: (locale) => ipcRenderer.invoke('set-menu-locale', locale),
+
   // Check if running in Electron
   isElectron: true,
 

--- a/frontend/desktop/renderer/app.js
+++ b/frontend/desktop/renderer/app.js
@@ -1,3 +1,98 @@
+// Translations
+const translations = {
+  cs: {
+    title: 'Nástroje pro navigační soutěže',
+    subtitle: 'Vyberte aplikaci',
+    'corridors.title': 'Foto koridory',
+    'corridors.desc': 'Interaktivní vizualizace koridorů',
+    'helper.title': 'Foto pomocník',
+    'helper.desc': 'Organizace a označování soutěžních fotek'
+  },
+  en: {
+    title: 'Navigation Flying Tools',
+    subtitle: 'Select an application',
+    'corridors.title': 'Photo Corridors',
+    'corridors.desc': 'Interactive corridor visualization',
+    'helper.title': 'Photo Helper',
+    'helper.desc': 'Organize and label competition photos'
+  }
+};
+
+// Language handling - uses Electron config in desktop, localStorage in browser
+const LOCALE_KEY = 'app-locale';
+
+async function getLocale() {
+  // In Electron, use config storage (shared across all app:// origins)
+  if (window.electronAPI?.getConfig) {
+    const saved = await window.electronAPI.getConfig('locale');
+    if (saved === 'cz') return 'cs';
+    if (saved === 'cs' || saved === 'en') return saved;
+  } else {
+    // Browser fallback
+    const saved = localStorage.getItem(LOCALE_KEY);
+    if (saved === 'cz') return 'cs';
+    if (saved === 'cs' || saved === 'en') return saved;
+  }
+  return 'cs'; // default
+}
+
+async function setLocale(locale) {
+  // Store as 'cz' for React apps compatibility (they expect 'cz' not 'cs')
+  const storageValue = locale === 'cs' ? 'cz' : locale;
+
+  // In Electron, use config storage
+  if (window.electronAPI?.setConfig) {
+    await window.electronAPI.setConfig('locale', storageValue);
+  } else {
+    localStorage.setItem(LOCALE_KEY, storageValue);
+  }
+
+  applyTranslations(locale);
+  updateLangButtons(locale);
+  document.documentElement.lang = locale;
+
+  // Update Electron menu language
+  if (window.electronAPI?.setMenuLocale) {
+    window.electronAPI.setMenuLocale(storageValue);
+  }
+}
+
+function applyTranslations(locale) {
+  const t = translations[locale] || translations.cs;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.dataset.i18n;
+    if (t[key]) {
+      el.textContent = t[key];
+    }
+  });
+}
+
+function updateLangButtons(locale) {
+  document.querySelectorAll('.lang-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.lang === locale);
+  });
+}
+
+// Initialize language
+(async () => {
+  const currentLocale = await getLocale();
+  applyTranslations(currentLocale);
+  updateLangButtons(currentLocale);
+  document.documentElement.lang = currentLocale;
+  // Set initial menu language
+  if (window.electronAPI?.setMenuLocale) {
+    const storageValue = currentLocale === 'cs' ? 'cz' : currentLocale;
+    window.electronAPI.setMenuLocale(storageValue);
+  }
+})();
+
+// Language switcher
+document.querySelectorAll('.lang-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    setLocale(btn.dataset.lang);
+  });
+});
+
 // Card navigation
 document.querySelectorAll('.card').forEach(card => {
   const navigate = () => {
@@ -6,7 +101,7 @@ document.querySelectorAll('.card').forEach(card => {
       window.electronAPI.navigateToApp(appName);
     } else {
       // Fallback for testing in browser
-      window.location.href = `app://${appName}/index.html`;
+      window.location.href = `../${appName}/index.html`;
     }
   };
 

--- a/frontend/desktop/renderer/index.html
+++ b/frontend/desktop/renderer/index.html
@@ -8,9 +8,29 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
+    <div class="lang-switcher">
+      <button class="lang-btn" data-lang="cs" title="Čeština">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width="20" height="13">
+          <rect width="900" height="600" fill="#d7141a"/>
+          <rect width="900" height="300" fill="#fff"/>
+          <path d="M 0,0 L 450,300 L 0,600 Z" fill="#11457e"/>
+        </svg>
+        CZ
+      </button>
+      <button class="lang-btn" data-lang="en" title="English">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900" width="20" height="11">
+          <rect width="7410" height="3900" fill="#b22234"/>
+          <path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" stroke-width="300"/>
+          <rect width="2964" height="2100" fill="#3c3b6e"/>
+          <g fill="#fff"><g id="s18"><g id="s9"><g id="s5"><g id="s4"><path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/><use href="#s" y="420"/><use href="#s" y="840"/><use href="#s" y="1260"/></g><use href="#s" y="1680"/></g><use href="#s4" x="247" y="210"/></g><use href="#s9" x="494"/></g><use href="#s18" x="988"/><use href="#s9" x="1976"/></g>
+        </svg>
+        EN
+      </button>
+    </div>
+
     <header>
-      <h1>Pomocné nástroje</h1>
-      <p>Vyberte aplikaci</p>
+      <h1 data-i18n="title">Nástroje pro navigační soutěže</h1>
+      <p data-i18n="subtitle">Vyberte aplikaci</p>
     </header>
 
     <main class="apps">
@@ -23,8 +43,8 @@
           </svg>
         </span>
         <span class="meta">
-          <span class="title">Foto koridory</span>
-          <span class="desc">Interaktivní vizualizace koridorů</span>
+          <span class="title" data-i18n="corridors.title">Foto koridory</span>
+          <span class="desc" data-i18n="corridors.desc">Interaktivní vizualizace koridorů</span>
         </span>
       </div>
 
@@ -37,8 +57,8 @@
           </svg>
         </span>
         <span class="meta">
-          <span class="title">Foto pomocník</span>
-          <span class="desc">Organizace a označování soutěžních fotek</span>
+          <span class="title" data-i18n="helper.title">Foto pomocník</span>
+          <span class="desc" data-i18n="helper.desc">Organizace a označování soutěžních fotek</span>
         </span>
       </div>
     </main>

--- a/frontend/desktop/renderer/styles.css
+++ b/frontend/desktop/renderer/styles.css
@@ -8,8 +8,47 @@ body {
   min-height: 100vh;
 }
 
+/* Language switcher */
+.lang-switcher {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  gap: 6px;
+}
+
+.lang-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid #E2E8F0;
+  border-radius: 6px;
+  background: #FFFFFF;
+  color: #4A5568;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+
+.lang-btn svg {
+  flex-shrink: 0;
+}
+
+.lang-btn:hover {
+  border-color: #CBD5E0;
+  background: #F7FAFC;
+}
+
+.lang-btn.active {
+  border-color: #1976D2;
+  background: #EBF5FF;
+  color: #1976D2;
+}
+
 header {
-  padding: 32px 16px 8px;
+  padding: 48px 16px 8px;
   text-align: center;
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,18 +3,52 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pomůcky na závody</title>
+    <title>AirQ Competition Helpers</title>
     <style>
       :root { color-scheme: light; }
-      * { box-sizing: border-box; }
+      * { box-sizing: border-box; margin: 0; padding: 0; }
       body {
-        margin: 0;
         font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
         color: #1A202C;
         background: #F8FAFC;
+        min-height: 100vh;
+      }
+      /* Language switcher */
+      .lang-switcher {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        display: flex;
+        gap: 6px;
+      }
+      .lang-btn {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        font-size: 13px;
+        font-weight: 500;
+        border: 1px solid #E2E8F0;
+        border-radius: 6px;
+        background: #FFFFFF;
+        color: #4A5568;
+        cursor: pointer;
+        transition: all 120ms ease;
+      }
+      .lang-btn svg {
+        flex-shrink: 0;
+      }
+      .lang-btn:hover {
+        border-color: #CBD5E0;
+        background: #F7FAFC;
+      }
+      .lang-btn.active {
+        border-color: #1976D2;
+        background: #EBF5FF;
+        color: #1976D2;
       }
       header {
-        padding: 32px 16px 8px;
+        padding: 48px 16px 8px;
         text-align: center;
       }
       header h1 { margin: 0 0 8px; font-size: 1.75rem; font-weight: 700; }
@@ -39,11 +73,15 @@
         text-decoration: none;
         color: inherit;
         transition: transform 120ms ease, box-shadow 120ms ease, border-color 120ms ease;
+        user-select: none;
       }
       .card:hover {
         transform: translateY(-2px);
         border-color: #BFDBFE;
         box-shadow: 0 6px 16px rgba(2,136,209,0.12);
+      }
+      .card:active {
+        transform: translateY(0);
       }
       .card[aria-disabled="true"] {
         opacity: 0.6;
@@ -63,59 +101,165 @@
         border-radius: 10px;
         background: linear-gradient(135deg, #1976D2 0%, #42A5F5 100%);
         color: white;
-        overflow: hidden;
+        flex-shrink: 0;
       }
-      .icon img { width: 28px; height: 28px; display: block; }
+      .icon svg {
+        width: 24px;
+        height: 24px;
+      }
       .meta { display: grid; gap: 2px; }
       .meta .title { font-weight: 700; }
       .meta .desc { color: #4A5568; font-size: 0.9rem; }
-      footer {
-        text-align: center;
-        color: #4A5568;
-        padding: 24px 12px 40px;
-      }
     </style>
   </head>
   <body>
+    <div class="lang-switcher">
+      <button class="lang-btn" data-lang="cs" title="Čeština">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width="20" height="13">
+          <rect width="900" height="600" fill="#d7141a"/>
+          <rect width="900" height="300" fill="#fff"/>
+          <path d="M 0,0 L 450,300 L 0,600 Z" fill="#11457e"/>
+        </svg>
+        CZ
+      </button>
+      <button class="lang-btn" data-lang="en" title="English">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900" width="20" height="11">
+          <rect width="7410" height="3900" fill="#b22234"/>
+          <path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" stroke-width="300"/>
+          <rect width="2964" height="2100" fill="#3c3b6e"/>
+          <g fill="#fff"><g id="s18"><g id="s9"><g id="s5"><g id="s4"><path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/><use href="#s" y="420"/><use href="#s" y="840"/><use href="#s" y="1260"/></g><use href="#s" y="1680"/></g><use href="#s4" x="247" y="210"/></g><use href="#s9" x="494"/></g><use href="#s18" x="988"/><use href="#s9" x="1976"/></g>
+        </svg>
+        EN
+      </button>
+    </div>
+
     <header>
-      <h1>Pomocné nástroje</h1>
-      <p>Vyberte aplikaci</p>
+      <h1 data-i18n="title">Nástroje pro navigační soutěže</h1>
+      <p data-i18n="subtitle">Vyberte aplikaci</p>
     </header>
 
     <main class="apps">
-      <a class="card" href="./map-corridors/" aria-label="Otevřít Foto koridory">
+      <a class="card" href="./map-corridors/" data-i18n-aria="corridors.aria">
         <span class="icon">
-          <img src="./map-corridors/vite.svg" alt="Map Corridors" />
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"></polygon>
+            <line x1="8" y1="2" x2="8" y2="18"></line>
+            <line x1="16" y1="6" x2="16" y2="22"></line>
+          </svg>
         </span>
         <span class="meta">
-          <span class="title">Foto koridory</span>
-          <span class="desc">Interaktivní vizualizace koridorů</span>
+          <span class="title" data-i18n="corridors.title">Foto koridory</span>
+          <span class="desc" data-i18n="corridors.desc">Interaktivní vizualizace koridorů</span>
         </span>
       </a>
 
-      <a class="card" href="./photo-helper/" aria-label="Otevřít Foto pomocníka">
+      <a class="card" href="./photo-helper/" data-i18n-aria="helper.aria">
         <span class="icon">
-          <img src="./photo-helper/vite.svg" alt="Photo Helper" />
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <circle cx="8.5" cy="8.5" r="1.5"></circle>
+            <polyline points="21 15 16 10 5 21"></polyline>
+          </svg>
         </span>
         <span class="meta">
-          <span class="title">Foto pomocník</span>
-          <span class="desc">Organizace a označování soutěžních fotek</span>
+          <span class="title" data-i18n="helper.title">Foto pomocník</span>
+          <span class="desc" data-i18n="helper.desc">Organizace a označování soutěžních fotek</span>
         </span>
       </a>
 
-      <div class="card" aria-disabled="true" aria-label="Generátor instrukcí (Práce probíhá)">
+      <div class="card" aria-disabled="true" data-i18n-aria="generator.aria">
         <span class="icon">
-          <img src="./photo-helper/vite.svg" alt="" />
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+            <polyline points="14 2 14 8 20 8"></polyline>
+            <line x1="16" y1="13" x2="8" y2="13"></line>
+            <line x1="16" y1="17" x2="8" y2="17"></line>
+            <polyline points="10 9 9 9 8 9"></polyline>
+          </svg>
         </span>
         <span class="meta">
-          <span class="title">Generátor instrukcí</span>
-          <span class="desc">Práce probíhá</span>
+          <span class="title" data-i18n="generator.title">Generátor instrukcí</span>
+          <span class="desc" data-i18n="generator.desc">Práce probíhá</span>
         </span>
       </div>
     </main>
 
-    
+    <script>
+      // Translations
+      const translations = {
+        cs: {
+          title: 'Nástroje pro navigační soutěže',
+          subtitle: 'Vyberte aplikaci',
+          'corridors.title': 'Foto koridory',
+          'corridors.desc': 'Interaktivní vizualizace koridorů',
+          'corridors.aria': 'Otevřít Foto koridory',
+          'helper.title': 'Foto pomocník',
+          'helper.desc': 'Organizace a označování soutěžních fotek',
+          'helper.aria': 'Otevřít Foto pomocníka',
+          'generator.title': 'Generátor instrukcí',
+          'generator.desc': 'Práce probíhá',
+          'generator.aria': 'Generátor instrukcí (Práce probíhá)'
+        },
+        en: {
+          title: 'Navigation Flying Tools',
+          subtitle: 'Select an application',
+          'corridors.title': 'Photo Corridors',
+          'corridors.desc': 'Interactive corridor visualization',
+          'corridors.aria': 'Open Photo Corridors',
+          'helper.title': 'Photo Helper',
+          'helper.desc': 'Organize and label competition photos',
+          'helper.aria': 'Open Photo Helper',
+          'generator.title': 'Instruction Generator',
+          'generator.desc': 'Work in progress',
+          'generator.aria': 'Instruction Generator (Work in progress)'
+        }
+      };
+
+      const LOCALE_KEY = 'app-locale';
+
+      function getLocale() {
+        const saved = localStorage.getItem(LOCALE_KEY);
+        if (saved === 'cz') return 'cs';
+        if (saved === 'cs' || saved === 'en') return saved;
+        return 'cs';
+      }
+
+      function setLocale(locale) {
+        const storageValue = locale === 'cs' ? 'cz' : locale;
+        localStorage.setItem(LOCALE_KEY, storageValue);
+        applyTranslations(locale);
+        updateLangButtons(locale);
+        document.documentElement.lang = locale;
+      }
+
+      function applyTranslations(locale) {
+        const t = translations[locale] || translations.cs;
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+          const key = el.dataset.i18n;
+          if (t[key]) el.textContent = t[key];
+        });
+        document.querySelectorAll('[data-i18n-aria]').forEach(el => {
+          const key = el.dataset.i18nAria;
+          if (t[key]) el.setAttribute('aria-label', t[key]);
+        });
+      }
+
+      function updateLangButtons(locale) {
+        document.querySelectorAll('.lang-btn').forEach(btn => {
+          btn.classList.toggle('active', btn.dataset.lang === locale);
+        });
+      }
+
+      // Initialize
+      const currentLocale = getLocale();
+      applyTranslations(currentLocale);
+      updateLangButtons(currentLocale);
+      document.documentElement.lang = currentLocale;
+
+      // Language switcher events
+      document.querySelectorAll('.lang-btn').forEach(btn => {
+        btn.addEventListener('click', () => setLocale(btn.dataset.lang));
+      });
+    </script>
   </body>
-  </html>
-
-
+</html>

--- a/frontend/map-corridors/src/components/LanguageSwitcher.tsx
+++ b/frontend/map-corridors/src/components/LanguageSwitcher.tsx
@@ -4,10 +4,39 @@ import { Close } from '@mui/icons-material'
 import { useI18n } from '../contexts/I18nContext'
 import { SUPPORTED_LOCALES } from '../locales'
 
+// SVG Flag components (Windows doesn't render emoji flags)
+const CzechFlag = ({ size = 20 }: { size?: number }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width={size} height={size * 0.67}>
+    <rect width="900" height="600" fill="#d7141a"/>
+    <rect width="900" height="300" fill="#fff"/>
+    <path d="M 0,0 L 450,300 L 0,600 Z" fill="#11457e"/>
+  </svg>
+)
+
+const USFlag = ({ size = 20 }: { size?: number }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900" width={size} height={size * 0.53}>
+    <rect width="7410" height="3900" fill="#b22234"/>
+    <path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" strokeWidth="300"/>
+    <rect width="2964" height="2100" fill="#3c3b6e"/>
+    <g fill="#fff">
+      <g id="s18"><g id="s9"><g id="s5"><g id="s4">
+        <path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/>
+        <use href="#s" y="420"/><use href="#s" y="840"/><use href="#s" y="1260"/>
+      </g><use href="#s" y="1680"/></g><use href="#s4" x="247" y="210"/></g>
+      <use href="#s9" x="494"/></g><use href="#s18" x="988"/><use href="#s9" x="1976"/>
+    </g>
+  </svg>
+)
+
+const FlagIcon = ({ code, size = 20 }: { code: string; size?: number }) => {
+  if (code === 'cz') return <CzechFlag size={size} />
+  if (code === 'en') return <USFlag size={size} />
+  return null
+}
+
 export const LanguageSwitcher: React.FC = () => {
   const { locale, setLocale, t } = useI18n()
-  
-  
+
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
       <ButtonGroup size="small" variant="outlined">
@@ -16,16 +45,17 @@ export const LanguageSwitcher: React.FC = () => {
             key={lang.code}
             onClick={() => setLocale(lang.code)}
             variant={locale === lang.code ? 'contained' : 'outlined'}
-            sx={{ fontSize: '0.75rem', px: 1.25, py: 0.5, minWidth: 'auto' }}
+            sx={{ fontSize: '0.75rem', px: 1.25, py: 0.5, minWidth: 'auto', display: 'flex', gap: 0.5 }}
           >
-            {lang.flag} {lang.code.toUpperCase()}
+            <FlagIcon code={lang.code} size={16} /> {lang.code.toUpperCase()}
           </Button>
         ))}
       </ButtonGroup>
       <Tooltip title={t('app.backToMenu')} arrow>
         <IconButton
           component="a"
-          href="../"
+          href={(window as any).electronAPI ? undefined : '../'}
+          onClick={(window as any).electronAPI ? () => (window as any).electronAPI.goHome() : undefined}
           aria-label={t('app.backToMenu')}
           size="small"
           sx={{

--- a/frontend/map-corridors/src/contexts/I18nContext.tsx
+++ b/frontend/map-corridors/src/contexts/I18nContext.tsx
@@ -27,29 +27,65 @@ const interpolate = (text: string, params?: Record<string, string | number>): st
 interface I18nProviderProps { children: ReactNode }
 
 export const I18nProvider: React.FC<I18nProviderProps> = ({ children }) => {
-  const getInitialLocale = (): Locale => {
-    try {
-      if (typeof window === 'undefined' || !window.localStorage) return DEFAULT_LOCALE
-      const stored = window.localStorage.getItem('app-locale')
-      const codes = SUPPORTED_LOCALES.map(l => l.code)
-      return stored && (codes as string[]).includes(stored) ? (stored as Locale) : DEFAULT_LOCALE
-    } catch {
-      return DEFAULT_LOCALE
-    }
-  }
+  const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE)
+  const [translations, setTranslations] = useState<Translation>(locales[DEFAULT_LOCALE])
+  const [initialized, setInitialized] = useState(false)
 
-  const [locale, setLocaleState] = useState<Locale>(getInitialLocale)
-  const [translations, setTranslations] = useState<Translation>(locales[locale])
+  // Load initial locale from Electron config or localStorage
+  useEffect(() => {
+    const loadLocale = async () => {
+      try {
+        let stored: string | null = null
+
+        // In Electron, use config storage (shared across all app:// origins)
+        if ((window as any).electronAPI?.getConfig) {
+          stored = await (window as any).electronAPI.getConfig('locale')
+        } else if (typeof window !== 'undefined' && window.localStorage) {
+          stored = window.localStorage.getItem('app-locale')
+        }
+
+        const codes = SUPPORTED_LOCALES.map(l => l.code)
+        if (stored && (codes as string[]).includes(stored)) {
+          setLocaleState(stored as Locale)
+        }
+      } catch (e) {
+        console.warn('Failed to load locale:', e)
+      }
+      setInitialized(true)
+    }
+    loadLocale()
+  }, [])
 
   useEffect(() => {
     setTranslations(locales[locale])
   }, [locale])
 
-  const setLocale = (newLocale: Locale) => {
+  // Sync menu language on mount and when locale changes
+  useEffect(() => {
+    if (initialized && (window as any).electronAPI?.setMenuLocale) {
+      (window as any).electronAPI.setMenuLocale(locale)
+    }
+  }, [locale, initialized])
+
+  const setLocale = async (newLocale: Locale) => {
     const codes = SUPPORTED_LOCALES.map(l => l.code)
     const safe = (codes as string[]).includes(newLocale) ? newLocale : DEFAULT_LOCALE
     setLocaleState(safe as Locale)
-    try { if (typeof window !== 'undefined') window.localStorage.setItem('app-locale', safe) } catch {}
+
+    try {
+      // In Electron, use config storage
+      if ((window as any).electronAPI?.setConfig) {
+        await (window as any).electronAPI.setConfig('locale', safe)
+      } else if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem('app-locale', safe)
+      }
+      // Update Electron menu language
+      if ((window as any).electronAPI?.setMenuLocale) {
+        (window as any).electronAPI.setMenuLocale(safe)
+      }
+    } catch (e) {
+      console.warn('Failed to save locale:', e)
+    }
   }
 
   const t = (key: string, params?: Record<string, string | number>): string => {

--- a/frontend/photo-helper/src/components/LanguageSwitcher.tsx
+++ b/frontend/photo-helper/src/components/LanguageSwitcher.tsx
@@ -15,6 +15,36 @@ import { Close } from '@mui/icons-material';
 import { useI18n } from '../contexts/I18nContext';
 import { SUPPORTED_LOCALES } from '../locales';
 
+// SVG Flag components (Windows doesn't render emoji flags)
+const CzechFlag = ({ size = 20 }: { size?: number }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" width={size} height={size * 0.67}>
+    <rect width="900" height="600" fill="#d7141a"/>
+    <rect width="900" height="300" fill="#fff"/>
+    <path d="M 0,0 L 450,300 L 0,600 Z" fill="#11457e"/>
+  </svg>
+);
+
+const USFlag = ({ size = 20 }: { size?: number }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900" width={size} height={size * 0.53}>
+    <rect width="7410" height="3900" fill="#b22234"/>
+    <path d="M0,450H7410m0,600H0m0,600H7410m0,600H0m0,600H7410m0,600H0" stroke="#fff" strokeWidth="300"/>
+    <rect width="2964" height="2100" fill="#3c3b6e"/>
+    <g fill="#fff">
+      <g id="s18"><g id="s9"><g id="s5"><g id="s4">
+        <path id="s" d="M247,90 317.534230,307.082039 132.873218,172.917961H361.126782L176.465770,307.082039z"/>
+        <use href="#s" y="420"/><use href="#s" y="840"/><use href="#s" y="1260"/>
+      </g><use href="#s" y="1680"/></g><use href="#s4" x="247" y="210"/></g>
+      <use href="#s9" x="494"/></g><use href="#s18" x="988"/><use href="#s9" x="1976"/>
+    </g>
+  </svg>
+);
+
+const FlagIcon = ({ code, size = 20 }: { code: string; size?: number }) => {
+  if (code === 'cz') return <CzechFlag size={size} />;
+  if (code === 'en') return <USFlag size={size} />;
+  return null;
+};
+
 interface LanguageSwitcherProps {
   compact?: boolean;
 }
@@ -43,14 +73,15 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ compact = fa
                 minWidth: 'auto'
               }}
             >
-              {lang.flag} {lang.code.toUpperCase()}
+              <FlagIcon code={lang.code} size={16} /> {lang.code.toUpperCase()}
             </Button>
           ))}
         </ButtonGroup>
         <Tooltip title={t('app.backToMenu')} arrow>
           <IconButton
             component="a"
-            href="../"
+            href={(window as any).electronAPI ? undefined : '../'}
+            onClick={(window as any).electronAPI ? () => (window as any).electronAPI.goHome() : undefined}
             aria-label={t('app.backToMenu')}
             size="small"
             sx={{
@@ -105,15 +136,13 @@ export const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ compact = fa
             }}
           >
             <CardContent sx={{ textAlign: 'center', py: 1, px: 1 }}>
-              <Box sx={{ 
-                display: 'flex', 
-                alignItems: 'center', 
+              <Box sx={{
+                display: 'flex',
+                alignItems: 'center',
                 justifyContent: 'center',
-                mb: 0.25,
-                color: isSelected ? 'primary.main' : 'text.secondary',
-                fontSize: '1.5rem'
+                mb: 0.25
               }}>
-                {lang.flag}
+                <FlagIcon code={lang.code} size={32} />
               </Box>
               
               <Typography 


### PR DESCRIPTION
## Summary
- Reorder desktop menu: Navigation → View → Settings → Help
- Add bilingual homepage with CZ/EN language selector
- Language persists via Electron config (desktop) or localStorage (web)
- Unify web homepage design with desktop homepage
- Translated menu labels (Czech/English)
- Fix close button navigation in Electron apps
- Auto-detect version from git tags in build workflow

## Changes
- **Desktop menu** (`main.js`): Reordered, added i18n support
- **Desktop homepage** (`renderer/`): Language switcher, bilingual content
- **Web homepage** (`frontend/index.html`): Unified design with desktop
- **React apps**: Use Electron config for locale storage (shared across app:// origins)
- **Build workflow**: Auto-detects version from latest git tag

## Language persistence
- **Desktop (Electron)**: Uses `electronAPI.getConfig/setConfig('locale')` - shared across all app:// origins
- **Web**: Uses `localStorage.setItem('app-locale', 'cz'|'en')`

## Test plan
- [ ] Desktop app menu shows in correct language (CZ/EN)
- [ ] Desktop homepage language switcher works
- [ ] Switching language on homepage persists to Photo Helper and Map Corridors
- [ ] Close button (X) in apps returns to homepage
- [ ] Web homepage has same design as desktop
- [ ] Build produces .exe with correct version from git tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)