### PR TITLE
sec(deps): bump legacy Pillow + python-multipart (3 HIGH CVEs) #patch

### DIFF
--- a/legacy/backend/photo-helper/requirements.txt
+++ b/legacy/backend/photo-helper/requirements.txt
@@ -3,8 +3,10 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 
 # File handling and image processing
-Pillow==10.3.0
-python-multipart==0.0.18
+# Pillow 12.2.0 fixes CVE-2026-25990 (OOB write via PSD) + CVE-2026-40192 (FITS gzip decompression bomb)
+Pillow==12.2.0
+# python-multipart 0.0.22 fixes CVE-2026-24486 (arbitrary file write via path traversal)
+python-multipart==0.0.22
 
 # PDF generation
 reportlab==4.0.7


### PR DESCRIPTION
## Summary

- Bumps `legacy/backend/photo-helper/requirements.txt` to CVE-patched versions flagged by `trivy fs --severity HIGH,CRITICAL`:
  - **Pillow** `10.3.0` → `12.2.0` — closes CVE-2026-25990 (OOB write via crafted PSD) and CVE-2026-40192 (FITS gzip decompression bomb).
  - **python-multipart** `0.0.18` → `0.0.22` — closes CVE-2026-24486 (arbitrary file write via path traversal).

The legacy Python backend is **not referenced** by the shipped Electron app (product moved to OPFS client-side storage), so there's no runtime impact on end users. Fix is for repo hygiene: keeps `trivy` + Dependabot clean and keeps the legacy tree buildable for anyone who wants to spin it up for reference.

## Test plan

- [x] `trivy fs --severity HIGH,CRITICAL` — 0 findings across repo
- [ ] No functional test: code path not executed by Electron bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)