### PR TITLE
feat: map print with A4 300 DPI offscreen rendering #minor

### DIFF
--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -85,19 +85,31 @@ function resolveAppUrl(requestUrl) {
 
   const resourcePath = getResourcePath();
   let filePath;
+  let baseDir;
 
   if (url.startsWith('photo-helper/')) {
-    filePath = isDev
-      ? path.join(resourcePath, 'photo-helper', 'dist', url.replace('photo-helper/', ''))
-      : path.join(resourcePath, 'photo-helper', url.replace('photo-helper/', ''));
+    baseDir = isDev
+      ? path.join(resourcePath, 'photo-helper', 'dist')
+      : path.join(resourcePath, 'photo-helper');
+    filePath = path.join(baseDir, url.replace('photo-helper/', ''));
   } else if (url.startsWith('map-corridors/')) {
-    filePath = isDev
-      ? path.join(resourcePath, 'map-corridors', 'dist', url.replace('map-corridors/', ''))
-      : path.join(resourcePath, 'map-corridors', url.replace('map-corridors/', ''));
+    baseDir = isDev
+      ? path.join(resourcePath, 'map-corridors', 'dist')
+      : path.join(resourcePath, 'map-corridors');
+    filePath = path.join(baseDir, url.replace('map-corridors/', ''));
   } else if (url.startsWith('home/')) {
-    filePath = path.join(__dirname, 'renderer', url.replace('home/', ''));
+    baseDir = path.join(__dirname, 'renderer');
+    filePath = path.join(baseDir, url.replace('home/', ''));
   } else {
-    filePath = path.join(__dirname, 'renderer', url);
+    baseDir = path.join(__dirname, 'renderer');
+    filePath = path.join(baseDir, url);
+  }
+
+  // Path traversal protection: ensure resolved path stays within base directory
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedFile = path.resolve(filePath);
+  if (!resolvedFile.startsWith(resolvedBase + path.sep) && resolvedFile !== resolvedBase) {
+    filePath = path.join(resolvedBase, 'index.html');
   }
 
   // SPA fallback: if file doesn't exist, serve the app's index.html
@@ -119,21 +131,26 @@ const CSP = "default-src 'self' app: blob: data:; script-src 'self' 'unsafe-eval
 // Uses protocol.handle() (modern API) to set proper response headers
 function setupProtocol() {
   protocol.handle('app', async (request) => {
-    const filePath = resolveAppUrl(request.url);
-    const fileUrl = pathToFileURL(filePath).href;
-    const original = await net.fetch(fileUrl);
-    // Copy response but add our headers
-    const headers = new Headers(original.headers);
-    headers.set('Content-Security-Policy', CSP);
-    if (isDev) {
-      headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
-      headers.set('Pragma', 'no-cache');
+    try {
+      const filePath = resolveAppUrl(request.url);
+      const fileUrl = pathToFileURL(filePath).href;
+      const original = await net.fetch(fileUrl);
+      // Copy response but add our headers
+      const headers = new Headers(original.headers);
+      headers.set('Content-Security-Policy', CSP);
+      if (isDev) {
+        headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+        headers.set('Pragma', 'no-cache');
+      }
+      return new Response(original.body, {
+        status: original.status,
+        statusText: original.statusText,
+        headers,
+      });
+    } catch (err) {
+      console.error(`Protocol handler error for ${request.url}:`, err);
+      return new Response('Not Found', { status: 404 });
     }
-    return new Response(original.body, {
-      status: original.status,
-      statusText: original.statusText,
-      headers,
-    });
   });
 }
 
@@ -637,6 +654,12 @@ ipcMain.handle('competition-delete', async (event, id) => {
 
 // Save map print image via native save dialog
 ipcMain.handle('save-map-image', async (event, base64Data) => {
+  if (typeof base64Data !== 'string' || base64Data.length === 0) {
+    throw new Error('Invalid image data');
+  }
+  if (base64Data.length > 50 * 1024 * 1024) {
+    throw new Error('Image data too large');
+  }
   const { filePath } = await dialog.showSaveDialog(mainWindow, {
     defaultPath: `map-print-${new Date().toISOString().slice(0, 10)}.png`,
     filters: [{ name: 'PNG Images', extensions: ['png'] }]

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1,6 +1,7 @@
-const { app, BrowserWindow, protocol, ipcMain, shell, globalShortcut, Menu, dialog } = require('electron');
+const { app, BrowserWindow, protocol, ipcMain, shell, globalShortcut, Menu, dialog, net } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const { pathToFileURL } = require('url');
 
 // Config file path in user data directory
 function getConfigPath() {
@@ -73,85 +74,65 @@ function getResourcePath() {
   return path.join(process.resourcesPath);
 }
 
+// Resolve app:// URL to local file path
+function resolveAppUrl(requestUrl) {
+  let url = requestUrl.replace('app://', '');
+  url = url.split('?')[0].split('#')[0];
+  url = decodeURIComponent(url);
+  if (process.platform === 'win32' && url.startsWith('/')) {
+    url = url.substring(1);
+  }
+
+  const resourcePath = getResourcePath();
+  let filePath;
+
+  if (url.startsWith('photo-helper/')) {
+    filePath = isDev
+      ? path.join(resourcePath, 'photo-helper', 'dist', url.replace('photo-helper/', ''))
+      : path.join(resourcePath, 'photo-helper', url.replace('photo-helper/', ''));
+  } else if (url.startsWith('map-corridors/')) {
+    filePath = isDev
+      ? path.join(resourcePath, 'map-corridors', 'dist', url.replace('map-corridors/', ''))
+      : path.join(resourcePath, 'map-corridors', url.replace('map-corridors/', ''));
+  } else if (url.startsWith('home/')) {
+    filePath = path.join(__dirname, 'renderer', url.replace('home/', ''));
+  } else {
+    filePath = path.join(__dirname, 'renderer', url);
+  }
+
+  // SPA fallback: if file doesn't exist, serve the app's index.html
+  if (url.startsWith('photo-helper/') || url.startsWith('map-corridors/')) {
+    try { fs.statSync(filePath); } catch {
+      const appName = url.startsWith('photo-helper/') ? 'photo-helper' : 'map-corridors';
+      filePath = isDev
+        ? path.join(resourcePath, appName, 'dist', 'index.html')
+        : path.join(resourcePath, appName, 'index.html');
+    }
+  }
+
+  return filePath;
+}
+
+const CSP = "default-src 'self' app: blob: data:; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' app:; style-src 'self' 'unsafe-inline' app:; img-src 'self' app: blob: data: https:; connect-src 'self' app: blob: data: https:; worker-src 'self' blob:";
+
 // Create custom protocol to serve local files
+// Uses protocol.handle() (modern API) to set proper response headers
 function setupProtocol() {
-  protocol.registerFileProtocol('app', (request, callback) => {
-    let url = request.url.replace('app://', '');
-
-    // Strip query string and hash before resolving file path
-    url = url.split('?')[0].split('#')[0];
-
-    // Decode URL
-    url = decodeURIComponent(url);
-
-    // Remove leading slash on Windows
-    if (process.platform === 'win32' && url.startsWith('/')) {
-      url = url.substring(1);
+  protocol.handle('app', async (request) => {
+    const filePath = resolveAppUrl(request.url);
+    const fileUrl = pathToFileURL(filePath).href;
+    const original = await net.fetch(fileUrl);
+    // Copy response but add our headers
+    const headers = new Headers(original.headers);
+    headers.set('Content-Security-Policy', CSP);
+    if (isDev) {
+      headers.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+      headers.set('Pragma', 'no-cache');
     }
-
-    // Determine which app to serve
-    const resourcePath = getResourcePath();
-    let filePath;
-
-    if (url.startsWith('photo-helper/')) {
-      if (isDev) {
-        filePath = path.join(resourcePath, 'photo-helper', 'dist', url.replace('photo-helper/', ''));
-      } else {
-        filePath = path.join(resourcePath, 'photo-helper', url.replace('photo-helper/', ''));
-      }
-    } else if (url.startsWith('map-corridors/')) {
-      if (isDev) {
-        filePath = path.join(resourcePath, 'map-corridors', 'dist', url.replace('map-corridors/', ''));
-      } else {
-        filePath = path.join(resourcePath, 'map-corridors', url.replace('map-corridors/', ''));
-      }
-    } else if (url.startsWith('home/')) {
-      // Handle home/ path for landing page (fixes Windows URL resolution)
-      filePath = path.join(__dirname, 'renderer', url.replace('home/', ''));
-    } else {
-      // Fallback for any other renderer assets
-      filePath = path.join(__dirname, 'renderer', url);
-    }
-
-    // For SPA routing in photo-helper and map-corridors, check if file exists
-    // Only do this check for the apps, not for the landing page
-    // Note: Use require('original-fs') for asar-compatible file checks, or just skip the check
-    // and let the protocol handler return a 404 naturally
-    if (url.startsWith('photo-helper/') || url.startsWith('map-corridors/')) {
-      // Try to check if file exists, with fallback for asar archives
-      let fileExists = false;
-      try {
-        // In packaged app, fs.existsSync may not work for asar files
-        // Use synchronous stat which works with asar
-        fs.statSync(filePath);
-        fileExists = true;
-      } catch {
-        fileExists = false;
-      }
-
-      if (!fileExists) {
-        // For SPA routing, serve the app's index.html
-        if (url.startsWith('photo-helper/')) {
-          if (isDev) {
-            filePath = path.join(resourcePath, 'photo-helper', 'dist', 'index.html');
-          } else {
-            filePath = path.join(resourcePath, 'photo-helper', 'index.html');
-          }
-        } else if (url.startsWith('map-corridors/')) {
-          if (isDev) {
-            filePath = path.join(resourcePath, 'map-corridors', 'dist', 'index.html');
-          } else {
-            filePath = path.join(resourcePath, 'map-corridors', 'index.html');
-          }
-        }
-      }
-    }
-
-    callback({
-      path: filePath,
-      headers: {
-        'Content-Security-Policy': "default-src 'self' app: blob: data:; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval' app:; style-src 'self' 'unsafe-inline' app:; img-src 'self' app: blob: data: https:; connect-src 'self' app: blob: data: https:; worker-src 'self' blob:"
-      }
+    return new Response(original.body, {
+      status: original.status,
+      statusText: original.statusText,
+      headers,
     });
   });
 }
@@ -654,6 +635,18 @@ ipcMain.handle('competition-delete', async (event, id) => {
   return { activeCompetitionId: index.activeCompetitionId };
 });
 
+// Save map print image via native save dialog
+ipcMain.handle('save-map-image', async (event, base64Data) => {
+  const { filePath } = await dialog.showSaveDialog(mainWindow, {
+    defaultPath: `map-print-${new Date().toISOString().slice(0, 10)}.png`,
+    filters: [{ name: 'PNG Images', extensions: ['png'] }]
+  });
+  if (!filePath) return null;
+  const buffer = Buffer.from(base64Data, 'base64');
+  fs.writeFileSync(filePath, buffer);
+  return filePath;
+});
+
 // Show Mapbox token dialog - single window with input field
 async function showMapboxTokenDialog() {
   const currentToken = getConfigValue('mapboxToken') || '';
@@ -941,7 +934,12 @@ function createMenu(locale = 'cs') {
 }
 
 // This method will be called when Electron has finished initialization
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  // Clear disk cache in dev so rebuilt files are always loaded fresh
+  if (isDev) {
+    const { session } = require('electron');
+    await session.defaultSession.clearCache();
+  }
   setupProtocol();
   createMenu();
   createWindow();

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -31,6 +31,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     delete: (id) => ipcRenderer.invoke('competition-delete', id),
   },
 
+  // Save map print image via native save dialog
+  saveMapImage: (base64Data) => ipcRenderer.invoke('save-map-image', base64Data),
+
   // Check if running in Electron
   isElectron: true,
 

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -390,8 +390,9 @@ function App() {
       }
     } catch (err) {
       console.error('Map print failed:', err)
+      alert(err instanceof Error ? err.message : t('errors.printFailed'))
     }
-  }, [])
+  }, [t])
 
   // Drag source for placing markers
   const onDragStartMarker = useCallback((e: React.DragEvent) => {

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -359,6 +359,40 @@ function App() {
     downloadKML(mergedKml, 'corridors_export.kml')
   }, [markers, loadOriginalKmlText, t])
 
+  const handlePrintMap = useCallback(async () => {
+    if (!mapRef.current) return
+    try {
+      const blob = await mapRef.current.captureForPrint()
+      const electronAPI = (window as any).electronAPI
+
+      if (electronAPI?.saveMapImage) {
+        // Electron: save via native dialog
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => {
+            const result = reader.result as string
+            resolve(result.split(',')[1]) // strip data:image/png;base64, prefix
+          }
+          reader.onerror = () => reject(reader.error)
+          reader.readAsDataURL(blob)
+        })
+        await electronAPI.saveMapImage(base64)
+      } else {
+        // Browser: download via anchor
+        const url = URL.createObjectURL(blob)
+        const link = document.createElement('a')
+        link.href = url
+        link.download = `map-print-${new Date().toISOString().slice(0, 10)}.png`
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        URL.revokeObjectURL(url)
+      }
+    } catch (err) {
+      console.error('Map print failed:', err)
+    }
+  }, [])
+
   // Drag source for placing markers
   const onDragStartMarker = useCallback((e: React.DragEvent) => {
     e.dataTransfer.setData('application/x-photo-marker', '1')
@@ -465,6 +499,9 @@ function App() {
           <Button variant="contained" size="small" onClick={onClickSelectFile}>{t('app.selectKml')}</Button>
           {(session?.leftSegments || session?.rightSegments || session?.gates) && (
             <Button variant="outlined" size="small" onClick={handleExportKML} startIcon={<Download sx={{ fontSize: 16 }} />}>{t('app.exportKml')}</Button>
+          )}
+          {session?.geojson && (
+            <Button variant="outlined" size="small" onClick={handlePrintMap} startIcon={<Print sx={{ fontSize: 16 }} />}>{t('app.printMap')}</Button>
           )}
           <Button variant="outlined" size="small" draggable onDragStart={onDragStartMarker} startIcon={<Place sx={{ fontSize: 16 }} />} title={t('app.dragToPlace')}>{t('app.dragToPlace')}</Button>
           <ToggleButtonGroup value={baseStyle} exclusive onChange={(_, val) => { if (val) setBaseStyle(val) }} size="small">

--- a/frontend/map-corridors/src/__tests__/mapCapture.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapCapture.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { detectOrientation, withTimeout } from '../utils/mapCapture'
+
+// ---------------------------------------------------------------------------
+// detectOrientation
+// ---------------------------------------------------------------------------
+describe('detectOrientation', () => {
+  const LANDSCAPE_W = 3508
+  const PORTRAIT_W = 2480
+
+  it('wide track near equator → landscape', () => {
+    // 2° lng × 1° lat at equator — lng dominates
+    const bbox: [[number, number], [number, number]] = [[10, -0.5], [12, 0.5]]
+    expect(detectOrientation(bbox).width).toBe(LANDSCAPE_W)
+  })
+
+  it('tall track near equator → portrait', () => {
+    // 0.5° lng × 2° lat at equator — lat dominates
+    const bbox: [[number, number], [number, number]] = [[10, -1], [10.5, 1]]
+    expect(detectOrientation(bbox).width).toBe(PORTRAIT_W)
+  })
+
+  it('square track near equator → landscape (>= favors landscape)', () => {
+    // 1° × 1° at equator: cos(0) = 1, so lngSpan == latSpan → >=
+    const bbox: [[number, number], [number, number]] = [[0, -0.5], [1, 0.5]]
+    expect(detectOrientation(bbox).width).toBe(LANDSCAPE_W)
+  })
+
+  it('square track at 60° latitude → portrait (Mercator compresses lng)', () => {
+    // 1° × 1° at lat 60: cos(60°) = 0.5, so lngSpan = 0.5 < latSpan = 1
+    const bbox: [[number, number], [number, number]] = [[14, 59.5], [15, 60.5]]
+    expect(detectOrientation(bbox).width).toBe(PORTRAIT_W)
+  })
+
+  it('wide track at high latitude can still be landscape', () => {
+    // 6° lng × 1° lat at lat 50: cos(50°) ≈ 0.643, lngSpan ≈ 3.86 > 1
+    const bbox: [[number, number], [number, number]] = [[14, 49.5], [20, 50.5]]
+    expect(detectOrientation(bbox).width).toBe(LANDSCAPE_W)
+  })
+
+  it('Czech Republic typical track (lat ~49.5°)', () => {
+    // Narrow rally track: ~0.05° lng × 0.15° lat
+    // cos(49.5°) ≈ 0.649, lngSpan ≈ 0.032 < 0.15
+    const bbox: [[number, number], [number, number]] = [[16.6, 49.1], [16.65, 49.25]]
+    expect(detectOrientation(bbox).width).toBe(PORTRAIT_W)
+  })
+
+  it('degenerate single-point bbox → landscape (0 >= 0)', () => {
+    const bbox: [[number, number], [number, number]] = [[15, 50], [15, 50]]
+    expect(detectOrientation(bbox).width).toBe(LANDSCAPE_W)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withTimeout
+// ---------------------------------------------------------------------------
+describe('withTimeout', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves when inner promise resolves before timeout', async () => {
+    const result = await withTimeout(Promise.resolve(42), 1000, 'timeout')
+    expect(result).toBe(42)
+  })
+
+  it('rejects with original error when inner promise rejects before timeout', async () => {
+    const err = new Error('inner failure')
+    await expect(withTimeout(Promise.reject(err), 1000, 'timeout')).rejects.toThrow('inner failure')
+  })
+
+  it('rejects with timeout message when inner promise does not settle', async () => {
+    vi.useFakeTimers()
+    const never = new Promise<void>(() => {})
+    const p = withTimeout(never, 5000, 'Map timed out')
+    vi.advanceTimersByTime(5000)
+    await expect(p).rejects.toThrow('Map timed out')
+  })
+
+  it('inner resolve after timeout is harmless (no double settle)', async () => {
+    vi.useFakeTimers()
+    let resolve!: (v: string) => void
+    const inner = new Promise<string>(r => { resolve = r })
+    const p = withTimeout(inner, 100, 'timeout')
+    vi.advanceTimersByTime(100)
+    await expect(p).rejects.toThrow('timeout')
+    // Late resolve — should not throw or cause issues
+    resolve('late')
+  })
+})

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -16,6 +16,7 @@
       "precision": "Precision",
       "rally": "Rally"
     },
+    "printMap": "Tisk mapy",
     "backToMenu": "Zpět do hlavního menu"
   },
   "popup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -42,7 +42,8 @@
     "configureToken": "Nastavit Mapbox token",
     "setTokenWeb": "Přidejte svůj token do proměnné prostředí VITE_MAPBOX_TOKEN a restartujte aplikaci.",
     "getTokenLink": "Získejte zdarma token na mapbox.com →",
-    "noOriginalKml": "Původní KML není k dispozici pro export"
+    "noOriginalKml": "Původní KML není k dispozici pro export",
+    "printFailed": "Tisk mapy selhal"
   }
   ,
   "opfs": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -16,6 +16,7 @@
       "precision": "Precision",
       "rally": "Rally"
     },
+    "printMap": "Print Map",
     "backToMenu": "Back to main menu"
   },
   "popup": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -42,7 +42,8 @@
     "configureToken": "Configure Mapbox Token",
     "setTokenWeb": "Add your token to the VITE_MAPBOX_TOKEN environment variable and restart the app.",
     "getTokenLink": "Get a free token at mapbox.com →",
-    "noOriginalKml": "Original KML file not available for export"
+    "noOriginalKml": "Original KML file not available for export",
+    "printFailed": "Map print failed"
   }
   ,
   "opfs": {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -4,6 +4,7 @@ import type { MapRef } from 'react-map-gl/mapbox'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import type { MapProviderId, ProviderConfig } from './providers'
 import { useI18n } from '../contexts/I18nContext'
+import { captureMapForPrint } from '../utils/mapCapture'
 
 type PhotoLabel = 'A'|'B'|'C'|'D'|'E'|'F'|'G'|'H'|'I'|'J'|'K'|'L'|'M'|'N'|'O'|'P'|'Q'|'R'|'S'|'T'
 const ALL_LABELS: PhotoLabel[] = ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T']
@@ -16,7 +17,9 @@ type Overlay = {
   layout?: any
 }
 
-export type MapProviderViewHandle = Record<string, never>
+export type MapProviderViewHandle = {
+  captureForPrint: () => Promise<Blob>
+}
 
 export const MapProviderView = forwardRef<MapProviderViewHandle, {
   provider: MapProviderId
@@ -144,7 +147,41 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   const isElectron = !!(typeof window !== 'undefined' && (window as any).electronAPI?.isElectron)
   const needsToken = !providerConfig.accessToken && typeof styleUrl === 'string' && styleUrl.startsWith('mapbox://')
 
-  useImperativeHandle(ref, () => ({}), [])
+  useImperativeHandle(ref, () => ({
+    async captureForPrint() {
+      // Compute bbox from the track overlay
+      const trackOverlay = (geojsonOverlays || []).find(ov => ov.id === 'uploaded-geojson')
+      if (!trackOverlay) throw new Error('No track data to print')
+      const bbox = computeBbox(trackOverlay.data)
+      if (!bbox) throw new Error('Could not compute track bounds')
+
+      // Only include track line, gates, and exact-point labels — no corridors
+      const printOverlayIds = new Set(['uploaded-geojson', 'gates', 'exact-points'])
+      const printOverlays = (geojsonOverlays || [])
+        .filter(ov => printOverlayIds.has(ov.id))
+        .map(ov => ({
+          id: ov.id,
+          data: ov.data,
+          type: ov.type as 'line' | 'circle',
+          paint: ov.paint,
+          layout: ov.layout,
+        }))
+
+      const printMarkers = (props.markers || []).map(m => ({
+        lng: m.lng,
+        lat: m.lat,
+        label: m.label,
+      }))
+
+      return captureMapForPrint({
+        bbox: bbox as [[number, number], [number, number]],
+        style: styleUrl,
+        accessToken: providerConfig.accessToken,
+        overlays: printOverlays,
+        markers: printMarkers,
+      })
+    }
+  }), [geojsonOverlays, props.markers, styleUrl, providerConfig.accessToken])
 
   if (needsToken) {
     return (

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -35,11 +35,7 @@ const PADDING = 100 // pixels padding around track in print
 export async function captureMapForPrint(options: PrintOptions): Promise<Blob> {
   const { bbox, style, accessToken, overlays, markers } = options
 
-  // Detect orientation from bbox aspect ratio (adjusted for Mercator projection)
-  const midLat = (bbox[0][1] + bbox[1][1]) / 2
-  const lngSpan = Math.abs(bbox[1][0] - bbox[0][0]) * Math.cos(midLat * Math.PI / 180)
-  const latSpan = Math.abs(bbox[1][1] - bbox[0][1])
-  const dims = lngSpan >= latSpan ? A4_LANDSCAPE : A4_PORTRAIT
+  const dims = detectOrientation(bbox)
 
   // Create hidden container
   const container = document.createElement('div')
@@ -62,6 +58,7 @@ export async function captureMapForPrint(options: PrintOptions): Promise<Blob> {
     interactive: false,
     fadeDuration: 0,
     attributionControl: false,
+    pixelRatio: 1,
   })
 
   try {
@@ -125,7 +122,8 @@ export async function captureMapForPrint(options: PrintOptions): Promise<Blob> {
     const offscreen = document.createElement('canvas')
     offscreen.width = mapCanvas.width
     offscreen.height = mapCanvas.height
-    const ctx = offscreen.getContext('2d')!
+    const ctx = offscreen.getContext('2d')
+    if (!ctx) throw new Error('Failed to create 2D canvas context — image may be too large for this device')
     ctx.drawImage(mapCanvas, 0, 0)
 
     // Scale factor: canvas pixels may differ from CSS pixels
@@ -193,7 +191,15 @@ export async function captureMapForPrint(options: PrintOptions): Promise<Blob> {
   }
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+/** Detect landscape vs portrait from bbox aspect ratio, adjusted for Mercator projection. */
+export function detectOrientation(bbox: [[number, number], [number, number]]) {
+  const midLat = (bbox[0][1] + bbox[1][1]) / 2
+  const lngSpan = Math.abs(bbox[1][0] - bbox[0][0]) * Math.cos(midLat * Math.PI / 180)
+  const latSpan = Math.abs(bbox[1][1] - bbox[0][1])
+  return lngSpan >= latSpan ? A4_LANDSCAPE : A4_PORTRAIT
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(message)), ms)
     promise.then(

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -1,0 +1,204 @@
+import mapboxgl from 'mapbox-gl'
+
+type OverlayConfig = {
+  id: string
+  data: any
+  type: 'line' | 'circle'
+  paint?: Record<string, any>
+  layout?: Record<string, any>
+}
+
+type MarkerConfig = {
+  lng: number
+  lat: number
+  label?: string
+}
+
+type PrintOptions = {
+  bbox: [[number, number], [number, number]] // [[minLng, minLat], [maxLng, maxLat]]
+  style: string
+  accessToken?: string
+  overlays: OverlayConfig[]
+  markers: MarkerConfig[]
+}
+
+// A4 at 300 DPI
+const A4_LANDSCAPE = { width: 3508, height: 2480 }
+const A4_PORTRAIT = { width: 2480, height: 3508 }
+const TIMEOUT_MS = 15_000
+const PADDING = 100 // pixels padding around track in print
+
+/**
+ * Render a high-resolution offscreen map at A4 300 DPI.
+ * Auto-detects landscape vs portrait from the track bounding box.
+ */
+export async function captureMapForPrint(options: PrintOptions): Promise<Blob> {
+  const { bbox, style, accessToken, overlays, markers } = options
+
+  // Detect orientation from bbox aspect ratio (adjusted for Mercator projection)
+  const midLat = (bbox[0][1] + bbox[1][1]) / 2
+  const lngSpan = Math.abs(bbox[1][0] - bbox[0][0]) * Math.cos(midLat * Math.PI / 180)
+  const latSpan = Math.abs(bbox[1][1] - bbox[0][1])
+  const dims = lngSpan >= latSpan ? A4_LANDSCAPE : A4_PORTRAIT
+
+  // Create hidden container
+  const container = document.createElement('div')
+  container.style.width = `${dims.width}px`
+  container.style.height = `${dims.height}px`
+  container.style.position = 'absolute'
+  container.style.left = '-9999px'
+  container.style.top = '-9999px'
+  container.style.visibility = 'hidden'
+  document.body.appendChild(container)
+
+  if (accessToken) {
+    mapboxgl.accessToken = accessToken
+  }
+
+  const map = new mapboxgl.Map({
+    container,
+    style,
+    preserveDrawingBuffer: true,
+    interactive: false,
+    fadeDuration: 0,
+    attributionControl: false,
+  })
+
+  try {
+    // Wait for style to load
+    await withTimeout(
+      new Promise<void>(resolve => map.once('load', () => resolve())),
+      TIMEOUT_MS,
+      'Map style load timed out'
+    )
+
+    // Fit to track bounds
+    map.fitBounds(bbox as any, { padding: PADDING, duration: 0 })
+
+    // Add GeoJSON overlays (track line, gates, exact-point labels)
+    for (const ov of overlays) {
+      map.addSource(ov.id, { type: 'geojson', data: ov.data })
+
+      if (ov.type === 'line') {
+        map.addLayer({
+          id: `${ov.id}-line`,
+          type: 'line',
+          source: ov.id,
+          paint: { 'line-color': '#00b3ff', 'line-width': 3, ...(ov.paint || {}) },
+          layout: ov.layout ?? {},
+        })
+      } else if (ov.type === 'circle') {
+        map.addLayer({
+          id: `${ov.id}-circles`,
+          type: 'circle',
+          source: ov.id,
+          paint: { 'circle-radius': 0, 'circle-color': '#000000', ...(ov.paint || {}) },
+        })
+        map.addLayer({
+          id: `${ov.id}-labels`,
+          type: 'symbol',
+          source: ov.id,
+          paint: { 'text-color': '#000000', 'text-halo-color': '#ffffff', 'text-halo-width': 2 },
+          layout: {
+            'text-field': ['get', 'name'],
+            'text-font': ['Open Sans Regular', 'Arial Unicode MS Regular'],
+            'text-size': 16,
+            'text-offset': [0, -2],
+            'text-anchor': 'bottom',
+            'text-allow-overlap': true,
+            'text-ignore-placement': true,
+            ...(ov.layout ?? {}),
+          },
+        })
+      }
+    }
+
+    // Wait for all tiles + layers to render
+    await withTimeout(
+      new Promise<void>(resolve => map.once('idle', () => resolve())),
+      TIMEOUT_MS,
+      'Map tile rendering timed out'
+    )
+
+    // Capture the WebGL canvas
+    const mapCanvas = map.getCanvas()
+    const offscreen = document.createElement('canvas')
+    offscreen.width = mapCanvas.width
+    offscreen.height = mapCanvas.height
+    const ctx = offscreen.getContext('2d')!
+    ctx.drawImage(mapCanvas, 0, 0)
+
+    // Scale factor: canvas pixels may differ from CSS pixels
+    const scaleX = mapCanvas.width / dims.width
+    const scaleY = mapCanvas.height / dims.height
+
+    // Composite photo markers
+    const markerRadius = 6 * scaleX
+    const fontSize = Math.round(14 * scaleX)
+
+    for (const m of markers) {
+      const px = map.project([m.lng, m.lat])
+      const x = px.x * scaleX
+      const y = px.y * scaleY
+
+      // Yellow circle with dark border
+      ctx.beginPath()
+      ctx.arc(x, y, markerRadius, 0, Math.PI * 2)
+      ctx.fillStyle = '#FFFF00'
+      ctx.fill()
+      ctx.strokeStyle = '#333333'
+      ctx.lineWidth = 1.5 * scaleX
+      ctx.stroke()
+
+      // Label pill
+      if (m.label) {
+        ctx.font = `bold ${fontSize}px Arial, sans-serif`
+        ctx.textAlign = 'left'
+        ctx.textBaseline = 'middle'
+        const labelX = x + markerRadius + 4 * scaleX
+        const metrics = ctx.measureText(m.label)
+        const padX = 4 * scaleX
+        const padY = 2 * scaleY
+        const bgW = metrics.width + padX * 2
+        const bgH = fontSize + padY * 2
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.85)'
+        ctx.beginPath()
+        ctx.roundRect(labelX - padX, y - bgH / 2, bgW, bgH, 4 * scaleX)
+        ctx.fill()
+        ctx.strokeStyle = '#e5e7eb'
+        ctx.lineWidth = 1 * scaleX
+        ctx.stroke()
+        ctx.fillStyle = '#111111'
+        ctx.fillText(m.label, labelX, y)
+      }
+    }
+
+    // Attribution
+    const attrSize = Math.round(10 * scaleX)
+    ctx.font = `${attrSize}px Arial, sans-serif`
+    ctx.textAlign = 'right'
+    ctx.textBaseline = 'bottom'
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)'
+    ctx.fillText('\u00A9 Mapbox \u00A9 OpenStreetMap', offscreen.width - 8 * scaleX, offscreen.height - 4 * scaleY)
+
+    return await new Promise<Blob>((resolve, reject) => {
+      offscreen.toBlob(blob => {
+        if (blob) resolve(blob)
+        else reject(new Error('Canvas toBlob returned null'))
+      }, 'image/png')
+    })
+  } finally {
+    map.remove()
+    document.body.removeChild(container)
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms)
+    promise.then(
+      val => { clearTimeout(timer); resolve(val) },
+      err => { clearTimeout(timer); reject(err) }
+    )
+  })
+}


### PR DESCRIPTION
## Summary

- **Map print button**: Captures map at A4 300 DPI resolution (3508×2480 landscape or 2480×3508 portrait) via an offscreen Mapbox GL Map instance. Auto-detects orientation from track bounding box aspect ratio, adjusted for Mercator projection.
- **Print content**: Base map tiles, track line (yellow), gates (green), waypoint labels (SP/TP/FP), photo markers (yellow dots + letter labels). Corridors explicitly excluded.
- **Electron integration**: Native save dialog via new `save-map-image` IPC handler. Browser fallback via anchor download.
- **Protocol migration**: Migrated `app://` protocol from deprecated `registerFileProtocol` to `protocol.handle()` with proper `Cache-Control: no-store` response headers in dev mode. Clears disk cache on dev startup.

## Test plan

- [ ] Load RED.kml (rally) → click Print Map → verify landscape PNG at ~3508×2480
- [ ] Load RED_SC.kml (precision, portrait track) → verify portrait PNG at ~2480×3508
- [ ] Verify PNG contains: base map, yellow track, green gates, TP/SP/FP labels
- [ ] Verify PNG does NOT contain: corridor borders (green left/right lines)
- [ ] Place photo markers with labels → verify yellow dots + labels appear in PNG
- [ ] Test with satellite base style
- [ ] `pnpm --filter @airq/map-corridors exec vitest run` — 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)