### PR TITLE
fix: 2026-04-18 testing feedback — map-corridors + photo-helper #minor

### DIFF
--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -16,6 +16,7 @@ import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-mate
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
+import { parseDisciplineFromSearch } from './utils/parseDiscipline'
 import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
 import { calculateDistance } from './corridors/segments'
 import { useI18n } from './contexts/I18nContext'
@@ -42,14 +43,7 @@ function App() {
     }
   }, [])
 
-  const urlDiscipline = useMemo(() => {
-    try {
-      const params = new URLSearchParams(window.location.search)
-      const d = params.get('discipline')
-      if (d === 'precision' || d === 'rally') return d
-    } catch {}
-    return null
-  }, [])
+  const urlDiscipline = useMemo(() => parseDisciplineFromSearch(window.location.search), [])
 
   // Fetch competition name from index for display
   const [competitionName, setCompetitionName] = useState<string | null>(null)
@@ -396,11 +390,18 @@ function App() {
     }
     // Rasterize each used ground-marker shape to a PNG data URI so the exported
     // KML renders the same icons as the app and print output (feedback 2026-04-18).
-    // Missing types fall back to the default yellow-dot style inside kmlMerge.
+    // Missing types fall back to the default yellow-dot style inside kmlMerge;
+    // we surface the list of failures so the user knows the KML is partial.
     const uniqueTypes = Array.from(new Set(groundMarkers.map(gm => gm.type)))
-    const groundMarkerIcons = uniqueTypes.length
-      ? await rasterizeGroundMarkerSet(uniqueTypes, 128)
-      : undefined
+    let groundMarkerIcons: Record<string, string> | undefined
+    if (uniqueTypes.length) {
+      const { icons, failed } = await rasterizeGroundMarkerSet(uniqueTypes, 128)
+      groundMarkerIcons = icons
+      if (failed.length) {
+        console.warn('[kmlExport] Ground-marker rasterization failed for:', failed)
+        alert(t('errors.someGroundMarkersFailed', { types: failed.join(', ') }))
+      }
+    }
     const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, 'corridors_export', { groundMarkerIcons })
     downloadKML(mergedKml, 'corridors_export.kml')
   }, [markers, groundMarkers, loadOriginalKmlText, t])

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -11,10 +11,11 @@ import type { GeoJSON } from 'geojson'
 import { buildPreciseCorridorsAndGates, DISCIPLINE_CONFIGS } from './corridors/preciseCorridor'
 import type { Discipline } from './corridors/preciseCorridor'
 
-import { Box, Button, Chip, Container, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, ToggleButton, ToggleButtonGroup, IconButton, Tooltip, Alert } from '@mui/material'
+import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, ToggleButton, ToggleButtonGroup, IconButton, Tooltip, Alert } from '@mui/material'
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
+import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
 import { calculateDistance } from './corridors/segments'
 import { useI18n } from './contexts/I18nContext'
@@ -78,6 +79,7 @@ function App() {
     setBaseStyle,
     setMarkers: persistMarkers,
     setGroundMarkers: persistGroundMarkers,
+    setUse1NmAfterSp,
     setComputedData,
     saveOriginalKmlText,
     loadOriginalKmlText,
@@ -106,7 +108,20 @@ function App() {
   }, [markers])
 
   // Avoid infinite recompute loops by memoizing last compute signature
-  const lastComputeSigRef = useRef<{ geojson: GeoJSON; discipline: Discipline } | null>(null)
+  const lastComputeSigRef = useRef<{ geojson: GeoJSON; discipline: Discipline; use1NmAfterSp: boolean } | null>(null)
+
+  // Rally-only toggle: start the corridor 1 NM after SP instead of the 5 NM default.
+  // Precision disciplines ignore this flag — the value came back in user feedback
+  // 2026-04-18 and is persisted per-competition via `session.use1NmAfterSp`.
+  const use1NmAfterSp = !!session?.use1NmAfterSp
+  const effectiveDiscipline: Discipline = (urlDiscipline || session?.discipline || 'rally')
+  const effectiveConfig = useMemo(() => {
+    const base = DISCIPLINE_CONFIGS[effectiveDiscipline]
+    if (effectiveDiscipline === 'rally' && use1NmAfterSp) {
+      return { ...base, spAfterNm: 1.0 }
+    }
+    return base
+  }, [effectiveDiscipline, use1NmAfterSp])
 
   // Precompute corridor polygons and start TP coordinates
   const corridorPolygons = useMemo(() => {
@@ -237,11 +252,10 @@ function App() {
     await saveOriginalKmlText(file.name.toLowerCase().endsWith('.kml') ? fileText : '')
     const { parseFileToGeoJSON } = await import('./parsers/detect')
     const parsed = await parseFileToGeoJSON(file)
-    // compute corridors using discipline from URL param (desktop) or session fallback (web)
-    const discipline = urlDiscipline || session?.discipline || 'rally'
-    const config = DISCIPLINE_CONFIGS[discipline]
+    // compute corridors using discipline from URL param (desktop) or session fallback (web).
+    // Rally honors the `use1NmAfterSp` flag; see `effectiveConfig` for details.
     try {
-      const { gates, points, exactPoints, leftSegments, rightSegments } = buildPreciseCorridorsAndGates(parsed, config)
+      const { gates, points, exactPoints, leftSegments, rightSegments } = buildPreciseCorridorsAndGates(parsed, effectiveConfig)
       await setComputedData({
         geojson: parsed,
         gates: gates && gates.length ? ({ type: 'FeatureCollection', features: gates } as any) : null,
@@ -253,19 +267,17 @@ function App() {
     } catch {
       await setComputedData({ geojson: parsed, gates: null, points: null, exactPoints: null, leftSegments: null, rightSegments: null })
     }
-  }, [saveOriginalKmlText, urlDiscipline, session?.discipline, setComputedData])
+  }, [saveOriginalKmlText, effectiveConfig, setComputedData])
 
-  // Recompute when discipline changes
+  // Recompute when discipline or the rally 1NM toggle changes
   useEffect(() => {
     if (!session?.geojson) return
     const input = session.geojson
-    const discipline = urlDiscipline || session.discipline || 'rally'
     const last = lastComputeSigRef.current
-    // Only recompute when input or discipline changed
-    if (last && last.geojson === input && last.discipline === discipline) return
-    const config = DISCIPLINE_CONFIGS[discipline]
+    // Only recompute when input, discipline, or the 1NM flag changed
+    if (last && last.geojson === input && last.discipline === effectiveDiscipline && last.use1NmAfterSp === use1NmAfterSp) return
     try {
-      const { gates, points, exactPoints, leftSegments, rightSegments } = buildPreciseCorridorsAndGates(input, config)
+      const { gates, points, exactPoints, leftSegments, rightSegments } = buildPreciseCorridorsAndGates(input, effectiveConfig)
       setComputedData({
         geojson: input,
         gates: gates && gates.length ? ({ type: 'FeatureCollection', features: gates } as any) : null,
@@ -277,9 +289,9 @@ function App() {
     } catch {
       setComputedData({ geojson: input, gates: null, points: null, exactPoints: null, leftSegments: null, rightSegments: null })
     } finally {
-      lastComputeSigRef.current = { geojson: input, discipline }
+      lastComputeSigRef.current = { geojson: input, discipline: effectiveDiscipline, use1NmAfterSp }
     }
-  }, [session?.geojson, urlDiscipline, session?.discipline])
+  }, [session?.geojson, effectiveDiscipline, use1NmAfterSp, effectiveConfig])
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []
@@ -345,22 +357,32 @@ function App() {
     // Export photo markers and ground markers — no corridors, gates, or exact point labels
     const features: any[] = []
     if (markers.length) {
-      const markerFeatures = markers.map(m => ({
-        type: 'Feature',
-        properties: {
-          name: m.label ? `${m.label} - ${m.name || 'photo'}` : (m.name || 'photo'),
-          role: 'track_photos',
-          label: m.label || undefined
-        },
-        geometry: { type: 'Point', coordinates: [m.lng, m.lat] }
-      }))
+      const markerFeatures = markers.map(m => {
+        // Feedback 2026-04-18: drop the " - photo" fallback suffix — readers asked
+        // for clean label-only names. Keep the filename only when the user supplied one.
+        const displayName = m.label && m.name
+          ? `${m.label} - ${m.name}`
+          : (m.label || m.name || '')
+        return {
+          type: 'Feature',
+          properties: {
+            name: displayName,
+            role: 'track_photos',
+            label: m.label || undefined
+          },
+          geometry: { type: 'Point', coordinates: [m.lng, m.lat] }
+        }
+      })
       features.push(...markerFeatures as any)
     }
     if (groundMarkers.length) {
       const gmFeatures = groundMarkers.map(gm => ({
         type: 'Feature',
         properties: {
-          name: gm.type,
+          // Feedback 2026-04-18: ground-marker labels cluttered the KML view.
+          // Keep the type in ExtendedData (markerType) so round-tripping works,
+          // but hide it from the visible <name>.
+          name: '',
           role: 'ground_markers',
           markerType: gm.type,
         },
@@ -372,9 +394,16 @@ function App() {
       type: 'FeatureCollection' as const,
       features
     }
-    const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, 'corridors_export')
+    // Rasterize each used ground-marker shape to a PNG data URI so the exported
+    // KML renders the same icons as the app and print output (feedback 2026-04-18).
+    // Missing types fall back to the default yellow-dot style inside kmlMerge.
+    const uniqueTypes = Array.from(new Set(groundMarkers.map(gm => gm.type)))
+    const groundMarkerIcons = uniqueTypes.length
+      ? await rasterizeGroundMarkerSet(uniqueTypes, 128)
+      : undefined
+    const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, 'corridors_export', { groundMarkerIcons })
     downloadKML(mergedKml, 'corridors_export.kml')
-  }, [markers, loadOriginalKmlText, t])
+  }, [markers, groundMarkers, loadOriginalKmlText, t])
 
   const handlePrintMap = useCallback(async () => {
     if (!mapRef.current) return
@@ -566,10 +595,22 @@ function App() {
             <ToggleButton value="satellite">{t('app.toggleBase.satellite')}</ToggleButton>
           </ToggleButtonGroup>
           <Chip
-            label={(urlDiscipline || session?.discipline || 'rally') === 'precision' ? t('app.discipline.precision') : t('app.discipline.rally')}
+            label={effectiveDiscipline === 'precision' ? t('app.discipline.precision') : t('app.discipline.rally')}
             size="small"
             sx={{ bgcolor: 'rgba(255,255,255,0.2)', color: 'white', fontWeight: 600 }}
           />
+          {effectiveDiscipline === 'rally' && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  size="small"
+                  checked={use1NmAfterSp}
+                  onChange={(e) => setUse1NmAfterSp(e.target.checked)}
+                />
+              }
+              label={t('app.use1NmAfterSp')}
+            />
+          )}
           <Box sx={{ flex: 1 }} />
           <Button variant="outlined" size="small" onClick={() => setAnswerSheetOpen(true)}>{t('app.answerSheet')}</Button>
         </Box>
@@ -607,7 +648,7 @@ function App() {
               session?.geojson ? { id: 'uploaded-geojson', data: session.geojson, type: 'line' as const, paint: { 'line-color': '#d32f2f', 'line-width': 3 } } : null,
               // Segmented corridor borders in green
               session?.leftSegments ? { id: 'left-segments', data: session.leftSegments, type: 'line' as const, paint: { 'line-color': '#00ff00', 'line-width': 2 } } : null,
-              session?.rightSegments && (urlDiscipline || session?.discipline || 'rally') !== 'precision' ? { id: 'right-segments', data: session.rightSegments, type: 'line' as const, paint: { 'line-color': '#00ff00', 'line-width': 2 } } : null,
+              session?.rightSegments && effectiveDiscipline !== 'precision' ? { id: 'right-segments', data: session.rightSegments, type: 'line' as const, paint: { 'line-color': '#00ff00', 'line-width': 2 } } : null,
               // Gates as red perpendicular lines marking corridor start points
               session?.gates ? { id: 'gates', data: session.gates, type: 'line' as const, paint: { 'line-color': '#00ff00', 'line-width': 2 } } : null,
               // Hide original KML waypoint labels to avoid duplicates; keep exactPoints labels

--- a/frontend/map-corridors/src/__tests__/groundMarkerPng.test.ts
+++ b/frontend/map-corridors/src/__tests__/groundMarkerPng.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  rasterizeGroundMarker,
+  rasterizeGroundMarkerSet,
+} from '../utils/groundMarkerPng'
+import type { GroundMarkerType } from '../types/markers'
+
+// JSDOM doesn't fire `img.onload` / `img.onerror` for data-URI sources,
+// which would hang the Promise inside `rasterizeGroundMarker` forever.
+// We stub `Image` with per-test behavior: `succeed` → fires onload and
+// lets the canvas path run (canvas ctx is still null in JSDOM so the
+// function returns null, but for a different reason); `fail` → fires
+// onerror and the catch returns null early.
+type ImgBehavior = 'succeed' | 'fail'
+function installImageStub(behavior: ImgBehavior) {
+  class StubImage {
+    onload: (() => void) | null = null
+    onerror: (() => void) | null = null
+    private _src = ''
+    set src(value: string) {
+      this._src = value
+      queueMicrotask(() => {
+        if (behavior === 'succeed') this.onload?.()
+        else this.onerror?.()
+      })
+    }
+    get src() {
+      return this._src
+    }
+  }
+  vi.stubGlobal('Image', StubImage as any)
+}
+
+// ---------------------------------------------------------------------------
+// rasterizeGroundMarker — contract: "null for unknown type, null on canvas
+// failure, PNG data URI on success". The function must NEVER throw and must
+// refuse unknown types synchronously before touching the canvas or Image.
+// ---------------------------------------------------------------------------
+describe('rasterizeGroundMarker', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns null for unknown type without touching canvas', async () => {
+    // No Image stub needed — unknown type returns null before any async work.
+    const result = await rasterizeGroundMarker('NOT_A_TYPE' as GroundMarkerType, 64)
+    expect(result).toBeNull()
+  })
+
+  it('does not throw on any input (contract: always returns null-or-dataUri)', async () => {
+    const bogus = await rasterizeGroundMarker('' as GroundMarkerType, 64)
+    expect(bogus).toBeNull()
+  })
+
+  it('rejects prototype keys (hasOwnProperty guard)', async () => {
+    const proto = await rasterizeGroundMarker('toString' as GroundMarkerType, 64)
+    expect(proto).toBeNull()
+    const ctor = await rasterizeGroundMarker('constructor' as GroundMarkerType, 64)
+    expect(ctor).toBeNull()
+  })
+
+  it('returns null when image load fails', async () => {
+    installImageStub('fail')
+    const result = await rasterizeGroundMarker('LETTER_A', 64)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when canvas 2D context is unavailable (JSDOM default)', async () => {
+    installImageStub('succeed')
+    // JSDOM returns null from getContext('2d') → function returns null.
+    const result = await rasterizeGroundMarker('LETTER_A', 64)
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// rasterizeGroundMarkerSet — contract: "returns { icons, failed } so the
+// caller can surface partial failure to the user". A regression that drops
+// the `failed` field (e.g. reverts to the old `Record<string, string>` shape)
+// silently downgrades the KML export to yellow-dot placemarks — the exact
+// regression feedback 2026-04-18 was meant to prevent.
+// ---------------------------------------------------------------------------
+describe('rasterizeGroundMarkerSet', () => {
+  beforeEach(() => {
+    // Default: make Image load fail so real types also route through the
+    // `failed` branch (useful for the contract tests below).
+    installImageStub('fail')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns { icons: {}, failed: [] } for empty input', async () => {
+    const result = await rasterizeGroundMarkerSet([])
+    expect(result.icons).toEqual({})
+    expect(result.failed).toEqual([])
+  })
+
+  it('puts unknown types in `failed`, not `icons`', async () => {
+    const result = await rasterizeGroundMarkerSet([
+      'UNKNOWN_1' as GroundMarkerType,
+      'UNKNOWN_2' as GroundMarkerType,
+    ])
+    expect(result.icons).toEqual({})
+    expect(result.failed).toHaveLength(2)
+    expect(result.failed).toContain('UNKNOWN_1')
+    expect(result.failed).toContain('UNKNOWN_2')
+  })
+
+  it('accounts for every input type — either in icons or in failed', async () => {
+    const result = await rasterizeGroundMarkerSet([
+      'LETTER_A',
+      'UNKNOWN' as GroundMarkerType,
+      'HOOK',
+    ])
+    for (const t of ['LETTER_A', 'UNKNOWN', 'HOOK'] as GroundMarkerType[]) {
+      const inIcons = typeof result.icons[t] === 'string'
+      const inFailed = result.failed.includes(t)
+      expect(inIcons || inFailed).toBe(true)
+    }
+  })
+
+  it('never rejects for a mixed-validity input (failed channel, not throw)', async () => {
+    // Regression pin: the old contract returned `{}` on any failure, so a
+    // caller that passes a mix of valid + invalid types must not receive a
+    // rejected Promise. `failed` is the ONLY channel for partial failure.
+    await expect(
+      rasterizeGroundMarkerSet([
+        'LETTER_A',
+        'UNKNOWN' as GroundMarkerType,
+        'HOOK',
+      ]),
+    ).resolves.toBeDefined()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/groundMarkers.test.ts
+++ b/frontend/map-corridors/src/__tests__/groundMarkers.test.ts
@@ -60,6 +60,30 @@ describe('groundMarkerSvgString', () => {
     expect(svg72).toContain('width="72"')
     expect(svg72).toContain('height="72"')
   })
+
+  // --- `stroke` parameter: used by groundMarkerPng.ts for KML icons on
+  // satellite imagery ('white') vs. printed A4 on white paper ('black', default).
+  // The value is interpolated *unescaped* into the SVG attribute — pin both
+  // the default AND the explicit override so a regression doesn't silently
+  // render all-black icons on dark satellite tiles.
+  it('defaults stroke to black (print-on-white)', () => {
+    const svg = groundMarkerSvgString('LETTER_A', 48)
+    expect(svg).toContain('stroke="black"')
+    expect(svg).not.toContain('stroke="white"')
+  })
+
+  it('applies stroke="white" when explicitly requested (KML icons on satellite)', () => {
+    const svg = groundMarkerSvgString('LETTER_A', 48, 'white')
+    expect(svg).toContain('stroke="white"')
+    expect(svg).not.toContain('stroke="black"')
+  })
+
+  it('propagates stroke across every ground-marker type', () => {
+    for (const type of GROUND_MARKER_TYPES) {
+      const svg = groundMarkerSvgString(type, 48, 'white')
+      expect(svg).toContain('stroke="white"')
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/frontend/map-corridors/src/__tests__/kmlExport.test.ts
+++ b/frontend/map-corridors/src/__tests__/kmlExport.test.ts
@@ -17,19 +17,22 @@ describe('appendFeaturesToKML', () => {
     expect(result).toContain('ff00ffff')
   })
 
-  it('photo markers appear under track_photos folder', () => {
+  it('photo markers appear under track_photos folder using label-only name', () => {
     const kml = loadFixtureText('RED.kml')
     const markers: FeatureCollection = {
       type: 'FeatureCollection',
       features: [{
+        // Callers now pass `label` as the display name and drop the " - photo"
+        // fallback suffix (feedback 2026-04-18).
         type: 'Feature',
-        properties: { name: 'A - test photo', role: 'track_photos', label: 'A' },
+        properties: { name: 'A', role: 'track_photos', label: 'A' },
         geometry: { type: 'Point', coordinates: [14.0, 50.0] }
       }]
     }
     const result = appendFeaturesToKML(kml, markers, 'test_export')
     expect(result).toContain('track_photos')
-    expect(result).toContain('A - test photo')
+    expect(result).toContain('<name>A</name>')
+    expect(result).not.toContain('- photo')
   })
 
   it('does NOT include corridor features when only markers are passed', () => {
@@ -38,7 +41,7 @@ describe('appendFeaturesToKML', () => {
       type: 'FeatureCollection',
       features: [{
         type: 'Feature',
-        properties: { name: 'A - photo', role: 'track_photos' },
+        properties: { name: 'A', role: 'track_photos' },
         geometry: { type: 'Point', coordinates: [14.0, 50.0] }
       }]
     }
@@ -71,28 +74,66 @@ describe('appendFeaturesToKML', () => {
     expect(result).toContain('TP 1')
   })
 
-  it('ground markers appear under ground_markers folder with raw enum names', () => {
+  it('ground markers render without visible label text but preserve role + markerType', () => {
+    // Feedback 2026-04-18: ground-marker <name> text cluttered Google Earth.
+    // Callers now pass an empty name; we emit <name></name> and keep the
+    // semantic type in ExtendedData (markerType) for round-tripping.
     const kml = loadFixtureText('RED.kml')
     const fc: FeatureCollection = {
       type: 'FeatureCollection',
       features: [
         {
           type: 'Feature',
-          properties: { name: 'LETTER_A', role: 'ground_markers', markerType: 'LETTER_A' },
+          properties: { name: '', role: 'ground_markers', markerType: 'LETTER_A' },
           geometry: { type: 'Point', coordinates: [14.1, 50.1] }
         },
         {
           type: 'Feature',
-          properties: { name: 'HOOK', role: 'ground_markers', markerType: 'HOOK' },
+          properties: { name: '', role: 'ground_markers', markerType: 'HOOK' },
           geometry: { type: 'Point', coordinates: [14.2, 50.2] }
         }
       ]
     }
     const result = appendFeaturesToKML(kml, fc, 'test_export')
-    // Raw enum names (not localized labels) so external tooling can parse them
+    // Role still flows through via ExtendedData
     expect(result).toContain('ground_markers')
-    expect(result).toContain('LETTER_A')
-    expect(result).toContain('HOOK')
+    // Empty <name> element is emitted (self-closing `<name/>` is also valid XML)
+    // rather than falling through to the role fallback.
+    expect(result).toMatch(/<name(?:\s*\/>|><\/name>)/)
+    // And we don't leak the enum label into visible KML text
+    expect(result).not.toContain('<name>LETTER_A</name>')
+    expect(result).not.toContain('<name>HOOK</name>')
+  })
+
+  it('embeds a per-type IconStyle when groundMarkerIcons is passed', () => {
+    // Feedback 2026-04-18: KML viewers should render the same shapes as screen
+    // and print. appendFeaturesToKML takes an optional type → PNG-data-URI map
+    // and creates one `<Style id="groundMarker_<TYPE>">` per type.
+    const kml = loadFixtureText('RED.kml')
+    const fc: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: { name: '', role: 'ground_markers', markerType: 'LETTER_A' },
+          geometry: { type: 'Point', coordinates: [14.1, 50.1] }
+        }
+      ]
+    }
+    const pngUri = 'data:image/png;base64,AAAA'
+    const result = appendFeaturesToKML(kml, fc, 'test_export', {
+      groundMarkerIcons: { LETTER_A: pngUri }
+    })
+    // A style block for the type exists and points at the provided data URI.
+    expect(result).toContain('groundMarker_LETTER_A')
+    expect(result).toContain(pngUri)
+    // LabelStyle scale=0 suppresses visible names even for viewers that
+    // ignore empty <name> elements.
+    expect(result).toMatch(/LabelStyle>[\s\S]*?<scale>0/)
+    // The placemark uses the per-type style, not the default labelPoint.
+    expect(result).toMatch(/styleUrl>#groundMarker_LETTER_A/)
+    // markerType is preserved in ExtendedData for round-tripping.
+    expect(result).toContain('markerType')
   })
 
   it('XML-escapes attacker-controlled characters in ground marker names', () => {

--- a/frontend/map-corridors/src/__tests__/parseDiscipline.test.ts
+++ b/frontend/map-corridors/src/__tests__/parseDiscipline.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { parseDisciplineFromSearch } from '../utils/parseDiscipline'
+
+// map-corridors returns `Discipline | null` so the caller can fall back
+// to `session?.discipline` (the rally-vs-precision choice persists in the
+// session, not just the URL). A silent downgrade would still mis-configure
+// the 1-NM toggle and the corridor generator.
+
+describe('parseDisciplineFromSearch', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('returns "precision" for ?discipline=precision', () => {
+    expect(parseDisciplineFromSearch('?discipline=precision')).toBe('precision')
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns "rally" for ?discipline=rally', () => {
+    expect(parseDisciplineFromSearch('?discipline=rally')).toBe('rally')
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the param is absent (lets session discipline win)', () => {
+    expect(parseDisciplineFromSearch('')).toBeNull()
+    expect(parseDisciplineFromSearch('?other=1')).toBeNull()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null for empty ?discipline= without logging', () => {
+    // Empty string is "unset" semantically, not "invalid" — same as absent.
+    expect(parseDisciplineFromSearch('?discipline=')).toBeNull()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null AND logs for mixed-case or typo values', () => {
+    expect(parseDisciplineFromSearch('?discipline=Precision')).toBeNull()
+    expect(parseDisciplineFromSearch('?discipline=RALLY')).toBeNull()
+    expect(parseDisciplineFromSearch('?discipline=precsn')).toBeNull()
+    expect(errorSpy).toHaveBeenCalledTimes(3)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
+++ b/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
@@ -109,6 +109,32 @@ describe('DISCIPLINE_CONFIGS', () => {
     expect(c.leftDistanceM).toBe(300)
     expect(c.rightDistanceM).toBe(300)
   })
+
+  // Feedback 2026-04-18: the rally "1 NM after SP" checkbox must produce
+  // a corridor that is 1 NM — not 5 NM — past the start point, and it must
+  // NOT mutate the module-level DISCIPLINE_CONFIGS record (a regression
+  // from `base.spAfterNm = 1.0` instead of `{...base, spAfterNm: 1.0}`
+  // would poison every subsequent session).
+  it('rally-1NM override clones base config without mutating it', () => {
+    const base = DISCIPLINE_CONFIGS.rally
+    const overridden = { ...base, spAfterNm: 1.0 }
+    expect(overridden.spAfterNm).toBe(1.0)
+    expect(overridden.tpAfterNm).toBe(1.0)
+    expect(overridden.leftDistanceM).toBe(300)
+    // Module-level record must stay at the default.
+    expect(DISCIPLINE_CONFIGS.rally.spAfterNm).toBe(5.0)
+  })
+
+  it('buildPreciseCorridorsAndGates accepts spAfterNm=1.0 without throwing', () => {
+    const geojson = loadFixture('RED.kml')
+    const result = buildPreciseCorridorsAndGates(geojson, {
+      ...DISCIPLINE_CONFIGS.rally,
+      spAfterNm: 1.0,
+    })
+    expect(result.leftSegments.length).toBeGreaterThan(0)
+    expect(result.rightSegments.length).toBeGreaterThan(0)
+    expect(result.gates.length).toBeGreaterThan(0)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/frontend/map-corridors/src/components/GroundMarkerIcons.tsx
+++ b/frontend/map-corridors/src/components/GroundMarkerIcons.tsx
@@ -35,7 +35,7 @@ const SVG_CONTENT: Record<GroundMarkerType, string> = {
   HOOK: '<path d="M 25 25 L 60 25 L 60 80 L 95 80"/>',
 }
 
-const SVG_ATTRS_PRINT = 'xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" stroke="black" stroke-width="10" fill="none" stroke-linecap="square" stroke-linejoin="miter"'
+const SVG_ATTRS_PRINT_BASE = 'xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" stroke-width="10" fill="none" stroke-linecap="square" stroke-linejoin="miter"'
 
 function lookupSvgContent(type: GroundMarkerType): string {
   // Guard against prototype keys (`toString`, `constructor`, ...) leaking through.
@@ -73,8 +73,14 @@ export const GROUND_MARKER_ICON: Record<GroundMarkerType, React.FC<{ size?: numb
 // Raw SVG string for canvas print rendering (mapCapture.ts) — double stroke width for print.
 // Returns '' for unknown types so callers can detect the miss and surface a warning
 // (see mapCapture.ts). The guard uses hasOwnProperty to reject prototype keys.
-export function groundMarkerSvgString(type: GroundMarkerType, size: number): string {
+// `stroke` lets callers pick a color per surface — black for print-on-white
+// (mapCapture) and white for KML icons that sit on top of satellite imagery
+// (feedback 2026-04-18).
+export function groundMarkerSvgString(type: GroundMarkerType, size: number, stroke: string = 'black'): string {
   const content = lookupSvgContent(type)
   if (!content) return ''
-  return `<svg ${SVG_ATTRS_PRINT} width="${size}" height="${size}">${content}</svg>`
+  // Attribute value is embedded via string interpolation — keep it to a strict
+  // color-token subset (default 'black', otherwise validated by the caller)
+  // rather than hand-rolling XML escaping for arbitrary input.
+  return `<svg ${SVG_ATTRS_PRINT_BASE} stroke="${stroke}" width="${size}" height="${size}">${content}</svg>`
 }

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -75,7 +75,8 @@
     "setTokenWeb": "Přidejte svůj token do proměnné prostředí VITE_MAPBOX_TOKEN a restartujte aplikaci.",
     "getTokenLink": "Získejte zdarma token na mapbox.com →",
     "noOriginalKml": "Původní KML není k dispozici pro export",
-    "printFailed": "Tisk mapy selhal"
+    "printFailed": "Tisk mapy selhal",
+    "someGroundMarkersFailed": "Některé tvary pozemních značek nešlo exportovat do KML a zobrazí se jako výchozí žluté body: {{types}}"
   }
   ,
   "opfs": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -75,7 +75,8 @@
     "setTokenWeb": "Add your token to the VITE_MAPBOX_TOKEN environment variable and restart the app.",
     "getTokenLink": "Get a free token at mapbox.com →",
     "noOriginalKml": "Original KML file not available for export",
-    "printFailed": "Map print failed"
+    "printFailed": "Map print failed",
+    "someGroundMarkersFailed": "Some ground-marker shapes could not be exported to KML and will appear as default yellow dots: {{types}}"
   }
   ,
   "opfs": {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -180,8 +180,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       const bbox = computeBbox(trackOverlay.data)
       if (!bbox) throw new Error('Could not compute track bounds')
 
-      // Only include track line, gates, and exact-point labels — no corridors
-      const printOverlayIds = new Set(['uploaded-geojson', 'gates', 'exact-points'])
+      // Only include track line and exact-point labels — no corridors, no gates.
+      // Gates (perpendicular start lines) cluttered the printed A4 (2026-04-18 feedback).
+      const printOverlayIds = new Set(['uploaded-geojson', 'exact-points'])
       const printOverlays = (geojsonOverlays || [])
         .filter(ov => printOverlayIds.has(ov.id))
         .map(ov => ({

--- a/frontend/map-corridors/src/utils/groundMarkerPng.ts
+++ b/frontend/map-corridors/src/utils/groundMarkerPng.ts
@@ -1,0 +1,63 @@
+import { groundMarkerSvgString } from '../components/GroundMarkerIcons'
+import type { GroundMarkerType } from '../types/markers'
+
+/**
+ * Rasterize a ground-marker SVG to a PNG data URI.
+ *
+ * KML `IconStyle` supports image hrefs via data URIs; Google Earth
+ * renders PNG data URIs reliably while inline SVG support is
+ * inconsistent. We draw the SVG to an offscreen canvas and export PNG
+ * so the KML export can show the same marker shape users see on screen
+ * and in printed A4 (feedback 2026-04-18).
+ *
+ * Returns `null` for unknown types (mirrors `groundMarkerSvgString`),
+ * and for environments that can't mint a 2D canvas context.
+ *
+ * `stroke` is restricted to a safe whitelist because it is embedded into
+ * the SVG source unescaped — any caller wanting a new color has to be
+ * added explicitly.
+ */
+type SafeStroke = 'black' | 'white'
+
+export async function rasterizeGroundMarker(
+  type: GroundMarkerType,
+  sizePx: number,
+  stroke: SafeStroke = 'white',
+): Promise<string | null> {
+  const svg = groundMarkerSvgString(type, sizePx, stroke)
+  if (!svg) return null
+  const svgUri = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  const img = new Image()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error(`image onerror for ${type}`))
+      img.src = svgUri
+    })
+  } catch {
+    return null
+  }
+  const canvas = document.createElement('canvas')
+  canvas.width = sizePx
+  canvas.height = sizePx
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+  ctx.drawImage(img, 0, 0, sizePx, sizePx)
+  return canvas.toDataURL('image/png')
+}
+
+/** Build a `type → dataUri` map for the given marker types, skipping any that fail. */
+export async function rasterizeGroundMarkerSet(
+  types: readonly GroundMarkerType[],
+  sizePx = 64,
+  stroke: SafeStroke = 'white',
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {}
+  await Promise.all(
+    types.map(async (t) => {
+      const uri = await rasterizeGroundMarker(t, sizePx, stroke)
+      if (uri) out[t] = uri
+    }),
+  )
+  return out
+}

--- a/frontend/map-corridors/src/utils/groundMarkerPng.ts
+++ b/frontend/map-corridors/src/utils/groundMarkerPng.ts
@@ -11,7 +11,11 @@ import type { GroundMarkerType } from '../types/markers'
  * and in printed A4 (feedback 2026-04-18).
  *
  * Returns `null` for unknown types (mirrors `groundMarkerSvgString`),
- * and for environments that can't mint a 2D canvas context.
+ * and for environments that can't mint a 2D canvas context. Any error
+ * thrown by `drawImage` / `toDataURL` (e.g. canvas tainting, OOM on
+ * very large canvases) is also caught and returned as `null` so the
+ * function's contract holds — callers can branch on `null` to surface
+ * a warning instead of producing a broken KML `<href>`.
  *
  * `stroke` is restricted to a safe whitelist because it is embedded into
  * the SVG source unescaped — any caller wanting a new color has to be
@@ -42,22 +46,45 @@ export async function rasterizeGroundMarker(
   canvas.height = sizePx
   const ctx = canvas.getContext('2d')
   if (!ctx) return null
-  ctx.drawImage(img, 0, 0, sizePx, sizePx)
-  return canvas.toDataURL('image/png')
+  try {
+    ctx.drawImage(img, 0, 0, sizePx, sizePx)
+    const uri = canvas.toDataURL('image/png')
+    // `toDataURL` returns `"data:,"` on allocation failure in some engines
+    // instead of throwing; treat it as failure so the caller can surface it.
+    if (!uri || uri === 'data:,' || !uri.startsWith('data:image/png')) return null
+    return uri
+  } catch {
+    return null
+  }
 }
 
-/** Build a `type → dataUri` map for the given marker types, skipping any that fail. */
+export type RasterizeSetResult = {
+  /** `type → PNG data URI` for every type that rasterized successfully. */
+  icons: Record<string, string>
+  /** Types that failed to rasterize (unknown type, canvas unavailable, etc.). */
+  failed: GroundMarkerType[]
+}
+
+/**
+ * Build a `type → dataUri` map for the given marker types.
+ *
+ * Returns both the successful icons AND the list of failed types so the
+ * caller can surface a warning instead of silently downgrading the KML
+ * export to default-style placemarks (feedback 2026-04-18 regression risk).
+ */
 export async function rasterizeGroundMarkerSet(
   types: readonly GroundMarkerType[],
   sizePx = 64,
   stroke: SafeStroke = 'white',
-): Promise<Record<string, string>> {
-  const out: Record<string, string> = {}
+): Promise<RasterizeSetResult> {
+  const icons: Record<string, string> = {}
+  const failed: GroundMarkerType[] = []
   await Promise.all(
     types.map(async (t) => {
       const uri = await rasterizeGroundMarker(t, sizePx, stroke)
-      if (uri) out[t] = uri
+      if (uri) icons[t] = uri
+      else failed.push(t)
     }),
   )
-  return out
+  return { icons, failed }
 }

--- a/frontend/map-corridors/src/utils/kmlMerge.ts
+++ b/frontend/map-corridors/src/utils/kmlMerge.ts
@@ -58,25 +58,35 @@ function addLinePlacemark(doc: Document, name: string, coords: number[][], style
   documentEl.appendChild(pm)
 }
 
-function addPointPlacemark(doc: Document, name: string, coord: number[], role?: string) {
-  const parentEl = role === 'track_photos' 
-    ? ensureFolder(doc, 'track_photos') 
+function addPointPlacemark(doc: Document, name: string, coord: number[], role?: string, styleId?: string, markerType?: string) {
+  const parentEl = role === 'track_photos'
+    ? ensureFolder(doc, 'track_photos')
     : (doc.getElementsByTagName('Document')[0] || doc.documentElement)
   const pm = doc.createElementNS(KML_NS, 'Placemark')
   const nm = doc.createElementNS(KML_NS, 'name')
   nm.textContent = name
-  if (role) {
-    const ext = doc.createElementNS(KML_NS, 'ExtendedData')
+  const ext = (role || markerType) ? doc.createElementNS(KML_NS, 'ExtendedData') : null
+  if (ext && role) {
     const data = doc.createElementNS(KML_NS, 'Data')
     data.setAttribute('name', 'role')
     const val = doc.createElementNS(KML_NS, 'value')
     val.textContent = role
     data.appendChild(val)
     ext.appendChild(data)
-    pm.appendChild(ext)
   }
+  if (ext && markerType) {
+    // Preserve the raw enum so round-tripping the KML (re-import / external
+    // tooling) can recover the shape without parsing the icon image.
+    const data = doc.createElementNS(KML_NS, 'Data')
+    data.setAttribute('name', 'markerType')
+    const val = doc.createElementNS(KML_NS, 'value')
+    val.textContent = markerType
+    data.appendChild(val)
+    ext.appendChild(data)
+  }
+  if (ext) pm.appendChild(ext)
   const styleUrl = doc.createElementNS(KML_NS, 'styleUrl')
-  styleUrl.textContent = '#labelPoint'
+  styleUrl.textContent = `#${styleId || 'labelPoint'}`
   const pt = doc.createElementNS(KML_NS, 'Point')
   const coordsEl = doc.createElementNS(KML_NS, 'coordinates')
   coordsEl.textContent = `${coord[0]},${coord[1]},${coord[2] || 0}`
@@ -87,7 +97,35 @@ function addPointPlacemark(doc: Document, name: string, coord: number[], role?: 
   parentEl.appendChild(pm)
 }
 
-export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName?: string): string {
+function escapeXmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function ensureGroundMarkerStyle(doc: Document, type: string, iconHref: string) {
+  const id = `groundMarker_${type}`
+  // LabelStyle scale=0 hides the visible `<name>` text (feedback 2026-04-18:
+  // labels cluttered the map; users want the icon only).
+  // hotSpot anchors the icon's centre on the point so the shape lands exactly
+  // where the user placed it.
+  ensureStyle(
+    doc,
+    id,
+    `<IconStyle><scale>1.2</scale><Icon><href>${escapeXmlAttr(iconHref)}</href></Icon><hotSpot x="0.5" y="0.5" xunits="fraction" yunits="fraction"/></IconStyle><LabelStyle><scale>0</scale></LabelStyle>`,
+  )
+  return id
+}
+
+export type AppendOptions = {
+  /**
+   * Optional map of ground marker type → PNG data URI. When provided, each
+   * ground marker placemark gets its own IconStyle pointing at the raster of
+   * the shape users see in the app (see `rasterizeGroundMarkerSet`). Missing
+   * entries fall back to the default yellow-dot style.
+   */
+  groundMarkerIcons?: Record<string, string>
+}
+
+export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName?: string, options?: AppendOptions): string {
   const parser = new DOMParser()
   const xml = parser.parseFromString(originalKml, 'application/xml')
   let documentEl = xml.getElementsByTagName('Document')[0]
@@ -114,6 +152,15 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
   ensureStyle(xml, 'greenLine', '<LineStyle><color>ff00ff00</color><width>2</width></LineStyle>')
   ensureStyle(xml, 'labelPoint', '<IconStyle><color>ff00ffff</color><scale>0.8</scale></IconStyle><LabelStyle><scale>1</scale></LabelStyle>')
 
+  // Register one IconStyle per used ground-marker type (feedback 2026-04-18:
+  // KML should show the same shapes as screen + print, not just generic pins).
+  const iconMap = options?.groundMarkerIcons || {}
+  const groundMarkerStyleIds = new Map<string, string>()
+  for (const [type, href] of Object.entries(iconMap)) {
+    if (!type || !href) continue
+    groundMarkerStyleIds.set(type, ensureGroundMarkerStyle(xml, type, href))
+  }
+
   const features = extra.type === 'FeatureCollection' ? (extra as FeatureCollection).features : [extra as Feature]
 
   for (const feature of features) {
@@ -127,8 +174,15 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
       addLinePlacemark(xml, name, ls.coordinates as any, style, role)
     } else if (feature.geometry.type === 'Point') {
       const pt = feature.geometry as Point
-      const name = (props as any).name || (props as any).role || 'point'
-      addPointPlacemark(xml, name, pt.coordinates as any, (props as any).role)
+      // Treat an explicit empty `name` as intentional (feedback 2026-04-18:
+      // hide ground-marker label text in Google Earth) rather than falling
+      // through to the role/'point' fallback.
+      const rawName = (props as any).name
+      const name = typeof rawName === 'string' ? rawName : ((props as any).role || 'point')
+      const role = (props as any).role as string | undefined
+      const markerType = (props as any).markerType as string | undefined
+      const customStyleId = role === 'ground_markers' && markerType ? groundMarkerStyleIds.get(markerType) : undefined
+      addPointPlacemark(xml, name, pt.coordinates as any, role, customStyleId, markerType)
     }
   }
 

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -158,8 +158,10 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     const scaleX = mapCanvas.width / dims.width
     const scaleY = mapCanvas.height / dims.height
 
-    // Composite photo markers (3x size for print legibility)
-    const markerRadius = 18 * scaleX
+    // Composite photo markers. Screen uses 8px diameter; print was tuned up to
+    // 36px diameter originally — testing feedback (2026-04-18) said that was too
+    // large on paper, so we drop to 20px diameter (10px radius) here.
+    const markerRadius = 10 * scaleX
     const fontSize = Math.round(42 * scaleX)
 
     for (const m of markers) {
@@ -205,7 +207,10 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     // is a correctness bug, not a cosmetic one.
     const gms = options.groundMarkers || []
     if (gms.length) {
-      const iconSize = Math.round(72 * scaleX)
+      // Match the photo-marker label pill height (~46 px) so the two symbol
+      // types read at the same visual weight on A4 (feedback 2026-04-18 —
+      // 72 px made ground markers dominate their photo neighbours).
+      const iconSize = Math.round(40 * scaleX)
       const uniqueTypes = [...new Set(gms.map(gm => gm.type))]
       const gmImages = new Map<GroundMarkerType, HTMLImageElement>()
       const failedTypes = new Set<GroundMarkerType>()
@@ -234,21 +239,52 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
       if (failedTypes.size) {
         console.warn('[mapCapture] Ground marker SVG load failures:', Array.from(failedTypes))
       }
+      // Match the on-screen layout: 8px dot at the true point, icon in a white
+      // pill offset to the upper-right (feedback 2026-04-18 — the icon was
+      // previously centered on the point and obscured the exact position).
+      const iconPad = 4 * scaleX
+      const pillRadius = 4 * scaleX
       for (const gm of gms) {
         const px = map.project([gm.lng, gm.lat])
         const x = px.x * scaleX
         const y = px.y * scaleY
+        // Yellow dot marks the exact position.
+        ctx.beginPath()
+        ctx.arc(x, y, markerRadius, 0, Math.PI * 2)
+        ctx.fillStyle = '#FFFF00'
+        ctx.fill()
+        ctx.strokeStyle = '#333333'
+        ctx.lineWidth = 1.5 * scaleX
+        ctx.stroke()
+
         const img = gmImages.get(gm.type)
         if (img) {
-          ctx.drawImage(img, x - img.width / 2, y - img.height / 2, img.width, img.height)
-        } else {
-          // Fallback: orange diamond (shape unavailable — see `warnings`)
-          const r = 24 * scaleX
+          // Offset the icon pill up and to the right of the dot. The pill's
+          // left edge sits at `markerRadius + iconPad` from the dot; its
+          // vertical midline is raised ~60% of the icon height so the pill
+          // never overlaps the dot itself.
+          const pillW = img.width + iconPad * 2
+          const pillH = img.height + iconPad * 2
+          const pillLeft = x + markerRadius + iconPad
+          const pillTop = y - pillH * 0.6 - markerRadius * 0.5
+          ctx.fillStyle = 'rgba(255, 255, 255, 0.9)'
           ctx.beginPath()
-          ctx.moveTo(x, y - r)
-          ctx.lineTo(x + r, y)
-          ctx.lineTo(x, y + r)
-          ctx.lineTo(x - r, y)
+          ctx.roundRect(pillLeft, pillTop, pillW, pillH, pillRadius)
+          ctx.fill()
+          ctx.strokeStyle = '#e5e7eb'
+          ctx.lineWidth = 1 * scaleX
+          ctx.stroke()
+          ctx.drawImage(img, pillLeft + iconPad, pillTop + iconPad, img.width, img.height)
+        } else {
+          // Fallback: orange diamond offset to the right (shape unavailable — see `warnings`)
+          const r = 24 * scaleX
+          const cx = x + markerRadius + iconPad + r
+          const cy = y - r * 0.4 - markerRadius * 0.5
+          ctx.beginPath()
+          ctx.moveTo(cx, cy - r)
+          ctx.lineTo(cx + r, cy)
+          ctx.lineTo(cx, cy + r)
+          ctx.lineTo(cx - r, cy)
           ctx.closePath()
           ctx.fillStyle = '#FF9800'
           ctx.fill()

--- a/frontend/map-corridors/src/utils/parseDiscipline.ts
+++ b/frontend/map-corridors/src/utils/parseDiscipline.ts
@@ -1,0 +1,20 @@
+import type { Discipline } from '../corridors/preciseCorridor'
+
+/**
+ * Parse the `?discipline=` URL parameter. Returns `null` when the
+ * param is absent or invalid so the caller can fall back to the
+ * session-level discipline (see `App.tsx` — `effectiveDiscipline`).
+ *
+ * Invalid non-empty values are logged via `console.error` so a
+ * desktop-launcher drift surfaces during QA instead of silently
+ * downgrading precision sessions to rally.
+ */
+export function parseDisciplineFromSearch(search: string): Discipline | null {
+  const params = new URLSearchParams(search)
+  const d = params.get('discipline')
+  if (d === 'precision' || d === 'rally') return d
+  if (d !== null && d !== '') {
+    console.error(`[parseDiscipline] Invalid ?discipline="${d}"; falling back to session discipline.`)
+  }
+  return null
+}

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Container,
   Typography,
@@ -33,7 +33,8 @@ import {
   Shuffle,
   Warning,
   Home,
-  Map
+  Map,
+  Add as AddIcon,
 } from '@mui/icons-material';
 import { usePhotoSessionApi } from './hooks/usePhotoSessionApi';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
@@ -65,7 +66,21 @@ const LOADING_TEXT_DELAY = 3000; // 3 seconds
 const STORAGE_MODE = (import.meta as any).env?.VITE_STORAGE_MODE ?? 'opfs';
 const useSessionHook = STORAGE_MODE === 'backend' ? usePhotoSessionApi : useCompetitionSystem;
 
+type Discipline = 'precision' | 'rally';
+
 function AppApi() {
+  // Desktop launcher passes `?discipline=precision|rally` when opening this app
+  // (desktop/main.js:205). Default to rally for web / legacy sessions.
+  const discipline: Discipline = useMemo(() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const d = params.get('discipline');
+      if (d === 'precision' || d === 'rally') return d;
+    } catch {}
+    return 'rally';
+  }, []);
+  const isPrecision = discipline === 'precision';
+
   const sessionHookResult = useSessionHook() as any;
   const {
     session,
@@ -184,16 +199,36 @@ function AppApi() {
     }
   }, [session?.layoutMode, setLayoutMode]);
 
+  // Precision discipline: slot count follows actual photo count (feedback 2026-04-18
+  // — a 10-slot layout with 9 photos printed an empty 10th tile).
+  //   turning   → always 9 slots (landscape 3×3) — spec is SP + TP1..TP7 + FP
+  //   track     → 10 slots (portrait 2×5) *only when* the user reaches 10 photos;
+  //               otherwise 9-slot landscape so the printed page isn't padded with
+  //               an empty tile. Uploading the 10th photo snaps to portrait.
+  useEffect(() => {
+    if (!isPrecision || !session?.mode) return;
+    const photoCount = session.sets.set1.photos.length;
+    const required: 'portrait' | 'landscape' = (session.mode === 'track' && photoCount === 10)
+      ? 'portrait'
+      : 'landscape';
+    if (layoutMode !== required) {
+      setLayoutMode(required);
+      updateLayoutMode(required);
+    }
+  }, [isPrecision, session?.mode, session?.sets.set1.photos.length, layoutMode, setLayoutMode, updateLayoutMode]);
+
   const handlePhotoClick = (photo: ApiPhoto, setKey: 'set1' | 'set2') => {
     const setPhotos = session?.sets[setKey].photos || [];
     const photoIndex = setPhotos.findIndex(p => p.id === photo.id);
-    
+
     // Calculate label based on mode
     let label: string;
     if (session?.mode === 'turningpoint') {
       // Turning point mode: SP, TP1, TP2, ..., FP
       const set1Count = session.sets.set1.photos.length;
-      const set2Count = session.sets.set2.photos.length;
+      // Precision mode hides set2 in the UI, so labels also ignore it
+      // (keeps SP/TP/FP sequence anchored to the single visible grid).
+      const set2Count = isPrecision ? 0 : session.sets.set2.photos.length;
       const turningPointLabels = generateTurningPointLabels(set1Count, set2Count, session.layoutMode || 'landscape');
       
       if (setKey === 'set1') {
@@ -328,7 +363,10 @@ function AppApi() {
       if (session.mode === 'turningpoint') {
         // Turning point mode: use SP, TP1, TP2, ..., FP labels
         const set1Count = session.sets.set1.photos.length;
-        const set2Count = session.sets.set2.photos.length;
+        // Precision single-set: treat set2 as empty for both labeling and PDF
+        // pages so a stale set2 (e.g. user switched discipline mid-session)
+        // doesn't leak into the output.
+        const set2Count = isPrecision ? 0 : session.sets.set2.photos.length;
         const turningPointLabels = generateTurningPointLabels(set1Count, set2Count, session.layoutMode || 'landscape');
 
         set1WithLabels = {
@@ -339,13 +377,15 @@ function AppApi() {
           } as unknown as ApiPhoto & { label: string }))
         };
 
-        set2WithLabels = {
-          ...session.sets.set2,
-          photos: session.sets.set2.photos.map((photo, index) => ({
-            ...photo,
-            label: turningPointLabels.set2[index] || 'X'
-          } as unknown as ApiPhoto & { label: string }))
-        };
+        set2WithLabels = isPrecision
+          ? { ...session.sets.set2, photos: [] as any[] }
+          : {
+              ...session.sets.set2,
+              photos: session.sets.set2.photos.map((photo, index) => ({
+                ...photo,
+                label: turningPointLabels.set2[index] || 'X'
+              } as unknown as ApiPhoto & { label: string }))
+            };
       } else {
         // Track mode: use A, B, C, etc. labels
         set1WithLabels = {
@@ -357,13 +397,17 @@ function AppApi() {
         };
 
         const set1Count = session.sets.set1.photos.length;
-        set2WithLabels = {
-          ...session.sets.set2,
-          photos: session.sets.set2.photos.map((photo, index) => ({
-            ...photo,
-            label: generateLabel(index, set1Count) // Continue from where Set 1 left off
-          } as unknown as ApiPhoto & { label: string }))
-        };
+        // Precision track mode is a single-set layout — drop set2 from PDF
+        // to keep output consistent with what the user sees on screen.
+        set2WithLabels = isPrecision
+          ? { ...session.sets.set2, photos: [] as any[] }
+          : {
+              ...session.sets.set2,
+              photos: session.sets.set2.photos.map((photo, index) => ({
+                ...photo,
+                label: generateLabel(index, set1Count) // Continue from where Set 1 left off
+              } as unknown as ApiPhoto & { label: string }))
+            };
       }
 
       await generatePDF(set1WithLabels, set2WithLabels, sessionId, currentRatio.ratio, session.competition_name, session.layoutMode || 'landscape', t);
@@ -689,6 +733,7 @@ function AppApi() {
             onPhotoRemove={handlePhotoRemove}
             onPhotoMove={handlePhotoMove}
             totalPhotoCount={stats.set1Photos + stats.set2Photos}
+            isPrecision={isPrecision}
           />
         ) : (
           /* Track Mode - Responsive Layout */
@@ -710,7 +755,10 @@ function AppApi() {
                     <GridSizedDropZone
                       onFilesDropped={(files) => addPhotosToSet(files, 'set1')}
                       setName={t('sets.set1')}
-                      maxPhotos={layoutMode === 'portrait' ? 10 : 9}
+                      // Precision track allows up to 10 regardless of current
+                      // layoutMode — a fresh 10-photo drop will switch the
+                      // layout via the effect above (feedback 2026-04-18).
+                      maxPhotos={isPrecision && session?.mode === 'track' ? 10 : (layoutMode === 'portrait' ? 10 : 9)}
                       loading={loading}
                       error={error}
                     />
@@ -738,6 +786,7 @@ function AppApi() {
                         onPhotoClick={(photo) => handlePhotoClick(photo, 'set1')}
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set1', fromIndex, toIndex)}
                         onFilesDropped={(files) => addPhotosToSet(files, 'set1')}
+                        maxPhotosOverride={isPrecision && session.mode === 'track' ? 10 : undefined}
                       />
                     </Paper>
                   )
@@ -794,12 +843,59 @@ function AppApi() {
               </Box>
             );
 
+            // Precision track mode: user feedback 2026-04-18 — single upload of
+            // up to 10 photos, no second set. Rally keeps the two-set layout.
+            if (isPrecision) {
+              // When the user has exactly 9 photos in landscape (3×3), the grid
+              // is full and offers no visible drop target for a 10th photo.
+              // Surface an explicit compact add-one affordance below the grid;
+              // dropping here triggers the layout auto-switch to portrait.
+              const showAddTenth = session?.mode === 'track' && stats.set1Photos === 9;
+              return (
+                <Box sx={{ mb: 6 }}>
+                  {Set1Component}
+                  {showAddTenth && (
+                    <Box sx={{ mt: 2 }}>
+                      <Paper
+                        elevation={1}
+                        sx={{
+                          p: 2,
+                          borderRadius: 2,
+                          border: '2px dashed',
+                          borderColor: 'primary.light',
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          gap: 1,
+                        }}
+                      >
+                        <AddIcon color="primary" />
+                        <Typography variant="body2" color="text.secondary">
+                          {t('upload.addTenthPhoto')}
+                        </Typography>
+                        <Box sx={{ width: '100%' }}>
+                          <DropZone
+                            onFilesDropped={(files) => addPhotosToSet(files.slice(0, 1), 'set1')}
+                            setName={t('upload.addTenthPhoto')}
+                            currentPhotoCount={9}
+                            maxPhotos={10}
+                            loading={loading}
+                            error={null}
+                          />
+                        </Box>
+                      </Paper>
+                    </Box>
+                  )}
+                </Box>
+              );
+            }
+
             // Render based on layout mode
             if (shouldShowSideBySide) {
               // Side-by-side layout for large screens in portrait mode
               return (
-                <Box sx={{ 
-                  display: 'flex', 
+                <Box sx={{
+                  display: 'flex',
                   gap: 2, // Reduced gap from 3 to 2
                   mb: 6,
                   alignItems: 'flex-start'

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -58,7 +58,10 @@ import { useI18n } from './contexts/I18nContext';
 import { useLayoutMode } from './contexts/LayoutModeContext';
 import { generatePDF } from './utils/pdfGenerator';
 import { generateTurningPointLabels } from './utils/imageProcessing';
-import type { ApiPhoto, ApiPhotoSet } from './types/api';
+import { parseDiscipline } from './utils/parseDiscipline';
+import type { Discipline } from './utils/parseDiscipline';
+import { buildPdfSets } from './utils/buildPdfSets';
+import type { ApiPhoto } from './types/api';
 
 // Configurable delay before showing loading text (in milliseconds)
 const LOADING_TEXT_DELAY = 3000; // 3 seconds
@@ -66,19 +69,10 @@ const LOADING_TEXT_DELAY = 3000; // 3 seconds
 const STORAGE_MODE = (import.meta as any).env?.VITE_STORAGE_MODE ?? 'opfs';
 const useSessionHook = STORAGE_MODE === 'backend' ? usePhotoSessionApi : useCompetitionSystem;
 
-type Discipline = 'precision' | 'rally';
-
 function AppApi() {
   // Desktop launcher passes `?discipline=precision|rally` when opening this app
   // (desktop/main.js:205). Default to rally for web / legacy sessions.
-  const discipline: Discipline = useMemo(() => {
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const d = params.get('discipline');
-      if (d === 'precision' || d === 'rally') return d;
-    } catch {}
-    return 'rally';
-  }, []);
+  const discipline: Discipline = useMemo(() => parseDiscipline(window.location.search), []);
   const isPrecision = discipline === 'precision';
 
   const sessionHookResult = useSessionHook() as any;
@@ -358,57 +352,14 @@ function AppApi() {
     }
 
     try {
-      let set1WithLabels, set2WithLabels;
-
-      if (session.mode === 'turningpoint') {
-        // Turning point mode: use SP, TP1, TP2, ..., FP labels
-        const set1Count = session.sets.set1.photos.length;
-        // Precision single-set: treat set2 as empty for both labeling and PDF
-        // pages so a stale set2 (e.g. user switched discipline mid-session)
-        // doesn't leak into the output.
-        const set2Count = isPrecision ? 0 : session.sets.set2.photos.length;
-        const turningPointLabels = generateTurningPointLabels(set1Count, set2Count, session.layoutMode || 'landscape');
-
-        set1WithLabels = {
-          ...session.sets.set1,
-          photos: session.sets.set1.photos.map((photo, index) => ({
-            ...photo,
-            label: turningPointLabels.set1[index] || 'X'
-          } as unknown as ApiPhoto & { label: string }))
-        };
-
-        set2WithLabels = isPrecision
-          ? { ...session.sets.set2, photos: [] as any[] }
-          : {
-              ...session.sets.set2,
-              photos: session.sets.set2.photos.map((photo, index) => ({
-                ...photo,
-                label: turningPointLabels.set2[index] || 'X'
-              } as unknown as ApiPhoto & { label: string }))
-            };
-      } else {
-        // Track mode: use A, B, C, etc. labels
-        set1WithLabels = {
-          ...session.sets.set1,
-          photos: session.sets.set1.photos.map((photo, index) => ({
-            ...photo,
-            label: generateLabel(index) // Use dynamic labeling (letters or numbers) with dot
-          } as unknown as ApiPhoto & { label: string }))
-        };
-
-        const set1Count = session.sets.set1.photos.length;
-        // Precision track mode is a single-set layout — drop set2 from PDF
-        // to keep output consistent with what the user sees on screen.
-        set2WithLabels = isPrecision
-          ? { ...session.sets.set2, photos: [] as any[] }
-          : {
-              ...session.sets.set2,
-              photos: session.sets.set2.photos.map((photo, index) => ({
-                ...photo,
-                label: generateLabel(index, set1Count) // Continue from where Set 1 left off
-              } as unknown as ApiPhoto & { label: string }))
-            };
-      }
+      const { set1WithLabels, set2WithLabels } = buildPdfSets({
+        mode: session.mode,
+        layoutMode: session.layoutMode || 'landscape',
+        isPrecision,
+        set1: session.sets.set1,
+        set2: session.sets.set2,
+        generateLabel,
+      });
 
       await generatePDF(set1WithLabels, set2WithLabels, sessionId, currentRatio.ratio, session.competition_name, session.layoutMode || 'landscape', t);
     } catch (error) {

--- a/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
+++ b/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { buildPdfSets } from '../utils/buildPdfSets';
+import type { ApiPhoto, ApiPhotoSet } from '../types/api';
+
+// buildPdfSets is the pure core of the precision PDF correctness guarantee
+// from feedback 2026-04-18: "precision = single set". If a stale set2 from
+// a mid-session discipline switch leaks into the printed PDF, competition
+// judges see wrong photos. That regression ships silently unless pinned.
+
+function makePhoto(id: string, filename = `${id}.jpg`): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob://${id}`,
+    filename,
+    canvasState: {} as any,
+    label: '', // will be overwritten by buildPdfSets
+  };
+}
+
+function makeSet(title: string, ids: string[]): ApiPhotoSet {
+  return { title, photos: ids.map(id => makePhoto(id)) };
+}
+
+const letterLabel = (index: number, offset = 0): string =>
+  String.fromCharCode(65 + index + offset) + '.';
+
+describe('buildPdfSets — turningpoint mode', () => {
+  it('rally: labels full SP / TP1..TPn / FP sequence across both sets', () => {
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      set1: makeSet('SP - TP5', ['a', 'b', 'c', 'd', 'e']),
+      set2: makeSet('TP5 - FP', ['f', 'g', 'h', 'i', 'j']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set1WithLabels.photos.map(p => p.label)).toEqual([
+      'SP', 'TP1', 'TP2', 'TP3', 'TP4',
+    ]);
+    expect(result.set2WithLabels.photos.map(p => p.label)).toEqual([
+      'TP5', 'TP6', 'TP7', 'TP8', 'FP',
+    ]);
+  });
+
+  it('precision: set2 photos dropped, set1 labeled SP + TP1..TP7 + FP (9 photos)', () => {
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: true,
+      set1: makeSet('Precision', ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9']),
+      // stale set2 from a prior rally session that must NOT leak into PDF
+      set2: makeSet('stale', ['s1', 's2', 's3']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set2WithLabels.photos).toEqual([]);
+    expect(result.set1WithLabels.photos.map(p => p.label)).toEqual([
+      'SP', 'TP1', 'TP2', 'TP3', 'TP4', 'TP5', 'TP6', 'TP7', 'FP',
+    ]);
+  });
+
+  it('precision: preserves set2.title even when photos are cleared', () => {
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: true,
+      set1: makeSet('single', ['a', 'b', 'c']),
+      set2: makeSet('should-persist-title', ['x']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set2WithLabels.title).toBe('should-persist-title');
+  });
+
+  it('precision: empty set1 still zeros set2 without throwing', () => {
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: true,
+      set1: makeSet('empty', []),
+      set2: makeSet('stale', ['x', 'y']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set1WithLabels.photos).toEqual([]);
+    expect(result.set2WithLabels.photos).toEqual([]);
+  });
+
+  it('preserves ApiPhoto fields other than label', () => {
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      set1: makeSet('s1', ['a']),
+      set2: makeSet('s2', ['b']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set1WithLabels.photos[0].id).toBe('a');
+    expect(result.set1WithLabels.photos[0].filename).toBe('a.jpg');
+    expect(result.set1WithLabels.photos[0].sessionId).toBe('sess-1');
+  });
+});
+
+describe('buildPdfSets — track mode', () => {
+  it('rally: letter labels continue across sets (A B C | D E F)', () => {
+    const result = buildPdfSets({
+      mode: 'track',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      set1: makeSet('s1', ['a', 'b', 'c']),
+      set2: makeSet('s2', ['d', 'e', 'f']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set1WithLabels.photos.map(p => p.label)).toEqual(['A.', 'B.', 'C.']);
+    expect(result.set2WithLabels.photos.map(p => p.label)).toEqual(['D.', 'E.', 'F.']);
+  });
+
+  it('precision: set2 dropped regardless of layoutMode', () => {
+    const result = buildPdfSets({
+      mode: 'track',
+      layoutMode: 'portrait',
+      isPrecision: true,
+      set1: makeSet('s1', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']),
+      set2: makeSet('stale', ['s']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set2WithLabels.photos).toEqual([]);
+    expect(result.set1WithLabels.photos.map(p => p.label)).toEqual([
+      'A.', 'B.', 'C.', 'D.', 'E.', 'F.', 'G.', 'H.', 'I.', 'J.',
+    ]);
+  });
+
+  it('passes set1 offset to generateLabel for set2 so rally counts keep going', () => {
+    const calls: Array<[number, number | undefined]> = [];
+    const spyLabel = (index: number, offset?: number): string => {
+      calls.push([index, offset]);
+      return `${index}/${offset ?? 0}`;
+    };
+    buildPdfSets({
+      mode: 'track',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      set1: makeSet('s1', ['a', 'b', 'c']),
+      set2: makeSet('s2', ['d', 'e']),
+      generateLabel: spyLabel,
+    });
+    expect(calls).toEqual([
+      [0, undefined], [1, undefined], [2, undefined], // set1
+      [0, 3], [1, 3],                                 // set2 offset by set1.length
+    ]);
+  });
+});
+
+describe('buildPdfSets — non-mutation guarantee', () => {
+  it('does not mutate the input sets or photos', () => {
+    const set1 = makeSet('s1', ['a']);
+    const set2 = makeSet('s2', ['b']);
+    const frozen1 = JSON.parse(JSON.stringify(set1));
+    const frozen2 = JSON.parse(JSON.stringify(set2));
+    buildPdfSets({
+      mode: 'track',
+      layoutMode: 'landscape',
+      isPrecision: true,
+      set1,
+      set2,
+      generateLabel: letterLabel,
+    });
+    expect(set1).toEqual(frozen1);
+    expect(set2).toEqual(frozen2);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/parseDiscipline.test.ts
+++ b/frontend/photo-helper/src/__tests__/parseDiscipline.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseDiscipline } from '../utils/parseDiscipline';
+
+// parseDiscipline is load-bearing: `isPrecision` flips PDF set2 drop,
+// 9-photo cap, layout auto-switch, and UI gating. A silent downgrade to
+// rally (e.g. launcher drift emitting `?Discipline=Precision`) defeats
+// every feedback-2026-04-18 fix. These tests pin the allowlist exactly.
+
+describe('parseDiscipline', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  // Valid values — exact allowlist
+  it('accepts ?discipline=precision', () => {
+    expect(parseDiscipline('?discipline=precision')).toBe('precision');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts ?discipline=rally', () => {
+    expect(parseDiscipline('?discipline=rally')).toBe('rally');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  // Absent / empty — silent fallback (not a misconfiguration, just web use)
+  it('returns rally for empty search string', () => {
+    expect(parseDiscipline('')).toBe('rally');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns rally when discipline param is absent', () => {
+    expect(parseDiscipline('?foo=bar')).toBe('rally');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns rally when discipline is an empty string', () => {
+    expect(parseDiscipline('?discipline=')).toBe('rally');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  // Invalid values — fallback + console.error (visible during QA)
+  it('returns rally for mixed-case precision (strict allowlist)', () => {
+    expect(parseDiscipline('?discipline=Precision')).toBe('rally');
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns rally for uppercase RALLY', () => {
+    expect(parseDiscipline('?discipline=RALLY')).toBe('rally');
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns rally for typo "presicion"', () => {
+    expect(parseDiscipline('?discipline=presicion')).toBe('rally');
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('returns rally for completely wrong value', () => {
+    expect(parseDiscipline('?discipline=rallycross')).toBe('rally');
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logs the invalid value so launcher drift is visible in devtools', () => {
+    parseDiscipline('?discipline=Precision');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Precision'),
+    );
+  });
+
+  // Multi-param / coexistence with other launcher params
+  it('extracts discipline when other params precede it', () => {
+    expect(parseDiscipline('?competitionId=abc&discipline=precision')).toBe('precision');
+  });
+
+  it('extracts discipline when other params follow it', () => {
+    expect(parseDiscipline('?discipline=rally&foo=bar')).toBe('rally');
+  });
+
+  // URL-encoded edge cases — strict equality means encoded whitespace still
+  // counts as an invalid value and surfaces a console error.
+  it('does NOT accept URL-encoded whitespace around valid value', () => {
+    expect(parseDiscipline('?discipline=%20precision')).toBe('rally');
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -22,6 +22,13 @@ interface PhotoGridApiProps {
   onPhotoMove?: (fromIndex: number, toIndex: number) => void; // For drag-and-drop reordering
   labelOffset?: number; // Offset for label sequence (e.g., set2 continues from where set1 left off)
   customLabels?: string[]; // Custom labels to use instead of generated ones (for turning point mode)
+  /**
+   * Override the photo cap from `layoutConfig.maxPhotosPerSet`. Used by precision
+   * track mode (feedback 2026-04-18): the layout auto-switches between 9 and 10
+   * slots based on actual photo count, but the cap needs to stay at 10 in both
+   * layouts so a 10th upload can still land and flip the layout to portrait.
+   */
+  maxPhotosOverride?: number;
 }
 
 interface GridSlot {
@@ -47,7 +54,8 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   onFilesDropped,
   onPhotoMove,
   labelOffset = 0,
-  customLabels
+  customLabels,
+  maxPhotosOverride,
 }) => {
   const { currentRatio, isTransitioning } = useAspectRatio();
   const { generateLabel } = useLabeling();
@@ -69,7 +77,8 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   
   // Import the layout mode hook
   const { layoutConfig } = useLayoutMode();
-  const maxFilesRemaining = Math.max(0, layoutConfig.maxPhotosPerSet - photoSet.photos.length);
+  const effectiveMaxPhotos = maxPhotosOverride ?? layoutConfig.maxPhotosPerSet;
+  const maxFilesRemaining = Math.max(0, effectiveMaxPhotos - photoSet.photos.length);
   
   // Create grid slots based on layout mode (9 for landscape, 10 for portrait)
   const gridSlots: GridSlot[] = Array.from({ length: layoutConfig.slots }, (_, index) => {

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -18,7 +18,18 @@ interface TurningPointLayoutProps {
   onPhotoRemove: (setKey: 'set1' | 'set2', photoId: string) => void;
   onPhotoMove: (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => void;
   totalPhotoCount: number;
+  /**
+   * Precision discipline only uses a single set of up to 9 photos
+   * (SP + TP1…TP7 + FP) — user feedback 2026-04-18. Rally keeps the
+   * existing two-set 18-photo flow.
+   */
+  isPrecision?: boolean;
 }
+
+// Precision turning-point mode caps at 9 photos per feedback 2026-04-18:
+// SP + up to 7 turning points + FP.
+const PRECISION_TURNING_MAX_PHOTOS = 9;
+const RALLY_TURNING_MAX_PHOTOS = 18;
 
 export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   set1,
@@ -30,15 +41,20 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   onPhotoUpdate,
   onPhotoRemove,
   onPhotoMove,
-  totalPhotoCount
+  totalPhotoCount,
+  isPrecision = false
 }) => {
   const { t } = useI18n();
   const { layoutMode } = useLayoutMode();
   const theme = useTheme();
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
-  // Calculate turning point labels based on actual photo counts
-  const turningPointLabels = generateTurningPointLabels(set1.photos.length, set2.photos.length, layoutMode);
+  // Calculate turning point labels based on actual photo counts. In precision
+  // mode set2 is hidden, so we pass 0 for its count — the label generator
+  // produces SP + TP1..TPn + FP from the (capped) total.
+  const effectiveSet2Count = isPrecision ? 0 : set2.photos.length;
+  const turningPointLabels = generateTurningPointLabels(set1.photos.length, effectiveSet2Count, layoutMode);
+  const initialDropMax = isPrecision ? PRECISION_TURNING_MAX_PHOTOS : RALLY_TURNING_MAX_PHOTOS;
 
   return (
     <Box>
@@ -53,7 +69,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
           <GridSizedDropZone
             onFilesDropped={(files) => onFilesDropped('set1', files)}
             setName={t('turningpoint.photos')}
-            maxPhotos={18}
+            maxPhotos={initialDropMax}
             loading={loading}
             error={error}
           />
@@ -100,6 +116,11 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
               />
             </Paper>
           );
+
+          // Precision: only ever render the first set (no second page).
+          if (isPrecision) {
+            return <Box>{Set1}</Box>;
+          }
 
           const shouldSideBySide = isLargeScreen && layoutMode === 'portrait';
           if (shouldSideBySide) {

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -141,7 +141,8 @@
     "photos": "fotografií",
     "slotsAvailable": "{{count}} {{slotText}} k dispozici",
     "slot": "místo",
-    "slots": "míst"
+    "slots": "míst",
+    "addTenthPhoto": "Přidat 10. fotku"
   },
   "photo": {
     "clickToEdit": "Klikněte pro úpravu",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -141,7 +141,8 @@
     "photos": "photos",
     "slotsAvailable": "{{count}} {{slotText}} available",
     "slot": "slot",
-    "slots": "slots"
+    "slots": "slots",
+    "addTenthPhoto": "Add 10th photo"
   },
   "photo": {
     "clickToEdit": "Click to Edit",

--- a/frontend/photo-helper/src/utils/buildPdfSets.ts
+++ b/frontend/photo-helper/src/utils/buildPdfSets.ts
@@ -1,0 +1,85 @@
+import { generateTurningPointLabels } from './imageProcessing';
+import type { ApiPhoto, ApiPhotoSet } from '../types/api';
+
+export type PdfSetsInput = {
+  mode: 'turningpoint' | 'track';
+  layoutMode: 'landscape' | 'portrait';
+  isPrecision: boolean;
+  set1: ApiPhotoSet;
+  set2: ApiPhotoSet;
+  /** Track-mode label generator (letters/digits with dot). */
+  generateLabel: (index: number, offset?: number) => string;
+};
+
+export type LabeledPhoto = ApiPhoto & { label: string };
+export type LabeledSet = ApiPhotoSet & { photos: LabeledPhoto[] };
+
+export type PdfSetsOutput = {
+  set1WithLabels: LabeledSet;
+  set2WithLabels: LabeledSet;
+};
+
+/**
+ * Build the labeled `{set1WithLabels, set2WithLabels}` pair that
+ * `generatePDF` consumes.
+ *
+ * Precision mode drops set2 from the output (and from turningpoint
+ * label generation) so a stale set2 — e.g. user switched discipline
+ * mid-session — does not leak into the printed PDF. This is the core
+ * competition-artefact correctness guarantee from feedback 2026-04-18.
+ *
+ * Pure function, no React / session hook dependencies — tests can
+ * drive the full behavior matrix directly.
+ */
+export function buildPdfSets(input: PdfSetsInput): PdfSetsOutput {
+  const { mode, layoutMode, isPrecision, set1, set2, generateLabel } = input;
+
+  if (mode === 'turningpoint') {
+    const set1Count = set1.photos.length;
+    const set2Count = isPrecision ? 0 : set2.photos.length;
+    const turningPointLabels = generateTurningPointLabels(set1Count, set2Count, layoutMode);
+
+    const set1WithLabels: LabeledSet = {
+      ...set1,
+      photos: set1.photos.map((photo, index) => ({
+        ...photo,
+        label: turningPointLabels.set1[index] || 'X',
+      })),
+    };
+
+    const set2WithLabels: LabeledSet = isPrecision
+      ? { ...set2, photos: [] }
+      : {
+          ...set2,
+          photos: set2.photos.map((photo, index) => ({
+            ...photo,
+            label: turningPointLabels.set2[index] || 'X',
+          })),
+        };
+
+    return { set1WithLabels, set2WithLabels };
+  }
+
+  // Track mode — letter/digit labels continue across sets in rally,
+  // and set2 is dropped for precision.
+  const set1WithLabels: LabeledSet = {
+    ...set1,
+    photos: set1.photos.map((photo, index) => ({
+      ...photo,
+      label: generateLabel(index),
+    })),
+  };
+
+  const set1Count = set1.photos.length;
+  const set2WithLabels: LabeledSet = isPrecision
+    ? { ...set2, photos: [] }
+    : {
+        ...set2,
+        photos: set2.photos.map((photo, index) => ({
+          ...photo,
+          label: generateLabel(index, set1Count),
+        })),
+      };
+
+  return { set1WithLabels, set2WithLabels };
+}

--- a/frontend/photo-helper/src/utils/parseDiscipline.ts
+++ b/frontend/photo-helper/src/utils/parseDiscipline.ts
@@ -1,0 +1,25 @@
+export type Discipline = 'precision' | 'rally';
+
+/**
+ * Parse the `?discipline=` URL parameter emitted by the desktop launcher
+ * (see `desktop/main.js`). Accepts only the two exact values; anything
+ * else (absent, empty, typo, wrong case) falls back to `rally` — that
+ * is the safe default for web / legacy sessions that never saw the
+ * launcher.
+ *
+ * Invalid non-empty values are logged via `console.error` so a launcher
+ * drift (e.g. `?Discipline=Precision`) surfaces during QA instead of
+ * silently downgrading precision mode to rally.
+ *
+ * Exposed as a pure function so the browser consumer and tests share
+ * the same allowlist.
+ */
+export function parseDiscipline(search: string): Discipline {
+  const params = new URLSearchParams(search);
+  const d = params.get('discipline');
+  if (d === 'precision' || d === 'rally') return d;
+  if (d !== null && d !== '') {
+    console.error(`[parseDiscipline] Invalid ?discipline="${d}"; defaulting to rally.`);
+  }
+  return 'rally';
+}


### PR DESCRIPTION
## Summary

Round of feedback fixes from 2026-04-18 user testing, covering both sub-apps.

**Map Corridors**
- Rally: restore *"1 NM po SP"* checkbox (default stays 5 NM; persisted on `session.use1NmAfterSp`).
- Print: drop corridor-gate crosslines (cluttered paper); shrink yellow photo-marker dot (18 → 10 px radius); add matching yellow dot behind ground markers; move ground-marker SVG into a white pill offset upper-right of the dot (screen parity) and shrink icon 72 → 40 px so it matches photo-marker visual weight.
- KML export: drop `"- photo"` suffix on photo markers; emit empty `<name>` for ground markers (keep `markerType` in ExtendedData); embed per-type rasterized PNG `IconStyle` with white-stroke icons so Google Earth shows the same shapes as app + print.
- Fix stale-closure bug in `handleExportKML` that dropped ground markers in precision-only workflows.

**Photo Helper — precision discipline**
- Read `?discipline` URL param and render a single set in precision (set2 hidden).
- Turning-point: cap at 9 photos with SP + TP1..TP7 + FP; forces landscape 3×3.
- Track: auto-switch layout by photo count (9 → landscape 3×3, 10 → portrait 2×5) so a 9-photo page isn't padded with an empty tile.
- "Add 10th photo" drop zone under the 9-slot grid lets users reach 10 photos without clearing the grid; new `maxPhotosOverride` prop lifts the cap in precision+track.
- PDF export drops stale `set2` photos in precision.

## Test plan
- [x] \`pnpm --filter @airq/map-corridors vitest run\` — 72/72 pass
- [x] \`pnpm --filter @airq/photo-helper vitest run\` — 32/32 pass
- [x] \`pnpm tsc --noEmit\` clean in both packages
- [ ] Manually verify in Electron:
  - [ ] Rally: "1 NM" checkbox toggles corridor start between 5 NM and 1 NM after SP
  - [ ] Print A4: no gate crosslines, photo dot + label pill smaller, ground marker pill sits right of the dot and matches photo-marker size
  - [ ] KML in Google Earth: photo names show label only, ground markers render as white shapes with no text labels
  - [ ] Precision + turning: single set of 9 slots, labels SP + TP1–TP7 + FP
  - [ ] Precision + track, 9 photos: 3×3 grid + "Add 10th photo" drop zone visible; dropping a 10th flips the layout to 2×5

🤖 Generated with [Claude Code](https://claude.com/claude-code)