### PR TITLE
feat(map-corridors): multi-provider map style selector + prominent city labels #minor

### DIFF
--- a/.claude/skills/windows-app/SKILL.md
+++ b/.claude/skills/windows-app/SKILL.md
@@ -47,6 +47,48 @@ npx electron-builder --win -c.electronVersion=$ELECTRON_VERSION          # porta
 
 Output: `frontend/desktop/dist/win-unpacked/AirQ Competition Helpers.exe`
 
+### Known Issue: stale bundles after rebuild (dev mode)
+
+When you rebuild a sub-app and re-launch Electron (or navigate between sub-apps
+via the launcher), the window can keep running the **previous** JS bundle — the
+console will show an `index-<old-hash>.js` in stack traces that doesn't match
+what's currently in `dist/`. Symptom: the fix you just made doesn't appear and
+reloading doesn't help.
+
+This happens because two separate caches are independent of `dist/`:
+1. **Electron HTTP cache** for the `app://` protocol — fetched HTML + JS can be
+   reused across window loads.
+2. **V8 code cache** — Electron stores parsed bytecode for the previous bundle
+   on disk and serves it when the same URL loads, even after the source file
+   on disk has changed.
+
+`session.defaultSession.clearCache()` only covers (1). You also need:
+- `webPreferences.v8CacheOptions = 'none'` in dev so V8 never caches bytecode.
+- `mainWindow.webContents.session.clearCache()` **before every `loadURL`** in
+  dev — the startup-time clear doesn't help once the window has navigated.
+
+Both are wired up in `main.js` (`createWindow` + `navigate-to-app` handler).
+If you add a new `loadURL` call, mirror the `isDev` clearCache guard. If a
+rebuild appears to do nothing, kill every `electron.exe` (`taskkill /IM
+electron.exe /F`) before re-running `pnpm dev`.
+
+### Known Issue: "An API access token is required to use Mapbox GL"
+
+This error fires from `setStyle(mapbox://…)` inside `_makeAPIURL`, which reads
+the **module-level singleton** `mapboxgl.accessToken`. react-map-gl mirrors the
+`mapboxAccessToken` prop into that singleton, but the assignment lags one
+microtask behind `mapStyle` prop updates — so if a token and a style change
+commit in the same React batch, `setStyle` can run before the new token is
+visible and throw.
+
+**Fix** (already applied in `config/mapProviders.ts`): inside
+`setProviderToken('mapbox', …)`, synchronously write
+`mapboxgl.accessToken = value || ''`. This is the same singleton Mapbox GL
+reads during `setStyle`, so any `mapbox://` URL returned by `getStyleForId`
+is guaranteed to have the matching token in place. **Do not rely on the
+react-map-gl prop alone** when you're the one deciding which style URL to
+hand it.
+
 ### Known Issue: winCodeSign symlink error
 
 On Windows without Developer Mode, the portable .exe build fails with "Cannot create symbolic link" during winCodeSign extraction. This happens because the winCodeSign archive contains macOS symlinks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,96 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.5.0] - 2026-04-18
+
+### Added
+- **Map Corridors:** Multi-provider map style selector replacing the old
+  Streets/Satellite toggle. Users can now pick between **Mapy.com**, **Mapbox
+  Streets**, and **OpenStreetMap (CARTO Voyager)** for street maps, and
+  **Mapbox Satellite**, **Mapy.com Aerial**, and **ESRI Satellite** for
+  aerial imagery. Each category shows a dropdown when more than one provider
+  is configured. Mapy.com is the default street layer because its
+  village-level Czech labels are denser than Mapbox defaults. (PR #42)
+- **Map Corridors:** Prominent city labels on printed A4 — settlement /
+  place / town / city symbol layers on vector styles get `text-size` boosted
+  1.8× with a 2 px white halo so small towns remain legible at print scale.
+  Raster styles (Mapy.cz, OSM, ESRI) bake labels into their tiles and read
+  well as-is. (PR #42, feedback 2026-04-18)
+- **Desktop launcher:** New **Settings → Mapy.cz API klíč…** menu entry that
+  mirrors the existing Mapbox Token dialog. Enables Czech-focused street /
+  aerial maps. Token persists in the Electron user config. (PR #42)
+- **Monorepo env:** Root `.env` at the repo root is now read by both
+  map-corridors and photo-helper sub-apps (`envDir: <repo-root>`), so
+  `VITE_MAPBOX_TOKEN` / `VITE_MAPYCZ_TOKEN` can be configured once.
+
+### Fixed
+- **Map Corridors:** Mapbox GL race fix — `setStyle('mapbox://…')` could
+  throw "An API access token is required" when both the style URL and the
+  token arrived in the same React commit, because react-map-gl's mirror of
+  `mapboxgl.accessToken` lags one microtask behind its `mapStyle` prop.
+  `setProviderToken('mapbox', …)` now writes the Mapbox GL module singleton
+  synchronously, closing the race.
+- **Map Corridors:** `import.meta.env.VITE_*` reads were cast through
+  `(import.meta as any)?.env?.VITE_…` which defeated Vite's static-replace
+  regex, leaving literal `"VITE_MAPY_TOKEN"` string lookups in the bundle.
+  Symptom: Mapy.com never appeared in the selector regardless of `.env`
+  content. Reads are now in the direct dot-form Vite recognises.
+- **Desktop launcher:** Stale-bundle episodes after a rebuild traced back to
+  V8's code cache (separate from Electron's HTTP cache). `clearCache()` only
+  flushes (1). Fixed with `webPreferences.v8CacheOptions: 'none'` in dev
+  plus a per-`loadURL` `session.clearCache()` call on navigation — documented
+  in `.claude/skills/windows-app/SKILL.md` under a new "Known Issue"
+  section. Production builds are unaffected.
+- **Map Corridors:** Session migration from legacy
+  `baseStyle: 'streets' | 'satellite'` to the new `mapStyleId` field no
+  longer silently discards corrupted values. Malformed records now log a
+  warning and fall back to a default instead of pretending to succeed.
+  The migration logic was extracted to a pure helper with unit tests so
+  this code path — which touches every upgrading user's persisted state —
+  is pinned against regressions.
+
+### Security
+- **Desktop launcher:** Both token-input dialogs (Mapbox + Mapy.cz) hardened:
+  - HTML-attribute escaping now covers `& < > " '` instead of only `"`.
+  - Each dialog's inline HTML now carries a strict `Content-Security-Policy`
+    meta tag with a crypto-random per-dialog nonce, so inline scripts can
+    only run from the template we shipped.
+  - Inline `onclick=` handlers replaced with `addEventListener` bindings that
+    the CSP explicitly permits, removing the most common XSS foothold.
+- **Map Corridors:** Mapy.cz API key is now `encodeURIComponent`-wrapped in
+  tile URLs so a key containing `&`, `#`, or whitespace cannot inject extra
+  query parameters or corrupt the URL. Defense-in-depth against tampered
+  config values.
+- **Map Corridors:** Production bundles no longer log token prefixes — the
+  four-char debug preview is now guarded by `import.meta.env.DEV`.
+
+### Changed
+- **Map Corridors:** `CorridorsSession.baseStyle` field renamed to
+  `mapStyleId` (string). One-way migration reads either field from legacy
+  sessions on load; `baseStyle` is no longer written to new sessions.
+  Readers of the session type should use `mapStyleId` via `getStyleForId()`
+  from `config/mapProviders`.
+- **Map Corridors:** Error handling audit from the PR code review — fire-
+  and-forget OPFS writes, swallowed IPC errors, and bare `.catch(() => …)`
+  token-fallback branches now log on failure so broken persistence no
+  longer looks like a silent success in the console.
+
+### Tests
+- **Map Corridors:** Test count 99 → 132 (+33 cases, 3 new files):
+  - `mapProviders.test.ts` extended — token-clearing paths, subscribe/notify
+    leak check, monotonic snapshot, `isMapStyleId` / `normalizeStyleId`,
+    Mapbox-URL-never-embeds-token invariant, URL-encoded Mapy API key,
+    `MAP_STYLE_IDS` drift guard.
+  - `sessionMigration.test.ts` — migration precedence (new schema > legacy
+    baseStyle > default), malformed records, empty-string and non-string
+    mapStyleId handling.
+  - `boostSettlementLabels.test.ts` — layer matching, expression wrapping,
+    undefined-text-size skip, partial-mutation fix (halo applied even when
+    text-size write throws).
+- `pnpm audit` still reports **zero vulnerabilities** across the workspace
+  (trivy `pnpm-lock.yaml` scan confirms 0 in shipped deps). Semgrep baseline
+  scan against `main`: 0 findings on changed files.
+
 ## [2.4.1] - 2026-04-16
 
 ### Security

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1,7 +1,29 @@
 const { app, BrowserWindow, protocol, ipcMain, shell, globalShortcut, Menu, dialog, net } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 const { pathToFileURL } = require('url');
+
+// HTML-attribute escape for values interpolated into `value="…"`. The previous
+// `.replace(/"/g, '&quot;')` inline in the token dialogs defended only the
+// attribute terminator; other chars (`<`, `>`, `&`, `'`) could still distort
+// the surrounding markup if the template ever changes. Escaping all five is
+// defense-in-depth — see PR #42 review.
+function escapeHtmlAttr(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+// Per-dialog CSP nonce. Modal dialogs are loaded via `data:` URLs which inherit
+// none of the `app://` protocol's CSP, so we inline a restrictive policy with
+// a nonce that permits only the single inline script shipped in the template.
+function newCspNonce() {
+  return crypto.randomBytes(16).toString('base64');
+}
 
 // Config file path in user data directory
 function getConfigPath() {
@@ -216,7 +238,14 @@ ipcMain.handle('navigate-to-app', async (event, appName, competitionId) => {
   // navigating window a stale index.html whose <script src> points at a
   // bundle hash we've since replaced in `dist/`.
   if (isDev && mainWindow) {
-    try { await mainWindow.webContents.session.clearCache(); } catch {}
+    try {
+      await mainWindow.webContents.session.clearCache();
+    } catch (err) {
+      // Don't block navigation on cache-flush failures, but do surface them —
+      // a silent failure here reintroduces the stale-bundle bug documented in
+      // `.claude/skills/windows-app/SKILL.md`.
+      console.warn('[navigate-to-app] session.clearCache() failed; bundle may be stale:', err);
+    }
   }
   if (appName === 'photo-helper') {
     mainWindow.loadURL(`app://photo-helper/index.html${qs}`);
@@ -691,6 +720,7 @@ ipcMain.handle('save-map-image', async (event, base64Data) => {
 // Show Mapbox token dialog - single window with input field
 async function showMapboxTokenDialog() {
   const currentToken = getConfigValue('mapboxToken') || '';
+  const nonce = newCspNonce();
 
   const inputWindow = new BrowserWindow({
     width: 520,
@@ -712,12 +742,13 @@ async function showMapboxTokenDialog() {
     <html>
     <head>
       <meta charset="UTF-8">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; connect-src 'none'; img-src 'none';">
       <style>
         * { box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 24px; background: #ffffff; margin: 0; }
         h3 { margin: 0 0 8px; font-size: 18px; font-weight: 600; color: #1a1a1a; }
         .hint { font-size: 13px; color: #666; margin-bottom: 16px; }
-        .hint a { color: #1976D2; text-decoration: none; }
+        .hint a { color: #1976D2; text-decoration: none; cursor: pointer; }
         .hint a:hover { text-decoration: underline; }
         input { width: 100%; padding: 10px 12px; font-size: 14px; border: 1px solid #d0d0d0; border-radius: 6px; outline: none; }
         input:focus { border-color: #1976D2; box-shadow: 0 0 0 2px rgba(25,118,210,0.15); }
@@ -730,28 +761,42 @@ async function showMapboxTokenDialog() {
     </head>
     <body>
       <h3>Mapbox Access Token</h3>
-      <div class="hint">Required for satellite imagery. Get a free token at <a href="#" onclick="openMapbox()">mapbox.com</a></div>
-      <input type="text" id="token" placeholder="pk.eyJ1Ijo..." value="${currentToken.replace(/"/g, '&quot;')}">
+      <div class="hint">Required for satellite imagery. Get a free token at <a id="link-mapbox">mapbox.com</a></div>
+      <input type="text" id="token" placeholder="pk.eyJ1Ijo..." value="${escapeHtmlAttr(currentToken)}">
       <div class="buttons">
-        <button onclick="window.close()">Cancel</button>
-        <button class="primary" onclick="save()">Save</button>
+        <button id="btn-cancel">Cancel</button>
+        <button class="primary" id="btn-save">Save</button>
       </div>
-      <script>
-        function openMapbox() {
-          window.electronAPI?.openExternal?.('https://mapbox.com');
-        }
+      <script nonce="${nonce}">
+        var input = document.getElementById('token');
         function save() {
-          const token = document.getElementById('token').value.trim();
-          window.electronAPI?.setConfig?.('mapboxToken', token)
-            .then(() => window.close())
-            .catch(() => alert('Failed to save token'));
+          var api = window.electronAPI;
+          if (!api || typeof api.setConfig !== 'function') {
+            console.error('[mapbox-dialog] window.electronAPI.setConfig is unavailable');
+            alert('Preload bridge unavailable. Please restart the app.');
+            return;
+          }
+          var token = input.value.trim();
+          api.setConfig('mapboxToken', token)
+            .then(function () { window.close(); })
+            .catch(function (err) {
+              console.error('[mapbox-dialog] setConfig failed:', err);
+              alert('Failed to save token: ' + ((err && err.message) || err));
+            });
         }
-        document.getElementById('token').addEventListener('keydown', (e) => {
+        document.getElementById('btn-save').addEventListener('click', save);
+        document.getElementById('btn-cancel').addEventListener('click', function () { window.close(); });
+        document.getElementById('link-mapbox').addEventListener('click', function () {
+          if (window.electronAPI && typeof window.electronAPI.openExternal === 'function') {
+            window.electronAPI.openExternal('https://mapbox.com');
+          }
+        });
+        input.addEventListener('keydown', function (e) {
           if (e.key === 'Enter') save();
           if (e.key === 'Escape') window.close();
         });
-        document.getElementById('token').focus();
-        document.getElementById('token').select();
+        input.focus();
+        input.select();
       </script>
     </body>
     </html>
@@ -767,6 +812,7 @@ async function showMapboxTokenDialog() {
 // `MapStyleSelector` can offer Mapy.com styles.
 async function showMapyTokenDialog() {
   const currentToken = getConfigValue('mapyToken') || '';
+  const nonce = newCspNonce();
 
   const inputWindow = new BrowserWindow({
     width: 520,
@@ -788,12 +834,13 @@ async function showMapyTokenDialog() {
     <html>
     <head>
       <meta charset="UTF-8">
+      <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; connect-src 'none'; img-src 'none';">
       <style>
         * { box-sizing: border-box; }
         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 24px; background: #ffffff; margin: 0; }
         h3 { margin: 0 0 8px; font-size: 18px; font-weight: 600; color: #1a1a1a; }
         .hint { font-size: 13px; color: #666; margin-bottom: 16px; line-height: 1.5; }
-        .hint a { color: #1976D2; text-decoration: none; }
+        .hint a { color: #1976D2; text-decoration: none; cursor: pointer; }
         .hint a:hover { text-decoration: underline; }
         input { width: 100%; padding: 10px 12px; font-size: 14px; border: 1px solid #d0d0d0; border-radius: 6px; outline: none; }
         input:focus { border-color: #1976D2; box-shadow: 0 0 0 2px rgba(25,118,210,0.15); }
@@ -806,28 +853,42 @@ async function showMapyTokenDialog() {
     </head>
     <body>
       <h3>Mapy.cz API Key</h3>
-      <div class="hint">Enables Czech street/aerial maps (dense village-level labels). Register a free key at <a href="#" onclick="openMapy()">developer.mapy.com</a>.</div>
-      <input type="text" id="token" placeholder="your-mapy-api-key" value="${currentToken.replace(/"/g, '&quot;')}">
+      <div class="hint">Enables Czech street/aerial maps (dense village-level labels). Register a free key at <a id="link-mapy">developer.mapy.com</a>.</div>
+      <input type="text" id="token" placeholder="your-mapy-api-key" value="${escapeHtmlAttr(currentToken)}">
       <div class="buttons">
-        <button onclick="window.close()">Cancel</button>
-        <button class="primary" onclick="save()">Save</button>
+        <button id="btn-cancel">Cancel</button>
+        <button class="primary" id="btn-save">Save</button>
       </div>
-      <script>
-        function openMapy() {
-          window.electronAPI?.openExternal?.('https://developer.mapy.com/en/rest-api-mapy-com/');
-        }
+      <script nonce="${nonce}">
+        var input = document.getElementById('token');
         function save() {
-          const token = document.getElementById('token').value.trim();
-          window.electronAPI?.setConfig?.('mapyToken', token)
-            .then(() => window.close())
-            .catch(() => alert('Failed to save token'));
+          var api = window.electronAPI;
+          if (!api || typeof api.setConfig !== 'function') {
+            console.error('[mapy-dialog] window.electronAPI.setConfig is unavailable');
+            alert('Preload bridge unavailable. Please restart the app.');
+            return;
+          }
+          var token = input.value.trim();
+          api.setConfig('mapyToken', token)
+            .then(function () { window.close(); })
+            .catch(function (err) {
+              console.error('[mapy-dialog] setConfig failed:', err);
+              alert('Failed to save token: ' + ((err && err.message) || err));
+            });
         }
-        document.getElementById('token').addEventListener('keydown', (e) => {
+        document.getElementById('btn-save').addEventListener('click', save);
+        document.getElementById('btn-cancel').addEventListener('click', function () { window.close(); });
+        document.getElementById('link-mapy').addEventListener('click', function () {
+          if (window.electronAPI && typeof window.electronAPI.openExternal === 'function') {
+            window.electronAPI.openExternal('https://developer.mapy.com/en/rest-api-mapy-com/');
+          }
+        });
+        input.addEventListener('keydown', function (e) {
           if (e.key === 'Enter') save();
           if (e.key === 'Escape') window.close();
         });
-        document.getElementById('token').focus();
-        document.getElementById('token').select();
+        input.focus();
+        input.select();
       </script>
     </body>
     </html>

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -165,7 +165,13 @@ function createWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       preload: path.join(__dirname, 'preload.js'),
-      webSecurity: true
+      webSecurity: true,
+      // Disable V8 bytecode cache in dev so the window always runs the
+      // freshly-built bundle. Without this, Electron keeps a compiled copy
+      // of the previous bundle on disk and serves it when the HTML loads,
+      // which silently eats every hot rebuild. `clearCache()` only touches
+      // the HTTP cache — V8's code cache is separate and not covered.
+      ...(isDev ? { v8CacheOptions: 'none' } : {})
     },
     icon: path.join(__dirname, 'icons', 'icon.png'),
     title: 'AirQ Competition Helpers',
@@ -196,7 +202,7 @@ function createWindow() {
 }
 
 // Handle navigation between apps
-ipcMain.handle('navigate-to-app', (event, appName, competitionId) => {
+ipcMain.handle('navigate-to-app', async (event, appName, competitionId) => {
   let qs = competitionId ? `?competitionId=${encodeURIComponent(competitionId)}` : '';
   if (competitionId) {
     const index = readCompetitionsIndex();
@@ -204,6 +210,13 @@ ipcMain.handle('navigate-to-app', (event, appName, competitionId) => {
     if (comp && comp.discipline) {
       qs += `&discipline=${encodeURIComponent(comp.discipline)}`;
     }
+  }
+  // Flush cache on every navigation in dev so rebuilt sub-app bundles
+  // replace the old ones. Electron's HTTP cache can otherwise hand the
+  // navigating window a stale index.html whose <script src> points at a
+  // bundle hash we've since replaced in `dist/`.
+  if (isDev && mainWindow) {
+    try { await mainWindow.webContents.session.clearCache(); } catch {}
   }
   if (appName === 'photo-helper') {
     mainWindow.loadURL(`app://photo-helper/index.html${qs}`);
@@ -238,6 +251,11 @@ ipcMain.handle('open-external', (event, url) => {
 // Open Mapbox token settings dialog
 ipcMain.handle('open-mapbox-settings', () => {
   showMapboxTokenDialog();
+});
+
+// Open Mapy.cz token settings dialog (Czech maps provider)
+ipcMain.handle('open-mapy-settings', () => {
+  showMapyTokenDialog();
 });
 
 // Update menu language
@@ -743,6 +761,82 @@ async function showMapboxTokenDialog() {
   inputWindow.setMenu(null);
 }
 
+// Show Mapy.cz API key dialog. Mirrors the Mapbox dialog: single-input window
+// that writes to `mapyToken` in the Electron config. The renderer reads that
+// key on startup and calls `setProviderToken('mapy', ...)` so the
+// `MapStyleSelector` can offer Mapy.com styles.
+async function showMapyTokenDialog() {
+  const currentToken = getConfigValue('mapyToken') || '';
+
+  const inputWindow = new BrowserWindow({
+    width: 520,
+    height: 300,
+    parent: mainWindow,
+    modal: true,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="UTF-8">
+      <style>
+        * { box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 24px; background: #ffffff; margin: 0; }
+        h3 { margin: 0 0 8px; font-size: 18px; font-weight: 600; color: #1a1a1a; }
+        .hint { font-size: 13px; color: #666; margin-bottom: 16px; line-height: 1.5; }
+        .hint a { color: #1976D2; text-decoration: none; }
+        .hint a:hover { text-decoration: underline; }
+        input { width: 100%; padding: 10px 12px; font-size: 14px; border: 1px solid #d0d0d0; border-radius: 6px; outline: none; }
+        input:focus { border-color: #1976D2; box-shadow: 0 0 0 2px rgba(25,118,210,0.15); }
+        .buttons { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
+        button { padding: 9px 18px; font-size: 14px; cursor: pointer; border-radius: 6px; border: 1px solid #d0d0d0; background: #fff; color: #333; }
+        button:hover { background: #f5f5f5; }
+        button.primary { background: #1976D2; color: white; border: none; }
+        button.primary:hover { background: #1565C0; }
+      </style>
+    </head>
+    <body>
+      <h3>Mapy.cz API Key</h3>
+      <div class="hint">Enables Czech street/aerial maps (dense village-level labels). Register a free key at <a href="#" onclick="openMapy()">developer.mapy.com</a>.</div>
+      <input type="text" id="token" placeholder="your-mapy-api-key" value="${currentToken.replace(/"/g, '&quot;')}">
+      <div class="buttons">
+        <button onclick="window.close()">Cancel</button>
+        <button class="primary" onclick="save()">Save</button>
+      </div>
+      <script>
+        function openMapy() {
+          window.electronAPI?.openExternal?.('https://developer.mapy.com/en/rest-api-mapy-com/');
+        }
+        function save() {
+          const token = document.getElementById('token').value.trim();
+          window.electronAPI?.setConfig?.('mapyToken', token)
+            .then(() => window.close())
+            .catch(() => alert('Failed to save token'));
+        }
+        document.getElementById('token').addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') save();
+          if (e.key === 'Escape') window.close();
+        });
+        document.getElementById('token').focus();
+        document.getElementById('token').select();
+      </script>
+    </body>
+    </html>
+  `;
+
+  inputWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
+  inputWindow.setMenu(null);
+}
+
 // Menu translations
 const menuTranslations = {
   en: {
@@ -761,6 +855,7 @@ const menuTranslations = {
     resetZoom: 'Reset Zoom',
     settings: 'Settings',
     mapboxToken: 'Mapbox Token...',
+    mapyToken: 'Mapy.cz API Key...',
     help: 'Help',
     about: 'About',
     aboutDetail: 'Desktop application for FAI Rally Flying competitions.'
@@ -781,6 +876,7 @@ const menuTranslations = {
     resetZoom: 'Obnovit zvětšení',
     settings: 'Nastavení',
     mapboxToken: 'Mapbox Token...',
+    mapyToken: 'Mapy.cz API klíč...',
     help: 'Nápověda',
     about: 'O aplikaci',
     aboutDetail: 'Desktopová aplikace pro soutěže FAI Rally Flying.'
@@ -930,6 +1026,10 @@ function createMenu(locale = 'cs') {
         {
           label: t.mapboxToken,
           click: () => showMapboxTokenDialog()
+        },
+        {
+          label: t.mapyToken,
+          click: () => showMapyTokenDialog()
         }
       ]
     },

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -19,6 +19,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Open Mapbox token settings dialog
   openMapboxSettings: () => ipcRenderer.invoke('open-mapbox-settings'),
 
+  // Open Mapy.cz API-key settings dialog (Czech maps provider — feedback 2026-04-18)
+  openMapySettings: () => ipcRenderer.invoke('open-mapy-settings'),
+
   // Update menu language
   setMenuLocale: (locale) => ipcRenderer.invoke('set-menu-locale', locale),
 

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -81,22 +81,26 @@ function App() {
     // runtime. Keep this direct.
     const envMapbox = import.meta.env.VITE_MAPBOX_TOKEN || null
     const envMapy = import.meta.env.VITE_MAPYCZ_TOKEN || null
-    try {
+    // Dev-only diagnostic: did Vite actually inline the env vars? (Log-free
+    // in production to avoid leaking even 4-char token prefixes to DevTools.)
+    if (import.meta.env.DEV) {
       const mask = (v: unknown) => typeof v === 'string' && v.length > 4 ? `${v.slice(0, 4)}…(${v.length})` : (v ? 'set' : 'missing')
       const env = import.meta.env as Record<string, unknown>
       const detected = Object.keys(env).filter(k => k.startsWith('VITE_MAP'))
       console.info('[map tokens] VITE_MAPBOX_TOKEN:', mask(envMapbox), 'VITE_MAPYCZ_TOKEN:', mask(envMapy), 'detected keys:', detected)
-    } catch {}
+    }
     const electronAPI = window.electronAPI
     if (electronAPI?.getConfig) {
       electronAPI.getConfig('mapboxToken').then((token: string | undefined) => {
         setProviderToken('mapbox', token || envMapbox)
-      }).catch(() => {
+      }).catch((err: unknown) => {
+        console.warn('[map tokens] getConfig("mapboxToken") failed, falling back to env:', err)
         setProviderToken('mapbox', envMapbox)
       })
       electronAPI.getConfig('mapyToken').then((token: string | undefined) => {
         setProviderToken('mapy', token || envMapy)
-      }).catch(() => {
+      }).catch((err: unknown) => {
+        console.warn('[map tokens] getConfig("mapyToken") failed, falling back to env:', err)
         setProviderToken('mapy', envMapy)
       })
     } else {
@@ -120,7 +124,12 @@ function App() {
   // resolved id is passed through `getStyleForId` to obtain either a
   // `mapbox://` URL or an inline raster style spec for MapProviderView.
   const persistMapStyleId = useCallback((id: MapStyleId) => {
-    void setMapStyleId(id)
+    // OPFS writes can fail (quota, invalidated handle, backend down). Without
+    // a `.catch`, the rejection becomes an unhandledrejection and the user
+    // sees the new style for one render but it silently reverts on reload.
+    setMapStyleId(id).catch((err: unknown) => {
+      console.error('[session] Failed to persist mapStyleId — selection will not survive reload:', err)
+    })
   }, [setMapStyleId])
   const [mapStyleId, selectMapStyleId, availableStyles] = useMapStyle({
     preferredId: session?.mapStyleId,

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -1,22 +1,30 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import './App.css'
 
 import { MapProviderView } from './map/MapProviderView'
 import type { MapProviderViewHandle } from './map/MapProviderView'
-import type { MapProviderId } from './map/providers'
-import { mapProviders } from './map/providers'
 // DropZone removed; map area acts as drop target
 import type { GeoJSON } from 'geojson'
 // import { buildBufferedCorridor } from './corridors/bufferCorridor'
 import { buildPreciseCorridorsAndGates, DISCIPLINE_CONFIGS } from './corridors/preciseCorridor'
 import type { Discipline } from './corridors/preciseCorridor'
 
-import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, ToggleButton, ToggleButtonGroup, IconButton, Tooltip, Alert } from '@mui/material'
+import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Tooltip, Alert } from '@mui/material'
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { parseDisciplineFromSearch } from './utils/parseDiscipline'
+import { MapStyleSelector } from './components/MapStyleSelector'
+import { useMapStyle } from './hooks/useMapStyle'
+import {
+  getStyleForId,
+  setProviderToken,
+  subscribeToProvider,
+  getProviderSnapshot,
+  getMapboxAccessToken,
+  type MapStyleId,
+} from './config/mapProviders'
 import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
 import { calculateDistance } from './corridors/segments'
 import { useI18n } from './contexts/I18nContext'
@@ -30,8 +38,11 @@ function App() {
   useEffect(() => {
     try { document.title = t('app.title') } catch {}
   }, [t])
-  const [provider] = useState<MapProviderId>('mapbox')
-  const [electronMapboxToken, setElectronMapboxToken] = useState<string | null>(null)
+  // Both provider tokens live in the shared `mapProviders.ts` module. We
+  // don't mirror them into React state because the style resolver and the
+  // `<MapProviderView>` token prop both read from that module directly —
+  // keeping React state would introduce an extra render where `mapStyle`
+  // and `mapboxAccessToken` could diverge.
 
   // Read competition ID and discipline from URL (set by desktop launcher)
   const competitionId = useMemo(() => {
@@ -58,19 +69,45 @@ function App() {
     }
   }, [competitionId])
 
-  // Fetch Mapbox token from Electron config if running in desktop app
+  // Fetch Mapbox + Mapy.cz tokens from Electron config if running in desktop app,
+  // falling back to Vite env vars in the browser build. Tokens are pushed into
+  // the shared mapProviders module so the MapStyleSelector only offers styles
+  // the user can actually render.
   useEffect(() => {
+    // Vite replaces `import.meta.env.VITE_*` statically at build time — only
+    // when the access is plain dot-form. Optional chaining / `(… as any)`
+    // casts defeat that static analysis and leave literal `VITE_MAPY_TOKEN`
+    // string lookups in the bundle, which of course return undefined at
+    // runtime. Keep this direct.
+    const envMapbox = import.meta.env.VITE_MAPBOX_TOKEN || null
+    const envMapy = import.meta.env.VITE_MAPYCZ_TOKEN || null
+    try {
+      const mask = (v: unknown) => typeof v === 'string' && v.length > 4 ? `${v.slice(0, 4)}…(${v.length})` : (v ? 'set' : 'missing')
+      const env = import.meta.env as Record<string, unknown>
+      const detected = Object.keys(env).filter(k => k.startsWith('VITE_MAP'))
+      console.info('[map tokens] VITE_MAPBOX_TOKEN:', mask(envMapbox), 'VITE_MAPYCZ_TOKEN:', mask(envMapy), 'detected keys:', detected)
+    } catch {}
     const electronAPI = window.electronAPI
     if (electronAPI?.getConfig) {
       electronAPI.getConfig('mapboxToken').then((token: string | undefined) => {
-        if (token) setElectronMapboxToken(token)
-      }).catch(() => {})
+        setProviderToken('mapbox', token || envMapbox)
+      }).catch(() => {
+        setProviderToken('mapbox', envMapbox)
+      })
+      electronAPI.getConfig('mapyToken').then((token: string | undefined) => {
+        setProviderToken('mapy', token || envMapy)
+      }).catch(() => {
+        setProviderToken('mapy', envMapy)
+      })
+    } else {
+      setProviderToken('mapbox', envMapbox)
+      setProviderToken('mapy', envMapy)
     }
   }, [])
   const {
     session,
     backendAvailable,
-    setBaseStyle,
+    setMapStyleId,
     setMarkers: persistMarkers,
     setGroundMarkers: persistGroundMarkers,
     setUse1NmAfterSp,
@@ -78,7 +115,23 @@ function App() {
     saveOriginalKmlText,
     loadOriginalKmlText,
   } = useCorridorSessionOPFS(competitionId)
-  const baseStyle = (session?.baseStyle || 'streets') as 'streets' | 'satellite'
+  // Map-style selector — the hook resolves the user's persisted preference
+  // against the currently-available styles (tokens can arrive async). The
+  // resolved id is passed through `getStyleForId` to obtain either a
+  // `mapbox://` URL or an inline raster style spec for MapProviderView.
+  const persistMapStyleId = useCallback((id: MapStyleId) => {
+    void setMapStyleId(id)
+  }, [setMapStyleId])
+  const [mapStyleId, selectMapStyleId, availableStyles] = useMapStyle({
+    preferredId: session?.mapStyleId,
+    onChange: persistMapStyleId,
+  })
+  // Subscribe to token changes so `getStyleForId` is re-evaluated once an
+  // async-arriving Mapbox/Mapy key lands. Without this, the memo would stay
+  // on the first-render fallback style and handing a `mapbox://` URL to the
+  // map before the token propagates throws "API access token required".
+  const tokenVersion = useSyncExternalStore(subscribeToProvider, getProviderSnapshot, getProviderSnapshot)
+  const resolvedStyle = useMemo(() => getStyleForId(mapStyleId), [mapStyleId, tokenVersion])
   const [isDragOver, setIsDragOver] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const mapRef = useRef<MapProviderViewHandle | null>(null)
@@ -228,15 +281,6 @@ function App() {
     }
     return out
   }, [markers, corridorPolygons])
-
-  // Use Electron config token if available, otherwise fall back to env var
-  const providerConfig = useMemo(() => {
-    const config = { ...mapProviders[provider] }
-    if (electronMapboxToken && provider === 'mapbox') {
-      config.accessToken = electronMapboxToken
-    }
-    return config
-  }, [provider, electronMapboxToken])
 
   const onFiles = useCallback(async (files: File[]) => {
     const file = files[0]
@@ -591,10 +635,13 @@ function App() {
           )}
           <Button variant="outlined" size="small" draggable onDragStart={onDragStartMarker} startIcon={<Place sx={{ fontSize: 16 }} />} title={t('app.dragToPlace')}>{t('app.dragToPlace')}</Button>
           <Button variant="outlined" size="small" draggable onDragStart={onDragStartGroundMarker} startIcon={<Flag sx={{ fontSize: 16 }} />} title={t('app.dragToPlaceGround')}>{t('app.dragToPlaceGround')}</Button>
-          <ToggleButtonGroup value={baseStyle} exclusive onChange={(_, val) => { if (val) setBaseStyle(val) }} size="small">
-            <ToggleButton value="streets">{t('app.toggleBase.streets')}</ToggleButton>
-            <ToggleButton value="satellite">{t('app.toggleBase.satellite')}</ToggleButton>
-          </ToggleButtonGroup>
+          <MapStyleSelector
+            mapStyle={mapStyleId}
+            setMapStyle={selectMapStyleId}
+            availableStyles={availableStyles}
+            streetsLabel={t('app.toggleBase.streets')}
+            aerialLabel={t('app.toggleBase.satellite')}
+          />
           <Chip
             label={effectiveDiscipline === 'precision' ? t('app.discipline.precision') : t('app.discipline.rally')}
             size="small"
@@ -642,9 +689,12 @@ function App() {
           )}
           <MapProviderView
             ref={mapRef as any}
-            provider={provider}
-            baseStyle={baseStyle}
-            providerConfig={providerConfig}
+            mapStyle={resolvedStyle}
+            // Pull the Mapbox token from the same module-scoped store the
+            // style resolver reads, not from React state — otherwise the
+            // token prop can lag one render behind `resolvedStyle` when a
+            // `mapbox://` URL resolves in the same batch the token arrived.
+            mapboxAccessToken={getMapboxAccessToken()}
             geojsonOverlays={[
               session?.geojson ? { id: 'uploaded-geojson', data: session.geojson, type: 'line' as const, paint: { 'line-color': '#d32f2f', 'line-width': 3 } } : null,
               // Segmented corridor borders in green

--- a/frontend/map-corridors/src/__tests__/boostSettlementLabels.test.ts
+++ b/frontend/map-corridors/src/__tests__/boostSettlementLabels.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { boostSettlementLabels } from '../utils/mapCapture'
+
+/**
+ * Unit tests for the A4-print label-boost helper. The real helper runs against
+ * a Mapbox GL `Map`, but its API surface is tiny — we build a minimal mock so
+ * we can pin the silent-failure contract that the PR #42 review flagged.
+ */
+type MockLayer = { id: string; type: 'symbol' | 'raster' | 'line'; [k: string]: unknown }
+
+function makeMockMap(layers: MockLayer[], layoutValues: Record<string, unknown> = {}, opts: {
+  throwSetLayout?: (id: string) => boolean
+  throwSetPaint?: (id: string) => boolean
+} = {}) {
+  const setLayout = vi.fn((id: string, prop: string, value: unknown) => {
+    if (opts.throwSetLayout?.(id)) throw new Error(`setLayoutProperty(${id}, ${prop}) threw`)
+    // no-op otherwise
+    void value
+  })
+  const setPaint = vi.fn((id: string, prop: string, value: unknown) => {
+    if (opts.throwSetPaint?.(id)) throw new Error(`setPaintProperty(${id}, ${prop}) threw`)
+    void value
+  })
+  const getLayout = vi.fn((id: string, prop: string) => {
+    return layoutValues[`${id}.${prop}`]
+  })
+  return {
+    map: {
+      getStyle: () => ({ layers }),
+      getLayoutProperty: getLayout,
+      setLayoutProperty: setLayout,
+      setPaintProperty: setPaint,
+    } as any,
+    setLayout,
+    setPaint,
+    getLayout,
+  }
+}
+
+describe('boostSettlementLabels', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('boosts matching symbol layers (settlement, place-label, town-label, city-label)', () => {
+    const { map, setLayout, setPaint } = makeMockMap(
+      [
+        { id: 'settlement-minor-label', type: 'symbol' },
+        { id: 'place-label-major', type: 'symbol' },
+        { id: 'town-label-small', type: 'symbol' },
+        { id: 'city-label-capital', type: 'symbol' },
+        { id: 'place_label_legacy', type: 'symbol' },
+      ],
+      {
+        'settlement-minor-label.text-size': 12,
+        'place-label-major.text-size': 14,
+        'town-label-small.text-size': 10,
+        'city-label-capital.text-size': 16,
+        'place_label_legacy.text-size': 11,
+      }
+    )
+    boostSettlementLabels(map)
+    expect(setLayout).toHaveBeenCalledTimes(5)
+    expect(setLayout).toHaveBeenCalledWith('settlement-minor-label', 'text-size', 12 * 1.8)
+    expect(setPaint).toHaveBeenCalledTimes(10) // 2 paint calls per layer
+  })
+
+  it('skips non-symbol layers', () => {
+    const { map, setLayout, setPaint } = makeMockMap([
+      { id: 'settlement-fill', type: 'raster' },
+      { id: 'place-label-bg', type: 'line' },
+    ])
+    boostSettlementLabels(map)
+    expect(setLayout).not.toHaveBeenCalled()
+    expect(setPaint).not.toHaveBeenCalled()
+  })
+
+  it('skips symbol layers whose id does not match a target fragment', () => {
+    const { map, setLayout } = makeMockMap([
+      { id: 'road-label', type: 'symbol' },
+      { id: 'poi-label', type: 'symbol' },
+      { id: 'country-label', type: 'symbol' },
+    ])
+    boostSettlementLabels(map)
+    expect(setLayout).not.toHaveBeenCalled()
+  })
+
+  it('wraps expression text-size in a multiply expression (preserves zoom ramp)', () => {
+    const zoomExpr = ['interpolate', ['linear'], ['zoom'], 6, 10, 10, 14]
+    const { map, setLayout } = makeMockMap(
+      [{ id: 'settlement-label', type: 'symbol' }],
+      { 'settlement-label.text-size': zoomExpr }
+    )
+    boostSettlementLabels(map)
+    expect(setLayout).toHaveBeenCalledWith('settlement-label', 'text-size', ['*', 1.8, zoomExpr])
+  })
+
+  it('skips undefined text-size instead of creating a malformed [*,1.8,undefined] expression', () => {
+    const { map, setLayout, setPaint } = makeMockMap(
+      [{ id: 'settlement-label', type: 'symbol' }],
+      {} // text-size undefined
+    )
+    boostSettlementLabels(map)
+    expect(setLayout).not.toHaveBeenCalled()
+    // Halo still applied — the two concerns are independent now.
+    expect(setPaint).toHaveBeenCalledTimes(2)
+    expect(setPaint).toHaveBeenCalledWith('settlement-label', 'text-halo-width', 2)
+    expect(setPaint).toHaveBeenCalledWith('settlement-label', 'text-halo-color', '#ffffff')
+  })
+
+  it('applies halo even when text-size setLayoutProperty throws (partial-mutation fix)', () => {
+    const { map, setLayout, setPaint } = makeMockMap(
+      [{ id: 'settlement-label', type: 'symbol' }],
+      { 'settlement-label.text-size': 12 },
+      { throwSetLayout: () => true }
+    )
+    boostSettlementLabels(map)
+    // Size throw must NOT prevent halo application (previously it did).
+    expect(setLayout).toHaveBeenCalled()
+    expect(setPaint).toHaveBeenCalledTimes(2)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('logs (not throws) when setPaintProperty halo call throws', () => {
+    const { map, setPaint } = makeMockMap(
+      [{ id: 'settlement-label', type: 'symbol' }],
+      { 'settlement-label.text-size': 12 },
+      { throwSetPaint: () => true }
+    )
+    expect(() => boostSettlementLabels(map)).not.toThrow()
+    expect(setPaint).toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('is a no-op when map.getStyle returns no layers (raster-only styles)', () => {
+    const { map, setLayout } = makeMockMap([])
+    boostSettlementLabels(map)
+    expect(setLayout).not.toHaveBeenCalled()
+  })
+
+  it('handles map.getStyle() returning null without throwing', () => {
+    const map = {
+      getStyle: () => null,
+      getLayoutProperty: vi.fn(),
+      setLayoutProperty: vi.fn(),
+      setPaintProperty: vi.fn(),
+    } as any
+    expect(() => boostSettlementLabels(map)).not.toThrow()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/mapProviders.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapProviders.test.ts
@@ -1,11 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   MAP_STYLES,
+  MAP_STYLE_IDS,
   setProviderToken,
+  getProviderToken,
   getAvailableStyles,
   getStyleForId,
+  getMapboxAccessToken,
+  isMapStyleId,
   isStyleAvailable,
+  normalizeStyleId,
+  subscribeToProvider,
+  getProviderSnapshot,
 } from '../config/mapProviders'
+import mapboxgl from 'mapbox-gl'
 
 describe('mapProviders', () => {
   beforeEach(() => {
@@ -18,6 +26,12 @@ describe('mapProviders', () => {
     expect(MAP_STYLES.length).toBeGreaterThan(0)
     expect(MAP_STYLES.some(s => s.category === 'Streets')).toBe(true)
     expect(MAP_STYLES.some(s => s.category === 'Aerial')).toBe(true)
+  })
+
+  it('MAP_STYLE_IDS covers every entry in MAP_STYLES (no drift)', () => {
+    const registryIds = MAP_STYLES.map(s => s.id).sort()
+    const constIds = [...MAP_STYLE_IDS].sort()
+    expect(constIds).toEqual(registryIds)
   })
 
   it('filters out styles whose required token is absent', () => {
@@ -47,24 +61,39 @@ describe('mapProviders', () => {
   })
 
   it('falls back to the first available style for unknown ids', () => {
-    // No tokens — only OSM / ESRI are available; either is acceptable.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const result = getStyleForId('definitely-not-a-real-id')
     // Result is a raster style object, not a mapbox URL
     expect(typeof result === 'object' && result !== null).toBe(true)
+    // And unknown ids must be logged — distinguishing them from the silent
+    // "token pending async" fallback.
+    expect(warn).toHaveBeenCalled()
+    expect(warn.mock.calls[0][0]).toContain('Unknown style id')
+    warn.mockRestore()
   })
 
-  it('falls back when the requested style needs a missing token', () => {
-    // Mapy is gated; without the key, asking for mapy-basic must not leak
-    // a broken raster spec missing the apikey — fallback kicks in instead.
+  it('known-id-with-missing-token fallback is silent (token arrives async)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const result = getStyleForId('mapy-basic')
-    // Must not be the legacy URL string; must fall back to an available style
     expect(result).not.toBe('mapbox://styles/mapbox/streets-v12')
+    // Must NOT warn — this is the expected boot path while tokens load.
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 
-  it('embeds the Mapy.cz API key in tile URLs when token is set', () => {
-    setProviderToken('mapy', 'my-secret-key')
+  it('URL-encodes the Mapy.cz API key in tile URLs', () => {
+    setProviderToken('mapy', 'key with spaces & ampersand')
     const style = getStyleForId('mapy-basic')
     expect(typeof style).toBe('object')
+    const tiles = (style as any)?.sources?.['mapy-basic']?.tiles?.[0]
+    // `&` and spaces must be encoded — otherwise they'd inject query params.
+    expect(tiles).toContain('apikey=key%20with%20spaces%20%26%20ampersand')
+    expect(tiles).not.toContain('apikey=key with spaces & ampersand')
+  })
+
+  it('embeds the plain Mapy.cz API key when it has no special chars', () => {
+    setProviderToken('mapy', 'my-secret-key')
+    const style = getStyleForId('mapy-basic')
     const tiles = (style as any)?.sources?.['mapy-basic']?.tiles?.[0]
     expect(tiles).toContain('apikey=my-secret-key')
   })
@@ -74,5 +103,107 @@ describe('mapProviders', () => {
     expect(isStyleAvailable('mapy-basic')).toBe(false)
     setProviderToken('mapy', 'key')
     expect(isStyleAvailable('mapy-basic')).toBe(true)
+  })
+
+  describe('Mapbox URL shape', () => {
+    it('never embeds the Mapbox token in the style URL (auth is via SDK singleton)', () => {
+      setProviderToken('mapbox', 'pk.my.secret.token')
+      const streets = getStyleForId('mapbox-streets')
+      const satellite = getStyleForId('mapbox-satellite')
+      expect(typeof streets).toBe('string')
+      expect(typeof satellite).toBe('string')
+      expect(streets as string).not.toContain('pk.')
+      expect(streets as string).not.toContain('accessToken')
+      expect(satellite as string).not.toContain('pk.')
+      expect(satellite as string).not.toContain('accessToken')
+    })
+  })
+
+  describe('isMapStyleId / normalizeStyleId', () => {
+    it('isMapStyleId narrows only known ids', () => {
+      expect(isMapStyleId('mapy-basic')).toBe(true)
+      expect(isMapStyleId('mapbox-streets')).toBe(true)
+      expect(isMapStyleId('streets')).toBe(false)     // legacy form, not canonical
+      expect(isMapStyleId('')).toBe(false)
+      expect(isMapStyleId(null)).toBe(false)
+      expect(isMapStyleId(undefined)).toBe(false)
+      expect(isMapStyleId(42)).toBe(false)
+      expect(isMapStyleId({})).toBe(false)
+    })
+
+    it('normalizeStyleId accepts canonical and legacy ids', () => {
+      expect(normalizeStyleId('mapbox-streets')).toBe('mapbox-streets')
+      expect(normalizeStyleId('streets')).toBe('mapbox-streets')
+      expect(normalizeStyleId('satellite')).toBe('mapbox-satellite')
+    })
+
+    it('normalizeStyleId returns undefined for unknown / invalid values', () => {
+      expect(normalizeStyleId('unknown')).toBeUndefined()
+      expect(normalizeStyleId('')).toBeUndefined()
+      expect(normalizeStyleId(null)).toBeUndefined()
+      expect(normalizeStyleId(42)).toBeUndefined()
+    })
+  })
+
+  describe('setProviderToken token-clearing paths', () => {
+    it('empty string clears the token (treats as unset)', () => {
+      setProviderToken('mapbox', 'pk.test')
+      expect(getProviderToken('mapbox')).toBe('pk.test')
+      setProviderToken('mapbox', '')
+      expect(getProviderToken('mapbox')).toBeNull()
+    })
+
+    it('undefined clears the token', () => {
+      setProviderToken('mapbox', 'pk.test')
+      setProviderToken('mapbox', undefined)
+      expect(getProviderToken('mapbox')).toBeNull()
+    })
+
+    it('clearing mapbox token also clears mapboxgl.accessToken singleton', () => {
+      setProviderToken('mapbox', 'pk.real')
+      expect(mapboxgl.accessToken).toBe('pk.real')
+      setProviderToken('mapbox', null)
+      expect(mapboxgl.accessToken).toBe('')
+    })
+  })
+
+  describe('getMapboxAccessToken', () => {
+    it('returns undefined (not null, not empty) when unset', () => {
+      expect(getMapboxAccessToken()).toBeUndefined()
+    })
+    it('returns the configured token', () => {
+      setProviderToken('mapbox', 'pk.real')
+      expect(getMapboxAccessToken()).toBe('pk.real')
+    })
+  })
+
+  describe('subscribeToProvider / _notify', () => {
+    it('fires subscribers on every setProviderToken call, including same-value writes', () => {
+      const fn = vi.fn()
+      const unsub = subscribeToProvider(fn)
+      setProviderToken('mapbox', 'a')
+      setProviderToken('mapbox', 'a') // same value — still bump so React re-resolves
+      setProviderToken('mapy', 'b')
+      expect(fn).toHaveBeenCalledTimes(3)
+      unsub()
+    })
+
+    it('returned disposer removes the listener (no leak across component lifetimes)', () => {
+      const fn = vi.fn()
+      const unsub = subscribeToProvider(fn)
+      unsub()
+      setProviderToken('mapbox', 'x')
+      expect(fn).not.toHaveBeenCalled()
+    })
+
+    it('snapshot increments monotonically — useSyncExternalStore sees a new value each time', () => {
+      const before = getProviderSnapshot()
+      setProviderToken('mapbox', 'a')
+      const after1 = getProviderSnapshot()
+      setProviderToken('mapbox', 'b')
+      const after2 = getProviderSnapshot()
+      expect(after1).toBeGreaterThan(before)
+      expect(after2).toBeGreaterThan(after1)
+    })
   })
 })

--- a/frontend/map-corridors/src/__tests__/mapProviders.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapProviders.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  MAP_STYLES,
+  setProviderToken,
+  getAvailableStyles,
+  getStyleForId,
+  isStyleAvailable,
+} from '../config/mapProviders'
+
+describe('mapProviders', () => {
+  beforeEach(() => {
+    // Clear both tokens so each test starts from a known baseline.
+    setProviderToken('mapbox', null)
+    setProviderToken('mapy', null)
+  })
+
+  it('exposes a non-empty style registry with both categories', () => {
+    expect(MAP_STYLES.length).toBeGreaterThan(0)
+    expect(MAP_STYLES.some(s => s.category === 'Streets')).toBe(true)
+    expect(MAP_STYLES.some(s => s.category === 'Aerial')).toBe(true)
+  })
+
+  it('filters out styles whose required token is absent', () => {
+    const avail = getAvailableStyles().map(s => s.id)
+    // Token-free styles must always be present.
+    expect(avail).toContain('osm-classic')
+    expect(avail).toContain('esri-satellite')
+    // Token-gated styles must be hidden when no token is configured.
+    expect(avail).not.toContain('mapbox-streets')
+    expect(avail).not.toContain('mapbox-satellite')
+    expect(avail).not.toContain('mapy-basic')
+    expect(avail).not.toContain('mapy-aerial')
+  })
+
+  it('re-enables token-gated styles when the token arrives', () => {
+    setProviderToken('mapy', 'test-mapy-key')
+    const avail = getAvailableStyles().map(s => s.id)
+    expect(avail).toContain('mapy-basic')
+    expect(avail).toContain('mapy-aerial')
+    expect(avail).not.toContain('mapbox-streets')
+  })
+
+  it('resolves legacy "streets"/"satellite" ids to mapbox defaults', () => {
+    setProviderToken('mapbox', 'pk.test')
+    expect(getStyleForId('streets')).toBe('mapbox://styles/mapbox/streets-v12')
+    expect(getStyleForId('satellite')).toBe('mapbox://styles/mapbox/satellite-v9')
+  })
+
+  it('falls back to the first available style for unknown ids', () => {
+    // No tokens — only OSM / ESRI are available; either is acceptable.
+    const result = getStyleForId('definitely-not-a-real-id')
+    // Result is a raster style object, not a mapbox URL
+    expect(typeof result === 'object' && result !== null).toBe(true)
+  })
+
+  it('falls back when the requested style needs a missing token', () => {
+    // Mapy is gated; without the key, asking for mapy-basic must not leak
+    // a broken raster spec missing the apikey — fallback kicks in instead.
+    const result = getStyleForId('mapy-basic')
+    // Must not be the legacy URL string; must fall back to an available style
+    expect(result).not.toBe('mapbox://styles/mapbox/streets-v12')
+  })
+
+  it('embeds the Mapy.cz API key in tile URLs when token is set', () => {
+    setProviderToken('mapy', 'my-secret-key')
+    const style = getStyleForId('mapy-basic')
+    expect(typeof style).toBe('object')
+    const tiles = (style as any)?.sources?.['mapy-basic']?.tiles?.[0]
+    expect(tiles).toContain('apikey=my-secret-key')
+  })
+
+  it('isStyleAvailable tracks token state', () => {
+    expect(isStyleAvailable('osm-classic')).toBe(true)
+    expect(isStyleAvailable('mapy-basic')).toBe(false)
+    setProviderToken('mapy', 'key')
+    expect(isStyleAvailable('mapy-basic')).toBe(true)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/sessionMigration.test.ts
+++ b/frontend/map-corridors/src/__tests__/sessionMigration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { resolveMapStyleIdFromPersisted } from '../hooks/useCorridorSessionOPFS'
+
+/**
+ * Session migration is the one piece of code in PR #42 that can permanently
+ * corrupt every existing user's persisted state on upgrade. These tests pin
+ * the precedence rules: new-schema `mapStyleId` > legacy `baseStyle` > default.
+ */
+describe('resolveMapStyleIdFromPersisted', () => {
+  const DEFAULT_ID = 'mapbox-streets'
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('uses stored mapStyleId when present (new schema takes precedence)', () => {
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: 'mapy-basic' }, DEFAULT_ID)).toBe('mapy-basic')
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: 'osm-classic' }, DEFAULT_ID)).toBe('osm-classic')
+  })
+
+  it('new-schema mapStyleId wins over legacy baseStyle', () => {
+    const rec = { mapStyleId: 'mapy-aerial', baseStyle: 'streets' }
+    expect(resolveMapStyleIdFromPersisted(rec, DEFAULT_ID)).toBe('mapy-aerial')
+  })
+
+  it('migrates legacy baseStyle="streets" to mapbox-streets', () => {
+    expect(resolveMapStyleIdFromPersisted({ baseStyle: 'streets' }, DEFAULT_ID)).toBe('mapbox-streets')
+  })
+
+  it('migrates legacy baseStyle="satellite" to mapbox-satellite', () => {
+    expect(resolveMapStyleIdFromPersisted({ baseStyle: 'satellite' }, DEFAULT_ID)).toBe('mapbox-satellite')
+  })
+
+  it('returns default when session has neither field', () => {
+    expect(resolveMapStyleIdFromPersisted({}, DEFAULT_ID)).toBe(DEFAULT_ID)
+  })
+
+  it('returns default for malformed records (null, undefined, non-object)', () => {
+    expect(resolveMapStyleIdFromPersisted(null, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted(undefined, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted('not an object', DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted(42, DEFAULT_ID)).toBe(DEFAULT_ID)
+  })
+
+  it('ignores empty-string mapStyleId and falls through to legacy/default', () => {
+    // Empty string was previously allowed through (typeof 'string' passed)
+    // and would silently reach getStyleForId's fallback. Now it falls through.
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: '', baseStyle: 'satellite' }, DEFAULT_ID)).toBe('mapbox-satellite')
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: '' }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('warns and falls through on non-string mapStyleId (corrupted session)', () => {
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: 42 }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: {} }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: null }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('warns and falls through on unknown legacy baseStyle (future/corrupted value)', () => {
+    expect(resolveMapStyleIdFromPersisted({ baseStyle: 'hybrid' }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(resolveMapStyleIdFromPersisted({ baseStyle: 42 }, DEFAULT_ID)).toBe(DEFAULT_ID)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('passes through unknown mapStyleId strings (getStyleForId will fallback + warn)', () => {
+    // Unknown but string values are kept so `useMapStyle` can heal them
+    // via onChange — validating strings here would lose user preference.
+    expect(resolveMapStyleIdFromPersisted({ mapStyleId: 'some-future-style' }, DEFAULT_ID))
+      .toBe('some-future-style')
+  })
+})

--- a/frontend/map-corridors/src/components/MapStyleSelector.tsx
+++ b/frontend/map-corridors/src/components/MapStyleSelector.tsx
@@ -1,0 +1,164 @@
+import React, { useRef, useState } from 'react'
+import {
+  ButtonGroup,
+  Button,
+  Popper,
+  Paper,
+  MenuList,
+  MenuItem,
+  ClickAwayListener,
+  Grow,
+  Typography,
+} from '@mui/material'
+import { ArrowDropDown } from '@mui/icons-material'
+import type { MapStyleDef, MapStyleId } from '../config/mapProviders'
+
+/**
+ * Two-button map style selector: "Map: <provider>" | "Satellite: <provider>".
+ * Clicking the label toggles between the two categories (remembering the
+ * provider you used last in each). A small dropdown arrow appears next to
+ * each label when more than one provider is available for that category.
+ *
+ * Ported from `AirQ-Sports/frontend/shared/src/components/mapgl/MapStyleSelector.jsx`.
+ */
+type Props = {
+  mapStyle: MapStyleId
+  setMapStyle: (id: MapStyleId) => void
+  availableStyles: MapStyleDef[]
+  streetsLabel?: string
+  aerialLabel?: string
+  size?: 'small' | 'medium' | 'large'
+}
+
+type Category = 'Streets' | 'Aerial'
+
+export const MapStyleSelector: React.FC<Props> = ({
+  mapStyle,
+  setMapStyle,
+  availableStyles,
+  streetsLabel = 'Map',
+  aerialLabel = 'Satellite',
+  size = 'small',
+}) => {
+  const [openCat, setOpenCat] = useState<Category | null>(null)
+  const streetsRef = useRef<HTMLButtonElement | null>(null)
+  const aerialRef = useRef<HTMLButtonElement | null>(null)
+
+  if (!availableStyles || availableStyles.length === 0) return null
+
+  const streets = availableStyles.filter(s => s.category === 'Streets')
+  const aerial = availableStyles.filter(s => s.category === 'Aerial')
+  const currentDef = availableStyles.find(s => s.id === mapStyle)
+  const isAerial = currentDef?.category === 'Aerial'
+
+  // Remember the last pick per category so toggling doesn't lose the provider choice.
+  const activeStreets = isAerial ? streets[0] : currentDef
+  const activeAerial = isAerial ? currentDef : aerial[0]
+  const streetsProvider = (activeStreets || streets[0])?.label || ''
+  const aerialProvider = (activeAerial || aerial[0])?.label || ''
+
+  const handleMainClick = (category: Category) => {
+    const group = category === 'Streets' ? streets : aerial
+    if (group.length === 0) return
+    if ((category === 'Streets' && !isAerial) || (category === 'Aerial' && isAerial)) return
+    const target = category === 'Streets' ? activeStreets : activeAerial
+    setMapStyle((target?.id as MapStyleId) || group[0].id)
+  }
+
+  const handleArrowClick = (e: React.MouseEvent, category: Category) => {
+    e.stopPropagation()
+    setOpenCat(prev => (prev === category ? null : category))
+  }
+
+  const handleMenuSelect = (styleId: MapStyleId) => {
+    setMapStyle(styleId)
+    setOpenCat(null)
+  }
+
+  const handleClose = () => setOpenCat(null)
+
+  const btnSx = { textTransform: 'none' as const, fontSize: '0.8125rem', lineHeight: 1.4 }
+
+  // Child Typography spans default to `text.primary` (dark grey) which
+  // reads as unreadable grey-on-blue when this selector is dropped into a
+  // dark-themed app bar. Forcing `color: inherit` lets the Button's own
+  // color (white in the app bar, theme default elsewhere) propagate through.
+  const renderLabel = (category: string, provider: string) => (
+    <>
+      <Typography component="span" sx={{ fontSize: '0.7rem', opacity: 0.7, mr: 0.5, color: 'inherit' }}>{category}:</Typography>
+      <Typography component="span" sx={{ fontSize: '0.8125rem', fontWeight: 500, color: 'inherit' }}>{provider}</Typography>
+    </>
+  )
+
+  const renderDropdown = (category: Category, anchorRef: React.RefObject<HTMLButtonElement | null>, items: MapStyleDef[]) => (
+    <Popper open={openCat === category} anchorEl={anchorRef.current} transition disablePortal placement="bottom-start" sx={{ zIndex: 1300 }}>
+      {({ TransitionProps }) => (
+        <Grow {...TransitionProps}>
+          <Paper elevation={4} sx={{ mt: 0.5 }}>
+            <ClickAwayListener onClickAway={handleClose}>
+              <MenuList dense autoFocusItem={openCat === category}>
+                {items.map(s => (
+                  <MenuItem
+                    key={s.id}
+                    selected={s.id === mapStyle}
+                    onClick={() => handleMenuSelect(s.id)}
+                    sx={{ fontSize: '0.8125rem', minWidth: 140 }}
+                  >
+                    {s.label}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </ClickAwayListener>
+          </Paper>
+        </Grow>
+      )}
+    </Popper>
+  )
+
+  return (
+    <>
+      <ButtonGroup size={size} variant="outlined">
+        <Button
+          onClick={() => handleMainClick('Streets')}
+          variant={!isAerial ? 'contained' : 'outlined'}
+          sx={btnSx}
+        >
+          {renderLabel(streetsLabel, streetsProvider)}
+        </Button>
+        {streets.length > 1 && (
+          <Button
+            ref={streetsRef}
+            variant={!isAerial ? 'contained' : 'outlined'}
+            onClick={(e) => handleArrowClick(e, 'Streets')}
+            sx={{ px: 0, minWidth: 28 }}
+            aria-label="Choose streets provider"
+          >
+            <ArrowDropDown fontSize="small" />
+          </Button>
+        )}
+
+        <Button
+          onClick={() => handleMainClick('Aerial')}
+          variant={isAerial ? 'contained' : 'outlined'}
+          sx={btnSx}
+        >
+          {renderLabel(aerialLabel, aerialProvider)}
+        </Button>
+        {aerial.length > 1 && (
+          <Button
+            ref={aerialRef}
+            variant={isAerial ? 'contained' : 'outlined'}
+            onClick={(e) => handleArrowClick(e, 'Aerial')}
+            sx={{ px: 0, minWidth: 28 }}
+            aria-label="Choose satellite provider"
+          >
+            <ArrowDropDown fontSize="small" />
+          </Button>
+        )}
+      </ButtonGroup>
+
+      {streets.length > 1 && renderDropdown('Streets', streetsRef, streets)}
+      {aerial.length > 1 && renderDropdown('Aerial', aerialRef, aerial)}
+    </>
+  )
+}

--- a/frontend/map-corridors/src/config/mapProviders.ts
+++ b/frontend/map-corridors/src/config/mapProviders.ts
@@ -106,13 +106,20 @@ const osmClassicStyle: StyleSpecification = {
   layers: [{ id: 'osm-classic-layer', type: 'raster', source: 'osm-classic' }],
 }
 
+// URL-encode the API key when embedding in a query string so a token that
+// happens to contain `&`, `#`, `?`, or whitespace cannot escape the `apikey`
+// parameter or corrupt the URL. Mapy.cz keys are alphanumeric in practice but
+// defense-in-depth is cheap here.
+const mapyTilesUrl = (kind: 'basic' | 'aerial'): string =>
+  `https://api.mapy.cz/v1/maptiles/${kind}/256/{z}/{x}/{y}?apikey=${encodeURIComponent(_tokens.mapy ?? '')}`
+
 const mapyBasicStyle = (): StyleSpecification => ({
   version: 8,
   glyphs: FREE_GLYPHS_URL,
   sources: {
     'mapy-basic': {
       type: 'raster',
-      tiles: [`https://api.mapy.cz/v1/maptiles/basic/256/{z}/{x}/{y}?apikey=${_tokens.mapy ?? ''}`],
+      tiles: [mapyTilesUrl('basic')],
       tileSize: 256,
       attribution: '\u00A9 Seznam.cz, a.s.',
     },
@@ -126,7 +133,7 @@ const mapyAerialStyle = (): StyleSpecification => ({
   sources: {
     'mapy-aerial': {
       type: 'raster',
-      tiles: [`https://api.mapy.cz/v1/maptiles/aerial/256/{z}/{x}/{y}?apikey=${_tokens.mapy ?? ''}`],
+      tiles: [mapyTilesUrl('aerial')],
       tileSize: 256,
       attribution: '\u00A9 Seznam.cz, a.s.',
     },
@@ -139,13 +146,21 @@ const mapyAerialStyle = (): StyleSpecification => ({
 // ---------------------------------------------------------------------------
 
 export type MapStyleCategory = 'Streets' | 'Aerial'
-export type MapStyleId =
-  | 'mapy-basic'
-  | 'mapbox-streets'
-  | 'osm-classic'
-  | 'mapbox-satellite'
-  | 'mapy-aerial'
-  | 'esri-satellite'
+
+/** Source of truth for the set of valid style ids. Derive the literal union
+ *  from the const array so adding an id in `MAP_STYLES` forces the type to
+ *  widen (or the compiler to complain).
+ */
+export const MAP_STYLE_IDS = [
+  'mapy-basic',
+  'mapbox-streets',
+  'osm-classic',
+  'mapbox-satellite',
+  'mapy-aerial',
+  'esri-satellite',
+] as const
+
+export type MapStyleId = typeof MAP_STYLE_IDS[number]
 
 export type MapStyleDef = {
   id: MapStyleId
@@ -183,15 +198,39 @@ const LEGACY_IDS: Record<string, MapStyleId | undefined> = {
   satellite: 'mapbox-satellite',
 }
 
+/** Runtime type guard: is this an id we recognise? */
+export function isMapStyleId(value: unknown): value is MapStyleId {
+  return typeof value === 'string' && (MAP_STYLE_IDS as readonly string[]).includes(value)
+}
+
+/**
+ * Resolve an arbitrary string (possibly stale, possibly a legacy 'streets'/
+ * 'satellite' key) to a known `MapStyleId` or `undefined`. Does NOT check
+ * token availability — that's a concern of `getAvailableStyles()`.
+ *
+ * Returning `undefined` lets callers heal persisted state by writing back
+ * a valid id the next time the user interacts with the selector.
+ */
+export function normalizeStyleId(value: unknown): MapStyleId | undefined {
+  if (isMapStyleId(value)) return value
+  if (typeof value === 'string') return LEGACY_IDS[value]
+  return undefined
+}
+
 /**
  * Resolve a style id (including legacy 'streets'/'satellite') to a usable
  * style URL or style object. Falls back to the first available style if the
  * requested one doesn't exist or needs a token that isn't configured.
+ *
+ * Distinguishes two fallback reasons and logs only the bug case:
+ *  - Unknown style id → `console.warn` (stale persistence / typo)
+ *  - Known id but required token not yet loaded → silent (tokens arrive async)
  */
 export function getStyleForId(styleId: string): string | StyleSpecification {
-  const resolved: MapStyleId | undefined =
-    (MAP_STYLES.some(s => s.id === styleId) ? (styleId as MapStyleId) : undefined)
-    ?? LEGACY_IDS[styleId]
+  const resolved = normalizeStyleId(styleId)
+  if (resolved === undefined) {
+    console.warn(`[mapProviders] Unknown style id "${styleId}" — falling back to first available style`)
+  }
   const def = resolved ? MAP_STYLES.find(s => s.id === resolved) : undefined
   if (def && (!def.requiredToken || _tokens[def.requiredToken])) {
     return def.getStyle()

--- a/frontend/map-corridors/src/config/mapProviders.ts
+++ b/frontend/map-corridors/src/config/mapProviders.ts
@@ -1,0 +1,216 @@
+/**
+ * Map provider abstraction — supports multiple tile styles from several
+ * providers. Ported from the sibling AirQ-Sports repo.
+ *
+ * Tokens are set at runtime via `setProviderToken()`. Styles whose required
+ * token is missing are filtered out by `getAvailableStyles()`, so the UI
+ * only offers what will actually render.
+ */
+
+import mapboxgl, { type StyleSpecification } from 'mapbox-gl'
+
+// ---------------------------------------------------------------------------
+// Token state (module-scoped; shared across all consumers of this module)
+// ---------------------------------------------------------------------------
+
+type ProviderId = 'mapbox' | 'mapy'
+
+const _tokens: Record<ProviderId, string | null> = { mapbox: null, mapy: null }
+
+let _tokenVersion = 0
+const _listeners = new Set<() => void>()
+
+function _notify(): void {
+  _tokenVersion++
+  _listeners.forEach(fn => fn())
+}
+
+/** `useSyncExternalStore` subscribe/snapshot pair so hooks re-render on token change. */
+export function subscribeToProvider(callback: () => void): () => void {
+  _listeners.add(callback)
+  return () => {
+    _listeners.delete(callback)
+  }
+}
+export function getProviderSnapshot(): number {
+  return _tokenVersion
+}
+
+/** Set any provider token at runtime. Pass `null`/empty to clear. */
+export function setProviderToken(providerId: ProviderId, token: string | null | undefined): void {
+  const value = token && token.length > 0 ? token : null
+  _tokens[providerId] = value
+  // Mapbox GL JS reads `mapboxgl.accessToken` as a module-level singleton from
+  // inside `setStyle('mapbox://…')`. react-map-gl mirrors the prop into that
+  // singleton, but the assignment lags one microtask behind a `mapStyle` prop
+  // update, which causes `setStyle` to fire before the new token is visible
+  // and throw "An API access token is required". Writing the singleton here
+  // — synchronously, in the same call that flips `_tokens.mapbox` — closes
+  // that race: any subsequent `getStyleForId` that returns a `mapbox://`
+  // URL is guaranteed to have the matching token in place.
+  if (providerId === 'mapbox') {
+    mapboxgl.accessToken = value || ''
+  }
+  _notify()
+}
+
+export function getProviderToken(providerId: ProviderId): string | null {
+  return _tokens[providerId]
+}
+
+// ---------------------------------------------------------------------------
+// Raster style specs for providers that don't serve their own style.json
+// ---------------------------------------------------------------------------
+
+// Free glyph PBFs for raster styles that don't bring their own. Without this,
+// Mapbox GL rejects any symbol layer that uses `text-field` (the map-corridors
+// app adds one for waypoint + exact-point labels). MapLibre's demo server is
+// public, CORS-friendly and safe for light use.
+const FREE_GLYPHS_URL = 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf'
+
+const esriSatelliteStyle: StyleSpecification = {
+  version: 8,
+  glyphs: FREE_GLYPHS_URL,
+  sources: {
+    'esri-satellite': {
+      type: 'raster',
+      tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
+      tileSize: 256,
+      attribution: 'Tiles \u00A9 Esri',
+    },
+  },
+  layers: [{ id: 'esri-satellite-layer', type: 'raster', source: 'esri-satellite' }],
+}
+
+// CARTO Voyager: OSM-derived tiles served via basemaps.cartocdn.com. Works
+// without a Referer header so it's safe for Electron's `app://` origin,
+// unlike tile.openstreetmap.org which enforces OSM's tile usage policy and
+// returns 403 "Access blocked" from browsers that don't send a sensible
+// Referer. Same underlying data, CC-BY attribution required.
+const osmClassicStyle: StyleSpecification = {
+  version: 8,
+  glyphs: FREE_GLYPHS_URL,
+  sources: {
+    'osm-classic': {
+      type: 'raster',
+      tiles: [
+        'https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+        'https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+        'https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+        'https://d.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
+      ],
+      tileSize: 256,
+      attribution: '\u00A9 OpenStreetMap contributors, \u00A9 CARTO',
+    },
+  },
+  layers: [{ id: 'osm-classic-layer', type: 'raster', source: 'osm-classic' }],
+}
+
+const mapyBasicStyle = (): StyleSpecification => ({
+  version: 8,
+  glyphs: FREE_GLYPHS_URL,
+  sources: {
+    'mapy-basic': {
+      type: 'raster',
+      tiles: [`https://api.mapy.cz/v1/maptiles/basic/256/{z}/{x}/{y}?apikey=${_tokens.mapy ?? ''}`],
+      tileSize: 256,
+      attribution: '\u00A9 Seznam.cz, a.s.',
+    },
+  },
+  layers: [{ id: 'mapy-basic-layer', type: 'raster', source: 'mapy-basic' }],
+})
+
+const mapyAerialStyle = (): StyleSpecification => ({
+  version: 8,
+  glyphs: FREE_GLYPHS_URL,
+  sources: {
+    'mapy-aerial': {
+      type: 'raster',
+      tiles: [`https://api.mapy.cz/v1/maptiles/aerial/256/{z}/{x}/{y}?apikey=${_tokens.mapy ?? ''}`],
+      tileSize: 256,
+      attribution: '\u00A9 Seznam.cz, a.s.',
+    },
+  },
+  layers: [{ id: 'mapy-aerial-layer', type: 'raster', source: 'mapy-aerial' }],
+})
+
+// ---------------------------------------------------------------------------
+// Public style registry
+// ---------------------------------------------------------------------------
+
+export type MapStyleCategory = 'Streets' | 'Aerial'
+export type MapStyleId =
+  | 'mapy-basic'
+  | 'mapbox-streets'
+  | 'osm-classic'
+  | 'mapbox-satellite'
+  | 'mapy-aerial'
+  | 'esri-satellite'
+
+export type MapStyleDef = {
+  id: MapStyleId
+  label: string
+  category: MapStyleCategory
+  /** Which provider token must be present for this style to be usable. */
+  requiredToken: ProviderId | null
+  getStyle: () => string | StyleSpecification
+}
+
+/**
+ * Ordered by preference within each category. Mapy.com goes first in Streets
+ * because its Czech city/town labels are much denser than Mapbox defaults —
+ * which is the whole reason this selector exists (feedback 2026-04-18).
+ */
+export const MAP_STYLES: MapStyleDef[] = [
+  // Streets
+  { id: 'mapy-basic', label: 'Mapy.com', category: 'Streets', requiredToken: 'mapy', getStyle: () => mapyBasicStyle() },
+  { id: 'mapbox-streets', label: 'Mapbox Streets', category: 'Streets', requiredToken: 'mapbox', getStyle: () => 'mapbox://styles/mapbox/streets-v12' },
+  { id: 'osm-classic', label: 'OpenStreetMap', category: 'Streets', requiredToken: null, getStyle: () => osmClassicStyle },
+  // Aerial
+  { id: 'mapbox-satellite', label: 'Mapbox Satellite', category: 'Aerial', requiredToken: 'mapbox', getStyle: () => 'mapbox://styles/mapbox/satellite-v9' },
+  { id: 'mapy-aerial', label: 'Mapy.com Aerial', category: 'Aerial', requiredToken: 'mapy', getStyle: () => mapyAerialStyle() },
+  { id: 'esri-satellite', label: 'ESRI Satellite', category: 'Aerial', requiredToken: null, getStyle: () => esriSatelliteStyle },
+]
+
+/** Styles whose required token is present (or that need none). */
+export function getAvailableStyles(): MapStyleDef[] {
+  return MAP_STYLES.filter(s => !s.requiredToken || _tokens[s.requiredToken])
+}
+
+/** Legacy aliases from the old `baseStyle: 'streets' | 'satellite'` schema. */
+const LEGACY_IDS: Record<string, MapStyleId | undefined> = {
+  streets: 'mapbox-streets',
+  satellite: 'mapbox-satellite',
+}
+
+/**
+ * Resolve a style id (including legacy 'streets'/'satellite') to a usable
+ * style URL or style object. Falls back to the first available style if the
+ * requested one doesn't exist or needs a token that isn't configured.
+ */
+export function getStyleForId(styleId: string): string | StyleSpecification {
+  const resolved: MapStyleId | undefined =
+    (MAP_STYLES.some(s => s.id === styleId) ? (styleId as MapStyleId) : undefined)
+    ?? LEGACY_IDS[styleId]
+  const def = resolved ? MAP_STYLES.find(s => s.id === resolved) : undefined
+  if (def && (!def.requiredToken || _tokens[def.requiredToken])) {
+    return def.getStyle()
+  }
+  const fallback = getAvailableStyles()[0]
+  return fallback ? fallback.getStyle() : osmClassicStyle
+}
+
+/** True iff the given id matches a known style that's currently usable. */
+export function isStyleAvailable(styleId: string): boolean {
+  return getAvailableStyles().some(s => s.id === styleId)
+}
+
+/**
+ * Convenience reader used by `<MapProviderView>` to feed
+ * react-map-gl's `mapboxAccessToken` prop. Reads the same module-scoped
+ * token state that `getStyleForId` checks, so the token can never lag
+ * behind the style — they're consistent within one React render.
+ */
+export function getMapboxAccessToken(): string | undefined {
+  return _tokens.mapbox ?? undefined
+}

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -23,6 +23,43 @@ const LEGACY_BASE_STYLE_MAP: Record<LegacyBaseStyle, string> = {
   satellite: 'mapbox-satellite',
 }
 
+function isLegacyBaseStyle(value: unknown): value is LegacyBaseStyle {
+  return value === 'streets' || value === 'satellite'
+}
+
+/**
+ * Resolve the `mapStyleId` for a persisted session record.
+ *
+ * Precedence:
+ *   1. `mapStyleId` if present and a non-empty string (new-schema sessions)
+ *   2. `baseStyle` if a recognised legacy value (old-schema sessions)
+ *   3. `defaultId` (caller supplies, usually `defaultSession(id).mapStyleId`)
+ *
+ * Invalid or unknown values at any step are logged and fall through so the
+ * user is visibly reset to the default rather than silently stuck on a
+ * corrupted id. Exported for unit testing — the migration is the one code
+ * path that can permanently corrupt persisted user state across upgrades.
+ */
+export function resolveMapStyleIdFromPersisted(record: unknown, defaultId: string): string {
+  const asRec = (record && typeof record === 'object') ? record as Record<string, unknown> : {}
+
+  const storedRaw = asRec.mapStyleId
+  if (typeof storedRaw === 'string' && storedRaw.length > 0) {
+    return storedRaw
+  } else if (storedRaw !== undefined) {
+    console.warn('[session] Persisted mapStyleId was not a non-empty string, ignoring:', storedRaw)
+  }
+
+  const legacyRaw = asRec.baseStyle
+  if (isLegacyBaseStyle(legacyRaw)) {
+    return LEGACY_BASE_STYLE_MAP[legacyRaw]
+  } else if (legacyRaw !== undefined) {
+    console.warn('[session] Unknown legacy baseStyle, resetting to default:', legacyRaw)
+  }
+
+  return defaultId
+}
+
 export type CorridorsSession = {
   id: string
   version: number
@@ -137,11 +174,8 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           }
           // Migrate old `baseStyle: 'streets'|'satellite'` sessions to the
           // new `mapStyleId` field so users don't lose their current pick.
-          const legacyBase = asRec.baseStyle as LegacyBaseStyle | undefined
-          const storedMapStyleId = typeof asRec.mapStyleId === 'string' ? asRec.mapStyleId : undefined
-          const mapStyleId = storedMapStyleId
-            || (legacyBase ? LEGACY_BASE_STYLE_MAP[legacyBase] : undefined)
-            || defaultSession(id).mapStyleId
+          // Logic extracted to `resolveMapStyleIdFromPersisted` for unit tests.
+          const mapStyleId = resolveMapStyleIdFromPersisted(asRec, defaultSession(id).mapStyleId)
           setSession({
             ...defaultSession(id),
             ...existing,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -11,14 +11,30 @@ import {
   type DirectoryHandle,
 } from '@airq/shared-storage'
 
-type BaseStyle = 'streets' | 'satellite'
+/**
+ * Legacy two-value base style. New sessions use the richer `mapStyleId`
+ * (see `config/mapProviders`). Kept on the session for migration only —
+ * readers should prefer `mapStyleId`.
+ */
+type LegacyBaseStyle = 'streets' | 'satellite'
+
+const LEGACY_BASE_STYLE_MAP: Record<LegacyBaseStyle, string> = {
+  streets: 'mapbox-streets',
+  satellite: 'mapbox-satellite',
+}
 
 export type CorridorsSession = {
   id: string
   version: number
   createdAt: string
   updatedAt: string
-  baseStyle: BaseStyle
+  /**
+   * One of the `MapStyleId` values from `config/mapProviders.ts`. We use a
+   * plain `string` here to keep the session type free of a runtime import
+   * and to tolerate unknown ids from older builds — resolution falls back
+   * to the first available style if the id is unknown.
+   */
+  mapStyleId: string
   discipline: Discipline
   use1NmAfterSp: boolean
   // Persisted artifacts
@@ -38,7 +54,7 @@ const defaultSession = (id: string): CorridorsSession => ({
   version: 1,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
-  baseStyle: 'streets',
+  mapStyleId: 'mapbox-streets',
   discipline: 'rally',
   use1NmAfterSp: false,
   geojson: null,
@@ -119,10 +135,17 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           } else if (rawPm !== undefined && !Array.isArray(rawPm)) {
             console.warn('[session] Persisted markers was not an array, resetting', rawPm)
           }
+          // Migrate old `baseStyle: 'streets'|'satellite'` sessions to the
+          // new `mapStyleId` field so users don't lose their current pick.
+          const legacyBase = asRec.baseStyle as LegacyBaseStyle | undefined
+          const storedMapStyleId = typeof asRec.mapStyleId === 'string' ? asRec.mapStyleId : undefined
+          const mapStyleId = storedMapStyleId
+            || (legacyBase ? LEGACY_BASE_STYLE_MAP[legacyBase] : undefined)
+            || defaultSession(id).mapStyleId
           setSession({
             ...defaultSession(id),
             ...existing,
-            baseStyle: (asRec.baseStyle as CorridorsSession['baseStyle']) || 'streets',
+            mapStyleId,
             discipline: (asRec.discipline as CorridorsSession['discipline']) || 'rally',
             markers: cleanPm,
             groundMarkers: cleanGm,
@@ -156,9 +179,9 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     }
   }, [])
 
-  const setBaseStyle = useCallback(async (style: BaseStyle) => {
+  const setMapStyleId = useCallback(async (mapStyleId: string) => {
     if (!session) return
-    const next: CorridorsSession = { ...session, baseStyle: style, version: session.version + 1, updatedAt: new Date().toISOString() }
+    const next: CorridorsSession = { ...session, mapStyleId, version: session.version + 1, updatedAt: new Date().toISOString() }
     await persistSession(next)
   }, [session, persistSession])
 
@@ -239,7 +262,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     error,
     backendAvailable: storageAvailable,
     // actions
-    setBaseStyle,
+    setMapStyleId,
     setDiscipline,
     setUse1NmAfterSp,
     setMarkers,

--- a/frontend/map-corridors/src/hooks/useMapStyle.ts
+++ b/frontend/map-corridors/src/hooks/useMapStyle.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import {
   getAvailableStyles,
+  normalizeStyleId,
   subscribeToProvider,
   getProviderSnapshot,
   type MapStyleDef,
@@ -34,27 +35,41 @@ export function useMapStyle({ preferredId, onChange }: UseMapStyleArgs): [MapSty
   const availableStyles = getAvailableStyles()
   const availableIds = new Set(availableStyles.map(s => s.id))
 
+  // Normalize the raw preferred id once (may coerce legacy 'streets'/'satellite'
+  // to a real MapStyleId). `undefined` means "no valid preference known yet".
+  const normalizedPreferred = normalizeStyleId(preferredId)
+
   const pickDefault = useCallback((): MapStyleId => {
-    if (preferredId && availableIds.has(preferredId as MapStyleId)) return preferredId as MapStyleId
+    if (normalizedPreferred && availableIds.has(normalizedPreferred)) return normalizedPreferred
     if (availableStyles.length > 0) return availableStyles[0].id
     return 'osm-classic'
-  }, [availableIds, availableStyles, preferredId])
+  }, [availableIds, availableStyles, normalizedPreferred])
 
   const [mapStyleId, _setMapStyleId] = useState<MapStyleId>(() => pickDefault())
   const preferredRef = useRef<string | null | undefined>(preferredId)
+  const healedRef = useRef<string | null>(null)
 
   // When tokens change (Mapbox/Mapy key arrives async) or the stored
-  // preference updates, re-resolve. Intentionally narrow deps so we re-run
-  // on token bump — not on every render.
+  // preference updates, re-resolve. If the raw persisted id was legacy or
+  // unknown but normalization recovered a valid id, persist the normalized
+  // form back to storage so the session heals on first interaction.
   useEffect(() => {
     preferredRef.current = preferredId
-    if (preferredId && availableIds.has(preferredId as MapStyleId)) {
-      _setMapStyleId(preferredId as MapStyleId)
+    if (normalizedPreferred && availableIds.has(normalizedPreferred)) {
+      _setMapStyleId(normalizedPreferred)
+      // Heal persisted state if the raw form differed from the normalized form
+      // (e.g. legacy 'streets' → 'mapbox-streets'). Guard with `healedRef` so
+      // we don't loop when `preferredId` hasn't actually changed but tokens
+      // bumped the snapshot.
+      if (preferredId && preferredId !== normalizedPreferred && healedRef.current !== preferredId) {
+        healedRef.current = preferredId
+        onChange(normalizedPreferred)
+      }
     } else if (!availableIds.has(mapStyleId)) {
       _setMapStyleId(pickDefault())
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tokenSnapshot, preferredId])
+  }, [tokenSnapshot, preferredId, normalizedPreferred])
 
   const setMapStyleId = useCallback((id: MapStyleId) => {
     preferredRef.current = id

--- a/frontend/map-corridors/src/hooks/useMapStyle.ts
+++ b/frontend/map-corridors/src/hooks/useMapStyle.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import {
+  getAvailableStyles,
+  subscribeToProvider,
+  getProviderSnapshot,
+  type MapStyleDef,
+  type MapStyleId,
+} from '../config/mapProviders'
+
+/**
+ * Map-style selection hook with simple persistence.
+ *
+ * The selected style id is persisted externally (via the `session` / OPFS
+ * store) — callers pass it in and write it back through `onChange`. That
+ * keeps the style coupled to the competition rather than to the browser.
+ *
+ * Returns `[mapStyleId, setMapStyleId, availableStyles]`. Re-validates the
+ * id whenever provider tokens change (tokens arrive async on Electron
+ * start) so a previously-chosen Mapy.com style will be re-selected once
+ * the Mapy API key lands.
+ *
+ * Ported from `AirQ-Sports/frontend/shared/src/hooks/useMapStyle.js`,
+ * adapted to externally-owned state.
+ */
+type UseMapStyleArgs = {
+  preferredId: string | null | undefined
+  onChange: (id: MapStyleId) => void
+}
+
+export function useMapStyle({ preferredId, onChange }: UseMapStyleArgs): [MapStyleId, (id: MapStyleId) => void, MapStyleDef[]] {
+  // Re-run on any token change (subscribeToProvider fires on setProviderToken)
+  const tokenSnapshot = useSyncExternalStore(subscribeToProvider, getProviderSnapshot, getProviderSnapshot)
+
+  const availableStyles = getAvailableStyles()
+  const availableIds = new Set(availableStyles.map(s => s.id))
+
+  const pickDefault = useCallback((): MapStyleId => {
+    if (preferredId && availableIds.has(preferredId as MapStyleId)) return preferredId as MapStyleId
+    if (availableStyles.length > 0) return availableStyles[0].id
+    return 'osm-classic'
+  }, [availableIds, availableStyles, preferredId])
+
+  const [mapStyleId, _setMapStyleId] = useState<MapStyleId>(() => pickDefault())
+  const preferredRef = useRef<string | null | undefined>(preferredId)
+
+  // When tokens change (Mapbox/Mapy key arrives async) or the stored
+  // preference updates, re-resolve. Intentionally narrow deps so we re-run
+  // on token bump — not on every render.
+  useEffect(() => {
+    preferredRef.current = preferredId
+    if (preferredId && availableIds.has(preferredId as MapStyleId)) {
+      _setMapStyleId(preferredId as MapStyleId)
+    } else if (!availableIds.has(mapStyleId)) {
+      _setMapStyleId(pickDefault())
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tokenSnapshot, preferredId])
+
+  const setMapStyleId = useCallback((id: MapStyleId) => {
+    preferredRef.current = id
+    _setMapStyleId(id)
+    onChange(id)
+  }, [onChange])
+
+  return [mapStyleId, setMapStyleId, availableStyles]
+}

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -2,9 +2,8 @@ import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, use
 import MapGL, { Layer, Source, Marker, Popup } from 'react-map-gl/mapbox'
 import type { MapRef, MarkerDragEvent, MarkerEvent } from 'react-map-gl/mapbox'
 import type { GeoJSON, Geometry, Position } from 'geojson'
-import type { LngLatBoundsLike, LngLatLike } from 'mapbox-gl'
+import type { LngLatBoundsLike, LngLatLike, StyleSpecification } from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
-import type { MapProviderId, ProviderConfig } from './providers'
 import { useI18n } from '../contexts/I18nContext'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
@@ -27,9 +26,16 @@ export type MapProviderViewHandle = {
 }
 
 export const MapProviderView = forwardRef<MapProviderViewHandle, {
-  provider: MapProviderId
-  baseStyle: 'streets' | 'satellite'
-  providerConfig: ProviderConfig
+  /**
+   * Already-resolved Mapbox style: either a `mapbox://` URL, a
+   * hosted style JSON URL, or an inline `StyleSpecification` (raster
+   * or vector). The caller resolves this from the selected style id
+   * via `getStyleForId()` so the map doesn't need to know about the
+   * provider registry.
+   */
+  mapStyle: string | StyleSpecification
+  /** Mapbox access token — required for `mapbox://` styles, optional otherwise. */
+  mapboxAccessToken?: string
   geojsonOverlays?: Overlay[]
   markers?: readonly { id: string; lng: number; lat: number; name: string; label?: PhotoLabel }[]
   activeMarkerId?: string | null
@@ -44,9 +50,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   onMarkerLabelClear?: (id: string) => void
   groundMarkerProps?: GroundMarkerCallbacks
 }>(function MapProviderView(props, ref) {
-  const { baseStyle, providerConfig, geojsonOverlays } = props
+  const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
 
-  const styleUrl = providerConfig.styles[baseStyle]
   const { t } = useI18n()
 
   const mapRef = useRef<MapRef | null>(null)
@@ -167,10 +172,11 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     ref.fitBounds(bounds as LngLatBoundsLike, { padding: 40, maxZoom: 19, duration: 600 })
   }, [isMapLoaded, uploadedGeojson])
 
-  // Mapbox binding reads token via prop
-
   const isElectron = !!(typeof window !== 'undefined' && window.electronAPI?.isElectron)
-  const needsToken = !providerConfig.accessToken && typeof styleUrl === 'string' && styleUrl.startsWith('mapbox://')
+  // Only block the map when the currently selected style *needs* a Mapbox
+  // token we don't have. Non-mapbox styles (OSM, Mapy.cz, ESRI) work with
+  // no token, so we must not show the "configure token" wall for them.
+  const needsToken = !mapboxAccessToken && typeof mapStyle === 'string' && mapStyle.startsWith('mapbox://')
 
   useImperativeHandle(ref, () => ({
     async captureForPrint() {
@@ -207,14 +213,14 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
 
       return captureMapForPrint({
         bbox: bbox as [[number, number], [number, number]],
-        style: styleUrl,
-        accessToken: providerConfig.accessToken,
+        style: mapStyle,
+        accessToken: mapboxAccessToken,
         overlays: printOverlays,
         markers: printMarkers,
         groundMarkers: printGroundMarkers,
       })
     }
-  }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, styleUrl, providerConfig.accessToken])
+  }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken])
 
   if (needsToken) {
     return (
@@ -268,8 +274,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
 
   return (
     <MapGL
-      mapStyle={styleUrl}
-      mapboxAccessToken={providerConfig.accessToken}
+      mapStyle={mapStyle}
+      mapboxAccessToken={mapboxAccessToken}
       preserveDrawingBuffer
       initialViewState={{ longitude: 14.42076, latitude: 50.08804, zoom: 6 }}
       style={{ width: '100%', height: '100%' }}

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -1,5 +1,5 @@
 import mapboxgl from 'mapbox-gl'
-import type { LngLatBoundsLike } from 'mapbox-gl'
+import type { LngLatBoundsLike, StyleSpecification } from 'mapbox-gl'
 import type { GeoJSON } from 'geojson'
 import { groundMarkerSvgString } from '../components/GroundMarkerIcons'
 import type { GroundMarkerType, PhotoLabel } from '../types/markers'
@@ -28,7 +28,8 @@ type GroundMarkerPrintConfig = {
 
 type PrintOptions = {
   bbox: [[number, number], [number, number]] // [[minLng, minLat], [maxLng, maxLat]]
-  style: string
+  /** `mapbox://` URL, hosted style JSON URL, or an inline `StyleSpecification`. */
+  style: string | StyleSpecification
   accessToken?: string
   overlays: OverlayConfig[]
   markers: MarkerConfig[]
@@ -90,6 +91,13 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
       TIMEOUT_MS,
       'Map style load timed out'
     )
+
+    // Boost settlement/place labels so printed A4 maps have prominent town
+    // names (feedback 2026-04-18). This only affects vector Mapbox styles —
+    // raster styles (Mapy.cz, OSM, ESRI) bake labels into the tile image and
+    // can't be re-styled at render time, but Mapy.cz's default Czech label
+    // density is already strong enough.
+    boostSettlementLabels(map)
 
     // Fit to track bounds
     map.fitBounds(bbox as LngLatBoundsLike, { padding: PADDING, duration: 0 })
@@ -322,6 +330,37 @@ export function detectOrientation(bbox: [[number, number], [number, number]]) {
   const lngSpan = Math.abs(bbox[1][0] - bbox[0][0]) * Math.cos(midLat * Math.PI / 180)
   const latSpan = Math.abs(bbox[1][1] - bbox[0][1])
   return lngSpan >= latSpan ? A4_LANDSCAPE : A4_PORTRAIT
+}
+
+/**
+ * Vector Mapbox styles expose town / village labels as symbol layers whose
+ * ids contain "settlement" or "place". Bump their `text-size` by 1.8× and
+ * widen the halo so small towns don't disappear at print scale.
+ *
+ * Silent on raster styles (no matching layers). Silent on any layer whose
+ * existing `text-size` is an expression we can't multiply — better to leave
+ * it unchanged than throw and lose the whole print.
+ */
+function boostSettlementLabels(map: mapboxgl.Map): void {
+  const style = map.getStyle?.()
+  if (!style || !Array.isArray(style.layers)) return
+  const targetIdFragments = ['settlement', 'place-label', 'place_label', 'town-label', 'city-label']
+  for (const layer of style.layers) {
+    if (layer.type !== 'symbol') continue
+    const id = String(layer.id)
+    if (!targetIdFragments.some(frag => id.includes(frag))) continue
+    try {
+      const curr = map.getLayoutProperty(id, 'text-size')
+      // Wrap the current value in a multiply expression so zoom-dependent
+      // ramps keep their shape — just scaled up.
+      const boosted = typeof curr === 'number' ? curr * 1.8 : ['*', 1.8, curr]
+      map.setLayoutProperty(id, 'text-size', boosted as unknown as number)
+      map.setPaintProperty(id, 'text-halo-width', 2)
+      map.setPaintProperty(id, 'text-halo-color', '#ffffff')
+    } catch {
+      // Layer may not support these properties on some custom styles — skip it.
+    }
+  }
 }
 
 export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -71,6 +71,12 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
   document.body.appendChild(container)
 
   if (accessToken) {
+    // Writes the Mapbox singleton directly instead of going through
+    // `setProviderToken` so this utility stays dep-free of the mapProviders
+    // module. The caller is expected to pass the same value the rest of the
+    // app uses (`getMapboxAccessToken()`), so this is normally a no-op write.
+    // If a caller ever passes a different value, the module-scoped
+    // `_tokens.mapbox` will briefly lag until the next `setProviderToken`.
     mapboxgl.accessToken = accessToken
   }
 
@@ -341,7 +347,7 @@ export function detectOrientation(bbox: [[number, number], [number, number]]) {
  * existing `text-size` is an expression we can't multiply — better to leave
  * it unchanged than throw and lose the whole print.
  */
-function boostSettlementLabels(map: mapboxgl.Map): void {
+export function boostSettlementLabels(map: mapboxgl.Map): void {
   const style = map.getStyle?.()
   if (!style || !Array.isArray(style.layers)) return
   const targetIdFragments = ['settlement', 'place-label', 'place_label', 'town-label', 'city-label']
@@ -349,16 +355,33 @@ function boostSettlementLabels(map: mapboxgl.Map): void {
     if (layer.type !== 'symbol') continue
     const id = String(layer.id)
     if (!targetIdFragments.some(frag => id.includes(frag))) continue
+
+    // Split the three property writes so a failure on one doesn't skip the
+    // others. Previously a single try/catch could leave a layer with boosted
+    // text but no halo, making small towns unreadable on satellite imagery.
+    let sizeBoosted = false
     try {
       const curr = map.getLayoutProperty(id, 'text-size')
-      // Wrap the current value in a multiply expression so zoom-dependent
-      // ramps keep their shape — just scaled up.
-      const boosted = typeof curr === 'number' ? curr * 1.8 : ['*', 1.8, curr]
-      map.setLayoutProperty(id, 'text-size', boosted as unknown as number)
+      if (curr === undefined) {
+        // Default Mapbox text-size applies; wrapping `undefined` in an
+        // expression ('*', 1.8, undefined) would produce an invalid spec.
+        // Skip rather than silently crashing the layer.
+      } else {
+        // Wrap existing value in a multiply expression so zoom-dependent
+        // ramps keep their shape — just scaled up.
+        const boosted = typeof curr === 'number' ? curr * 1.8 : ['*', 1.8, curr]
+        map.setLayoutProperty(id, 'text-size', boosted as unknown as number)
+        sizeBoosted = true
+      }
+    } catch (err) {
+      console.warn(`[mapCapture] boostSettlementLabels: text-size failed for layer "${id}":`, err)
+    }
+
+    try {
       map.setPaintProperty(id, 'text-halo-width', 2)
       map.setPaintProperty(id, 'text-halo-color', '#ffffff')
-    } catch {
-      // Layer may not support these properties on some custom styles — skip it.
+    } catch (err) {
+      console.warn(`[mapCapture] boostSettlementLabels: halo failed for layer "${id}" (size boosted: ${sizeBoosted}):`, err)
     }
   }
 }

--- a/frontend/map-corridors/src/vite-env.d.ts
+++ b/frontend/map-corridors/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_MAPBOX_TOKEN?: string
+  readonly VITE_MAPYCZ_TOKEN?: string
+  readonly VITE_MAPTILER_KEY?: string
+  readonly VITE_DESKTOP_BUILD?: string
+  readonly VITE_DEBUG_CORRIDORS?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/frontend/map-corridors/vite.config.ts
+++ b/frontend/map-corridors/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
+
+// Monorepo-wide env file sits at the repo root so Mapbox/Mapy tokens don't
+// have to be duplicated per sub-app. `envDir` points Vite there for both
+// `loadEnv()` (build-time reads) and `import.meta.env` injection.
+const ENV_DIR = path.resolve(__dirname, '../..')
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, ENV_DIR, '')
   return {
+    envDir: ENV_DIR,
     // For desktop (Electron) builds, use relative paths
     base: env.VITE_DESKTOP_BUILD === 'true' ? './' : '/map-corridors/',
     plugins: [react()],

--- a/frontend/photo-helper/vite.config.ts
+++ b/frontend/photo-helper/vite.config.ts
@@ -1,11 +1,17 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import path from 'node:path'
+
+// Shared `.env` at the monorepo root (same pattern as map-corridors) — keeps
+// Mapbox/Mapy tokens and other VITE_* vars in one place.
+const ENV_DIR = path.resolve(__dirname, '../..')
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, ENV_DIR, '')
   return {
+    envDir: ENV_DIR,
     // Ensure assets load correctly when hosted under /photo-helper/
     // For desktop (Electron) builds, use relative paths
     base: env.VITE_DESKTOP_BUILD === 'true' ? './' : (mode === 'production' ? '/photo-helper/' : '/'),


### PR DESCRIPTION
## Summary

Port the Mapy.com / Mapbox / OSM (CARTO) / ESRI **style selector** from the AirQ-Sports sibling repo so users can switch the base map freely — and so the printed A4 can show dense Czech town labels, which was the whole reason for this feedback request.

**Map Corridors**
- New `config/mapProviders.ts` with 6 styles across 2 categories (Streets: Mapy.com, Mapbox Streets, OSM/CARTO Voyager; Aerial: Mapbox Satellite, Mapy.com Aerial, ESRI). Token gating hides entries whose required key is missing; `useSyncExternalStore` drives re-renders when a key lands async.
- `components/MapStyleSelector.tsx` (MUI ButtonGroup with per-category dropdown arrow) + `hooks/useMapStyle.ts`. Replaces the old Streets/Satellite toggle.
- `MapProviderView` now takes a resolved \`mapStyle\` (URL or \`StyleSpecification\`) — \`providerConfig\` plumbing dropped.
- Session field \`baseStyle\` → \`mapStyleId\` with one-way migration from the legacy values.
- Printed A4: any symbol layer whose id matches \`settlement\` / \`place-label\` / \`town-label\` gets \`text-size × 1.8\` and a 2 px white halo. Raster styles (OSM/Mapy/ESRI) bake labels so they already read well; Mapy.com is now the primary street layer for Czech terrain.
- Raster styles declare a free MapLibre glyphs URL so our \`waypoints-labels\` / \`exact-points-labels\` symbol layers render on non-vector styles.

**Electron launcher**
- New \`Settings → Mapy.cz API klíč…\` dialog mirroring the existing Mapbox one, \`openMapySettings\` IPC.
- Dev-only \`v8CacheOptions: 'none'\` on the BrowserWindow + per-\`loadURL\` \`session.clearCache()\` — the prior stale-bundle episodes traced back to V8's code cache (separate from HTTP cache). Documented in \`.claude/skills/windows-app/SKILL.md\` under a new \"Known Issue\" section.

**Build config**
- Both sub-apps set \`envDir: <repo-root>\` so \`VITE_*\` vars in the monorepo-level \`.env\` reach both bundles.
- Per-app \`vite-env.d.ts\` declares the \`ImportMetaEnv\` shape.
- Switched all env reads to the direct \`import.meta.env.VITE_…\` form — the prior \`(import.meta as any)?.env?.VITE_…\` cast defeated Vite's static-replace regex and left literal \`\"VITE_MAPY_TOKEN\"\` lookups in the bundle (symptom: Mapy.com never appeared in the dropdown regardless of \`.env\` content).

**Race fix (Mapbox GL)**
- \`setProviderToken('mapbox', …)\` writes \`mapboxgl.accessToken\` **synchronously** into Mapbox GL's module-level singleton. react-map-gl mirrors its \`mapboxAccessToken\` prop into that singleton but with a one-microtask lag, which caused \`setStyle(mapbox://…)\` to throw \"An API access token is required\" when both the style and the token arrived in the same React batch.

## Test plan
- [x] \`pnpm --filter @airq/map-corridors vitest run\` — 99/99 pass (new \`mapProviders.test.ts\` covers gating, legacy id migration, API-key embedding, fallback-on-missing-token)
- [x] \`pnpm tsc --noEmit\` clean in both packages
- [ ] Manual Electron verification (run \`pnpm --filter @airq/desktop dev\`):
  - [ ] \`Settings → Mapbox Token…\` + \`Settings → Mapy.cz API klíč…\` dialogs both save and persist
  - [ ] Map dropdown shows both categories with arrows when ≥2 providers have keys
  - [ ] Switching Mapy.com ↔ Mapbox Streets ↔ OSM/CARTO works without style errors
  - [ ] Printed A4 on a Mapbox vector style shows noticeably larger city names
  - [ ] \`.env\` in repo root with \`VITE_MAPBOX_TOKEN\` + \`VITE_MAPYCZ_TOKEN\` prewires both dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)