### PR TITLE
fix(deps): patch protocol-buffers-schema prototype pollution #patch

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
       "yaml@<1.10.3": "^1.10.3",
       "brace-expansion@<1.1.13": "^1.1.13",
       "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3",
-      "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5"
+      "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5",
+      "protocol-buffers-schema@<3.6.1": "3.6.1"
     }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   brace-expansion@<1.1.13: ^1.1.13
   brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
   brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
+  protocol-buffers-schema@<3.6.1: 3.6.1
 
 importers:
 
@@ -3232,8 +3233,8 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protocol-buffers-schema@3.6.0:
-    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -7978,7 +7979,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protocol-buffers-schema@3.6.0: {}
+  protocol-buffers-schema@3.6.1: {}
 
   pump@3.0.4:
     dependencies:
@@ -8072,7 +8073,7 @@ snapshots:
 
   resolve-protobuf-schema@2.1.0:
     dependencies:
-      protocol-buffers-schema: 3.6.0
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.11:
     dependencies:


### PR DESCRIPTION
## Summary

Closes the last remaining open Dependabot alert on `main` — **GHSA-j452-xhg8-qg39 / CVE-2026-5758**: prototype pollution in `protocol-buffers-schema@3.6.0` (medium severity, CVSS 6.5).

The vulnerable package is pulled in transitively:

```
protocol-buffers-schema@3.6.0
└─ resolve-protobuf-schema@2.1.0
  └─ pbf@4.0.1
    ├─ @mapbox/vector-tile@2.0.4 → maplibre-gl / mapbox-gl
    ├─ @maplibre/vt-pbf@4.3.0 → maplibre-gl
    └─ mapbox-gl@3.19.1 → @airq/map-corridors
```

Upstream maintainers (maplibre-gl, mapbox-gl, pbf) have not yet cut releases that bump their transitive constraint past `3.6.0`, so this patches via a **pnpm workspace override** following the pattern already used in `frontend/package.json` for `yaml`, `brace-expansion`, etc.

## Changes

- `frontend/package.json` — added `"protocol-buffers-schema@<3.6.1": "3.6.1"` to `pnpm.overrides`. Uses exact-version replacement per the CLAUDE.md supply-chain rule (axios 2026-03-31 incident).
- `frontend/pnpm-lock.yaml` — regenerated via `pnpm install`.

## Test plan

- [x] `pnpm why protocol-buffers-schema` reports a single `3.6.1` install.
- [x] `npx tsc --noEmit` clean in `photo-helper` and `map-corridors`.
- [x] `npx vitest run` — photo-helper **54/54**, map-corridors **132/132**.
- [ ] Confirm Dependabot closes alert #141 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)