### PR TITLE
feat: round-1 user feedback (photo helper + map corridors) #minor

### DIFF
--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -717,6 +717,46 @@ ipcMain.handle('save-map-image', async (event, base64Data) => {
   return filePath;
 });
 
+// Save KML text via native save dialog. Prefers the directory the source
+// KML was imported from (users care about their own project folders, not
+// our internal competition storage). Falls back to the competition folder
+// and finally to ~/Documents (feedback 2026-04-23).
+ipcMain.handle('save-kml', async (event, kmlText, fileName, defaultDir, competitionId) => {
+  if (typeof kmlText !== 'string' || kmlText.length === 0) {
+    throw new Error('Invalid KML content');
+  }
+  if (kmlText.length > 50 * 1024 * 1024) {
+    throw new Error('KML content too large');
+  }
+  const safeName = (typeof fileName === 'string' && fileName.trim())
+    ? sanitizeFileName(fileName).replace(/\.kml$/i, '') + '.kml'
+    : `corridors_export_${new Date().toISOString().slice(0, 10)}.kml`;
+
+  let startDir = null;
+  // 1) User-supplied directory (the folder they imported the KML from)
+  if (typeof defaultDir === 'string' && defaultDir.trim()) {
+    try {
+      const abs = path.resolve(defaultDir);
+      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
+    } catch { /* ignore and fall through */ }
+  }
+  // 2) Competition folder fallback
+  if (!startDir && typeof competitionId === 'string' && competitionId.trim()) {
+    const compDir = path.join(getPhotoSessionsPath(), 'competitions', sanitizeFileName(competitionId));
+    if (fs.existsSync(compDir)) startDir = compDir;
+  }
+  // 3) Documents fallback
+  if (!startDir) startDir = app.getPath('documents');
+
+  const { filePath } = await dialog.showSaveDialog(mainWindow, {
+    defaultPath: path.join(startDir, safeName),
+    filters: [{ name: 'KML files', extensions: ['kml'] }]
+  });
+  if (!filePath) return null;
+  fs.writeFileSync(filePath, kmlText, 'utf8');
+  return filePath;
+});
+
 // Show Mapbox token dialog - single window with input field
 async function showMapboxTokenDialog() {
   const currentToken = getConfigValue('mapboxToken') || '';

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -224,7 +224,7 @@ function createWindow() {
 }
 
 // Handle navigation between apps
-ipcMain.handle('navigate-to-app', async (event, appName, competitionId) => {
+safeHandle('navigate-to-app', async (event, appName, competitionId) => {
   let qs = competitionId ? `?competitionId=${encodeURIComponent(competitionId)}` : '';
   if (competitionId) {
     const index = readCompetitionsIndex();
@@ -257,38 +257,38 @@ ipcMain.handle('navigate-to-app', async (event, appName, competitionId) => {
 });
 
 // Handle going back to home
-ipcMain.handle('go-home', () => {
+safeHandle('go-home', () => {
   mainWindow.loadURL('app://home/index.html');
 });
 
 // Handle config get/set
-ipcMain.handle('get-config', (event, key) => {
+safeHandle('get-config', (event, key) => {
   return getConfigValue(key);
 });
 
-ipcMain.handle('set-config', (event, key, value) => {
+safeHandle('set-config', (event, key, value) => {
   return setConfigValue(key, value);
 });
 
 // Open external URL in default browser
-ipcMain.handle('open-external', (event, url) => {
+safeHandle('open-external', (event, url) => {
   if (url && (url.startsWith('https://') || url.startsWith('http://'))) {
     shell.openExternal(url);
   }
 });
 
 // Open Mapbox token settings dialog
-ipcMain.handle('open-mapbox-settings', () => {
+safeHandle('open-mapbox-settings', () => {
   showMapboxTokenDialog();
 });
 
 // Open Mapy.cz token settings dialog (Czech maps provider)
-ipcMain.handle('open-mapy-settings', () => {
+safeHandle('open-mapy-settings', () => {
   showMapyTokenDialog();
 });
 
 // Update menu language
-ipcMain.handle('set-menu-locale', (event, locale) => {
+safeHandle('set-menu-locale', (event, locale) => {
   // Map 'cz' to 'cs' for internal use
   const menuLocale = locale === 'cz' ? 'cs' : locale;
   if (menuLocale !== currentMenuLocale) {
@@ -316,6 +316,49 @@ function sanitizeFileName(input) {
   return truncated.length > 0 ? truncated : 'file';
 }
 
+// Defense-in-depth: only accept IPC from frames WE created.
+// - `app://` = our main window + sub-apps (photo-helper, map-corridors)
+// - `data:text/html` = our own Mapbox/Mapy settings dialogs (modal
+//   BrowserWindows we open with a controlled CSP'd template)
+//
+// `will-navigate` restricts navigation to `app://`, and
+// `setWindowOpenHandler` blocks http(s) window.open from the renderer,
+// so only frames we control can reach these checks. A compromised
+// renderer cannot conjure a fresh data: or app: frame.
+function isTrustedSender(event) {
+  try {
+    const url = event && event.senderFrame && event.senderFrame.url;
+    if (typeof url !== 'string') return false;
+    return url.startsWith('app://') || url.startsWith('data:text/html');
+  } catch {
+    return false;
+  }
+}
+
+// Wrap every `ipcMain.handle` so untrusted senders are rejected before the
+// handler body runs. Channel name is included in the error so the renderer
+// can distinguish a sender-gate failure from a regular handler error.
+function safeHandle(channel, fn) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    if (!isTrustedSender(event)) {
+      throw new Error(`${channel}: untrusted sender`);
+    }
+    return fn(event, ...args);
+  });
+}
+
+// Reject UNC paths (`\\server\share`, `//server/share`) and Windows device
+// namespaces (`\\?\`, `\\.\`). A renderer-supplied UNC path as the save
+// dialog's `defaultPath` would pre-point the user at an attacker-controlled
+// SMB share — one click later the KML lands remote and, on Windows, an
+// NTLMv2 handshake to the attacker's host leaks the user's hashed creds.
+function isSafeStartDir(abs) {
+  if (typeof abs !== 'string' || !abs) return false;
+  if (/^(\\\\|\/\/)/.test(abs)) return false;
+  if (/^\\\\[?.]\\/.test(abs)) return false;
+  return true;
+}
+
 // Ensure a directory exists
 function ensureDir(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -336,7 +379,7 @@ function validateStoragePath(inputPath) {
 }
 
 // Initialize storage - create root and sessions directories
-ipcMain.handle('storage-init', async () => {
+safeHandle('storage-init', async () => {
   const rootPath = getPhotoSessionsPath();
   const sessionsPath = path.join(rootPath, 'sessions');
 
@@ -347,7 +390,7 @@ ipcMain.handle('storage-init', async () => {
 });
 
 // Ensure session directories exist
-ipcMain.handle('storage-ensure-session-dirs', async (event, sessionId) => {
+safeHandle('storage-ensure-session-dirs', async (event, sessionId) => {
   const sessionsPath = path.join(getPhotoSessionsPath(), 'sessions');
   const dirPath = path.join(sessionsPath, sanitizeFileName(sessionId));
   const photosPath = path.join(dirPath, 'photos');
@@ -359,7 +402,7 @@ ipcMain.handle('storage-ensure-session-dirs', async (event, sessionId) => {
 });
 
 // Write JSON to a file
-ipcMain.handle('storage-write-json', async (event, dirPath, name, data) => {
+safeHandle('storage-write-json', async (event, dirPath, name, data) => {
   const safeDirPath = validateStoragePath(dirPath);
   const safeName = sanitizeFileName(name);
   const filePath = path.join(safeDirPath, safeName);
@@ -367,7 +410,7 @@ ipcMain.handle('storage-write-json', async (event, dirPath, name, data) => {
 });
 
 // Read JSON from a file
-ipcMain.handle('storage-read-json', async (event, dirPath, name) => {
+safeHandle('storage-read-json', async (event, dirPath, name) => {
   const safeDirPath = validateStoragePath(dirPath);
   const safeName = sanitizeFileName(name);
   const filePath = path.join(safeDirPath, safeName);
@@ -383,7 +426,7 @@ ipcMain.handle('storage-read-json', async (event, dirPath, name) => {
 });
 
 // Save a photo file (receives base64 data)
-ipcMain.handle('storage-save-photo', async (event, photosPath, photoId, base64Data, mimeType) => {
+safeHandle('storage-save-photo', async (event, photosPath, photoId, base64Data, mimeType) => {
   const safePhotosPath = validateStoragePath(photosPath);
   const safeId = sanitizeFileName(photoId);
 
@@ -401,7 +444,7 @@ ipcMain.handle('storage-save-photo', async (event, photosPath, photoId, base64Da
 });
 
 // Get a photo as base64
-ipcMain.handle('storage-get-photo', async (event, photosPath, photoId) => {
+safeHandle('storage-get-photo', async (event, photosPath, photoId) => {
   const safePhotosPath = validateStoragePath(photosPath);
   const safeId = sanitizeFileName(photoId);
 
@@ -428,7 +471,7 @@ ipcMain.handle('storage-get-photo', async (event, photosPath, photoId) => {
 });
 
 // Delete a photo file
-ipcMain.handle('storage-delete-photo', async (event, photosPath, photoId) => {
+safeHandle('storage-delete-photo', async (event, photosPath, photoId) => {
   const safePhotosPath = validateStoragePath(photosPath);
   const safeId = sanitizeFileName(photoId);
 
@@ -445,7 +488,7 @@ ipcMain.handle('storage-delete-photo', async (event, photosPath, photoId) => {
 });
 
 // Clear a directory (remove all contents)
-ipcMain.handle('storage-clear-directory', async (event, dirPath) => {
+safeHandle('storage-clear-directory', async (event, dirPath) => {
   const safeDirPath = validateStoragePath(dirPath);
   if (fs.existsSync(safeDirPath)) {
     const entries = fs.readdirSync(safeDirPath, { withFileTypes: true });
@@ -461,7 +504,7 @@ ipcMain.handle('storage-clear-directory', async (event, dirPath) => {
 });
 
 // Delete a session directory
-ipcMain.handle('storage-delete-session', async (event, sessionId) => {
+safeHandle('storage-delete-session', async (event, sessionId) => {
   const sessionsPath = path.join(getPhotoSessionsPath(), 'sessions');
   const sessionPath = path.join(sessionsPath, sanitizeFileName(sessionId));
 
@@ -471,7 +514,7 @@ ipcMain.handle('storage-delete-session', async (event, sessionId) => {
 });
 
 // Get a directory handle (create if needed)
-ipcMain.handle('storage-get-directory', async (event, parentPath, name, create) => {
+safeHandle('storage-get-directory', async (event, parentPath, name, create) => {
   const safeParentPath = validateStoragePath(parentPath);
   const safeName = sanitizeFileName(name);
   const dirPath = path.join(safeParentPath, safeName);
@@ -486,7 +529,7 @@ ipcMain.handle('storage-get-directory', async (event, parentPath, name, create) 
 });
 
 // List directory contents
-ipcMain.handle('storage-list-directory', async (event, dirPath) => {
+safeHandle('storage-list-directory', async (event, dirPath) => {
   const safeDirPath = validateStoragePath(dirPath);
   if (!fs.existsSync(safeDirPath)) {
     return [];
@@ -500,7 +543,7 @@ ipcMain.handle('storage-list-directory', async (event, dirPath) => {
 });
 
 // Get storage statistics
-ipcMain.handle('storage-get-stats', async () => {
+safeHandle('storage-get-stats', async () => {
   try {
     const rootPath = getPhotoSessionsPath();
 
@@ -574,12 +617,12 @@ function writeCompetitionsIndex(index) {
 }
 
 // List all competitions
-ipcMain.handle('competition-list', async () => {
+safeHandle('competition-list', async () => {
   return readCompetitionsIndex();
 });
 
 // Create a new competition
-ipcMain.handle('competition-create', async (event, name) => {
+safeHandle('competition-create', async (event, name) => {
   const id = `comp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const now = new Date().toISOString();
   const index = readCompetitionsIndex();
@@ -636,7 +679,7 @@ ipcMain.handle('competition-create', async (event, name) => {
 });
 
 // Set active competition
-ipcMain.handle('competition-set-active', async (event, id) => {
+safeHandle('competition-set-active', async (event, id) => {
   const index = readCompetitionsIndex();
   index.competitions.forEach(c => { c.isActive = (c.id === id); });
   const target = index.competitions.find(c => c.id === id);
@@ -650,7 +693,7 @@ ipcMain.handle('competition-set-active', async (event, id) => {
 });
 
 // Set discipline for a competition
-ipcMain.handle('competition-set-discipline', async (event, id, discipline) => {
+safeHandle('competition-set-discipline', async (event, id, discipline) => {
   if (discipline !== 'precision' && discipline !== 'rally') {
     throw new Error(`Invalid discipline: ${discipline}`);
   }
@@ -666,7 +709,7 @@ ipcMain.handle('competition-set-discipline', async (event, id, discipline) => {
 });
 
 // Delete a competition
-ipcMain.handle('competition-delete', async (event, id) => {
+safeHandle('competition-delete', async (event, id) => {
   const index = readCompetitionsIndex();
   const target = index.competitions.find(c => c.id === id);
   if (!target) {
@@ -700,7 +743,7 @@ ipcMain.handle('competition-delete', async (event, id) => {
 });
 
 // Save map print image via native save dialog
-ipcMain.handle('save-map-image', async (event, base64Data) => {
+safeHandle('save-map-image', async (event, base64Data) => {
   if (typeof base64Data !== 'string' || base64Data.length === 0) {
     throw new Error('Invalid image data');
   }
@@ -721,7 +764,7 @@ ipcMain.handle('save-map-image', async (event, base64Data) => {
 // KML was imported from (users care about their own project folders, not
 // our internal competition storage). Falls back to the competition folder
 // and finally to ~/Documents (feedback 2026-04-23).
-ipcMain.handle('save-kml', async (event, kmlText, fileName, defaultDir, competitionId) => {
+safeHandle('save-kml', async (event, kmlText, fileName, defaultDir, competitionId) => {
   if (typeof kmlText !== 'string' || kmlText.length === 0) {
     throw new Error('Invalid KML content');
   }
@@ -733,11 +776,16 @@ ipcMain.handle('save-kml', async (event, kmlText, fileName, defaultDir, competit
     : `corridors_export_${new Date().toISOString().slice(0, 10)}.kml`;
 
   let startDir = null;
-  // 1) User-supplied directory (the folder they imported the KML from)
-  if (typeof defaultDir === 'string' && defaultDir.trim()) {
+  // 1) User-supplied directory (the folder they imported the KML from).
+  //    Length-clamp before `path.resolve`/`statSync` so a pathological input
+  //    can't stall the main process, and reject UNC/device-namespace paths
+  //    that bypass drive sandboxing.
+  if (typeof defaultDir === 'string' && defaultDir.trim() && defaultDir.length <= 4096) {
     try {
       const abs = path.resolve(defaultDir);
-      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
+      if (isSafeStartDir(abs) && fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
+        startDir = abs;
+      }
     } catch { /* ignore and fall through */ }
   }
   // 2) Competition folder fallback

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron');
+const { contextBridge, ipcRenderer, webUtils } = require('electron');
 
 // Expose protected methods that allow the renderer process to use
 // ipcRenderer without exposing the entire object
@@ -36,6 +36,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Save map print image via native save dialog
   saveMapImage: (base64Data) => ipcRenderer.invoke('save-map-image', base64Data),
+
+  // Save KML text via native save dialog. The renderer passes the directory
+  // the source KML was imported from (see `getPathForFile`) so the export
+  // dialog lands in the user's own project folder (feedback 2026-04-23).
+  saveKml: (kmlText, fileName, defaultDir, competitionId) =>
+    ipcRenderer.invoke('save-kml', kmlText, fileName, defaultDir, competitionId),
+
+  // Resolve the full filesystem path of a File picked / dropped in the
+  // renderer. Electron 32+ removed `File.path`; webUtils replaces it.
+  // Returns '' if the File has no disk backing (e.g. generated Blob).
+  getPathForFile: (file) => {
+    try { return webUtils.getPathForFile(file) || ''; } catch { return ''; }
+  },
 
   // Check if running in Electron
   isElectron: true,

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -16,6 +16,7 @@ import { appendFeaturesToKML } from './utils/kmlMerge'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { parseDisciplineFromSearch } from './utils/parseDiscipline'
 import { MapStyleSelector } from './components/MapStyleSelector'
+import { GROUND_MARKER_ICON } from './components/GroundMarkerIcons'
 import { useMapStyle } from './hooks/useMapStyle'
 import {
   getStyleForId,
@@ -241,59 +242,117 @@ function App() {
     return res
   }, [session?.leftSegments, session?.rightSegments, session?.exactPoints])
 
-  // Compute per-marker distance info (NM) if inside a corridor
-  const markerDistanceNmById = useMemo(() => {
-    const out: Record<string, number | null> = {}
-    const NM = 1852
-    for (const m of markers) {
-      let found: number | null = null
-      for (const c of corridorPolygons) {
-        const [minLng, minLat, maxLng, maxLat] = c.bbox
-        if (m.lng < minLng || m.lng > maxLng || m.lat < minLat || m.lat > maxLat) continue
-        try {
-          const pt = turfPoint([m.lng, m.lat])
-          const poly = turfPolygon([c.ring])
-          if (booleanPointInPolygon(pt, poly)) {
-            if (c.startCoord) {
-              const meters = calculateDistance([c.startCoord[0], c.startCoord[1], 0], [m.lng, m.lat, 0])
-              const nm = Math.round((meters / NM) * 100) / 100
-              found = nm
-            } else {
-              found = null
-            }
-            break
+  // For each { id, lng, lat } find the containing corridor (if any); fall
+  // back to the corridor whose startCoord is closest. Without the fallback
+  // the answer sheet left distances blank whenever a marker drifted outside
+  // the polygon by even a metre (feedback 2026-04-23).
+  const matchPointsToCorridors = useCallback(
+    (pts: ReadonlyArray<{ id: string; lng: number; lat: number }>) => {
+      const out: Record<string, { startCoord?: [number, number]; startName: string } | null> = {}
+      for (const m of pts) {
+        let match: typeof corridorPolygons[number] | null = null
+        for (const c of corridorPolygons) {
+          const [minLng, minLat, maxLng, maxLat] = c.bbox
+          if (m.lng < minLng || m.lng > maxLng || m.lat < minLat || m.lat > maxLat) continue
+          try {
+            const pt = turfPoint([m.lng, m.lat])
+            const poly = turfPolygon([c.ring])
+            if (booleanPointInPolygon(pt, poly)) { match = c; break }
+          } catch {}
+        }
+        if (!match && corridorPolygons.length) {
+          let bestD2 = Infinity
+          for (const c of corridorPolygons) {
+            if (!c.startCoord) continue
+            const dx = c.startCoord[0] - m.lng
+            const dy = c.startCoord[1] - m.lat
+            const d2 = dx * dx + dy * dy
+            if (d2 < bestD2) { bestD2 = d2; match = c }
           }
-        } catch {}
+        }
+        out[m.id] = match ? { startCoord: match.startCoord, startName: match.startName } : null
       }
-      out[m.id] = found
-    }
-    return out
-  }, [markers, corridorPolygons])
+      return out
+    },
+    [corridorPolygons],
+  )
+
+  const markerCorridorMatchById = useMemo(
+    () => matchPointsToCorridors(markers),
+    [markers, matchPointsToCorridors],
+  )
+  // Ground markers (FAI signs) use the same corridor-matching as photo
+  // markers so the answer sheet can list them with distance + from-TP
+  // (feedback 2026-04-23: user saw only photo letters, no signs).
+  const groundMarkerCorridorMatchById = useMemo(
+    () => matchPointsToCorridors(groundMarkers),
+    [groundMarkers, matchPointsToCorridors],
+  )
+
+  const computeDistancesNm = useCallback(
+    (
+      pts: ReadonlyArray<{ id: string; lng: number; lat: number }>,
+      matches: Record<string, { startCoord?: [number, number]; startName: string } | null>,
+    ) => {
+      const out: Record<string, number | null> = {}
+      const NM = 1852
+      for (const m of pts) {
+        const match = matches[m.id]
+        if (!match || !match.startCoord) { out[m.id] = null; continue }
+        const meters = calculateDistance([match.startCoord[0], match.startCoord[1], 0], [m.lng, m.lat, 0])
+        out[m.id] = Math.round((meters / NM) * 100) / 100
+      }
+      return out
+    },
+    [],
+  )
+  const markerDistanceNmById = useMemo(
+    () => computeDistancesNm(markers, markerCorridorMatchById),
+    [markers, markerCorridorMatchById, computeDistancesNm],
+  )
+  const groundMarkerDistanceNmById = useMemo(
+    () => computeDistancesNm(groundMarkers, groundMarkerCorridorMatchById),
+    [groundMarkers, groundMarkerCorridorMatchById, computeDistancesNm],
+  )
 
   const markerFromTpById = useMemo(() => {
     const out: Record<string, string | null> = {}
     for (const m of markers) {
-      let start: string | null = null
-      for (const c of corridorPolygons) {
-        const [minLng, minLat, maxLng, maxLat] = c.bbox
-        if (m.lng < minLng || m.lng > maxLng || m.lat < minLat || m.lat > maxLat) continue
-        try {
-          const pt = turfPoint([m.lng, m.lat])
-          const poly = turfPolygon([c.ring])
-          if (booleanPointInPolygon(pt, poly)) {
-            start = c.startName || null
-            break
-          }
-        } catch {}
-      }
-      out[m.id] = start
+      const match = markerCorridorMatchById[m.id]
+      out[m.id] = match ? (match.startName || null) : null
     }
     return out
-  }, [markers, corridorPolygons])
+  }, [markers, markerCorridorMatchById])
+  const groundMarkerFromTpById = useMemo(() => {
+    const out: Record<string, string | null> = {}
+    for (const m of groundMarkers) {
+      const match = groundMarkerCorridorMatchById[m.id]
+      out[m.id] = match ? (match.startName || null) : null
+    }
+    return out
+  }, [groundMarkers, groundMarkerCorridorMatchById])
+
+  // Directory the KML was imported from. Passed to Electron's save-kml
+  // handler so the Export dialog opens in the user's own project folder
+  // instead of our internal photo-sessions directory (feedback 2026-04-23).
+  const [importedKmlDir, setImportedKmlDir] = useState<string | null>(null)
 
   const onFiles = useCallback(async (files: File[]) => {
     const file = files[0]
     if (!file) return
+    // Capture the source directory for Electron-side save-kml default. Only
+    // works inside the desktop app; browser uploads have no disk path.
+    try {
+      const api = (window as any)?.electronAPI
+      if (api && typeof api.getPathForFile === 'function') {
+        const fullPath: string = api.getPathForFile(file) || ''
+        if (fullPath) {
+          const sepIdx = Math.max(fullPath.lastIndexOf('\\'), fullPath.lastIndexOf('/'))
+          const dir = sepIdx > 0 ? fullPath.slice(0, sepIdx) : ''
+          if (dir) setImportedKmlDir(dir)
+        }
+      }
+    } catch { /* non-fatal */ }
     // Store original KML text for export
     const fileText = await file.text()
     await saveOriginalKmlText(file.name.toLowerCase().endsWith('.kml') ? fileText : '')
@@ -311,7 +370,10 @@ function App() {
         leftSegments: leftSegments && leftSegments.length ? ({ type: 'FeatureCollection', features: leftSegments } as any) : null,
         rightSegments: rightSegments && rightSegments.length ? ({ type: 'FeatureCollection', features: rightSegments } as any) : null,
       })
-    } catch {
+    } catch (err) {
+      // Never silently drop everything — users previously lost corridors and
+      // TP markers with no visible hint (feedback 2026-04-23: 16-section race).
+      console.error('buildPreciseCorridorsAndGates failed on upload:', err)
       await setComputedData({ geojson: parsed, gates: null, points: null, exactPoints: null, leftSegments: null, rightSegments: null })
     }
   }, [saveOriginalKmlText, effectiveConfig, setComputedData])
@@ -333,7 +395,8 @@ function App() {
         leftSegments: leftSegments && leftSegments.length ? ({ type: 'FeatureCollection', features: leftSegments } as any) : null,
         rightSegments: rightSegments && rightSegments.length ? ({ type: 'FeatureCollection', features: rightSegments } as any) : null,
       })
-    } catch {
+    } catch (err) {
+      console.error('buildPreciseCorridorsAndGates failed on recompute:', err)
       setComputedData({ geojson: input, gates: null, points: null, exactPoints: null, leftSegments: null, rightSegments: null })
     } finally {
       lastComputeSigRef.current = { geojson: input, discipline: effectiveDiscipline, use1NmAfterSp }
@@ -456,8 +519,20 @@ function App() {
       }
     }
     const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, 'corridors_export', { groundMarkerIcons })
+    // Prefer the Electron save dialog when running in the desktop app so the
+    // dialog defaults to the folder the source KML was imported from
+    // (feedback 2026-04-23 — users don't care about our internal storage).
+    const api = (window as any)?.electronAPI
+    if (api && typeof api.saveKml === 'function') {
+      try {
+        await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
+        return
+      } catch (err) {
+        console.error('electronAPI.saveKml failed, falling back to browser download:', err)
+      }
+    }
     downloadKML(mergedKml, 'corridors_export.kml')
-  }, [markers, groundMarkers, loadOriginalKmlText, t])
+  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir])
 
   const handlePrintMap = useCallback(async () => {
     if (!mapRef.current) return
@@ -516,15 +591,36 @@ function App() {
     const container = answerSheetRef.current
     if (!container) return
     const html = container.innerHTML
-    const w = window.open('', '_blank', 'noopener,noreferrer')
-    if (!w) return
-    try { (w as any).opener = null } catch {}
-    const styles = `@page { size: A4 portrait; margin: 12mm; } body { font-family: Arial, sans-serif; color: #111; } table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid #999; padding: 6px 8px; font-size: 12px; } th { background: #f2f2f2; text-align: left; }`
-    w.document.write(`<!doctype html><html><head><meta charset="utf-8"><title>${t('app.title')} - ${t('sheet.print')}</title><style>${styles}</style></head><body>${html}</body></html>`)
-    w.document.close()
-    try { w.focus() } catch {}
-    try { w.print() } catch {}
-    try { w.close() } catch {}
+    // `window.open()` + `w.print()` was racy in Electron — the new BrowserWindow
+    // was often closed before the print dialog fired (feedback 2026-04-23).
+    // A hidden iframe with `srcdoc` stays attached to the same webContents,
+    // fires `onload` reliably, and prints the iframe's document directly.
+    const styles = `@page { size: A4 portrait; margin: 12mm; } body { font-family: Arial, sans-serif; color: #111; margin: 0; } table { border-collapse: collapse; width: 100%; } th, td { border: 1px solid #999; padding: 6px 8px; font-size: 12px; text-align: left; vertical-align: middle; } th { background: #f2f2f2; } svg { display: inline-block; vertical-align: middle; }`
+    const docHtml = `<!doctype html><html><head><meta charset="utf-8"><title>${t('app.title')} - ${t('sheet.print')}</title><style>${styles}</style></head><body>${html}</body></html>`
+    const iframe = document.createElement('iframe')
+    iframe.setAttribute('aria-hidden', 'true')
+    iframe.style.cssText = 'position:fixed;right:0;bottom:0;width:0;height:0;border:0;visibility:hidden;'
+    iframe.srcdoc = docHtml
+    const cleanup = () => {
+      try { iframe.remove() } catch {}
+    }
+    iframe.onload = () => {
+      const win = iframe.contentWindow
+      if (!win) { cleanup(); return }
+      // Print dialog is modal; run it on a microtask so onload resolves first.
+      setTimeout(() => {
+        try {
+          win.focus()
+          win.print()
+        } catch (err) {
+          console.error('Answer-sheet print failed:', err)
+        }
+        // Give Electron a moment to present / dismiss the print dialog before
+        // the iframe gets torn down.
+        setTimeout(cleanup, 800)
+      }, 0)
+    }
+    document.body.appendChild(iframe)
   }, [t])
 
   // Marker callbacks passed to map.
@@ -765,6 +861,36 @@ function App() {
               return (
                 <TableRow key={L} hover>
                   <TableCell>{L}</TableCell>
+                  <TableCell>{dist != null ? dist.toFixed(2) : ''}</TableCell>
+                  <TableCell>{from}</TableCell>
+                </TableRow>
+              )
+            })}
+            {/* Ground markers (FAI signs) in order of placement. User asked
+                for signs in the answer sheet, not only photo letters
+                (feedback 2026-04-23). */}
+            {groundMarkers.length > 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  sx={{ bgcolor: 'grey.100', fontWeight: 600, fontSize: 13, py: 0.5 }}
+                >
+                  {t('sheet.signs')}
+                </TableCell>
+              </TableRow>
+            )}
+            {groundMarkers.map((gm, idx) => {
+              const Icon = GROUND_MARKER_ICON[gm.type]
+              const dist = groundMarkerDistanceNmById[gm.id]
+              const from = groundMarkerFromTpById[gm.id] || ''
+              return (
+                <TableRow key={gm.id} hover>
+                  <TableCell sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <Typography component="span" sx={{ fontSize: 13, color: 'text.secondary', minWidth: 18 }}>
+                      {idx + 1}.
+                    </Typography>
+                    {Icon ? <Icon size={20} /> : <Typography component="span">{gm.type}</Typography>}
+                  </TableCell>
                   <TableCell>{dist != null ? dist.toFixed(2) : ''}</TableCell>
                   <TableCell>{from}</TableCell>
                 </TableRow>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -26,8 +26,8 @@ import {
   getMapboxAccessToken,
   type MapStyleId,
 } from './config/mapProviders'
-import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
 import { calculateDistance } from './corridors/segments'
+import { matchPointsToCorridors as matchPointsToCorridorsPure } from './corridors/matchPoints'
 import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
 import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
@@ -242,38 +242,12 @@ function App() {
     return res
   }, [session?.leftSegments, session?.rightSegments, session?.exactPoints])
 
-  // For each { id, lng, lat } find the containing corridor (if any); fall
-  // back to the corridor whose startCoord is closest. Without the fallback
-  // the answer sheet left distances blank whenever a marker drifted outside
-  // the polygon by even a metre (feedback 2026-04-23).
+  // Delegates to the pure helper in `corridors/matchPoints.ts` (unit-tested
+  // there). Kept as a hook-level `useCallback` so the `useMemo`s below get a
+  // stable reference.
   const matchPointsToCorridors = useCallback(
-    (pts: ReadonlyArray<{ id: string; lng: number; lat: number }>) => {
-      const out: Record<string, { startCoord?: [number, number]; startName: string } | null> = {}
-      for (const m of pts) {
-        let match: typeof corridorPolygons[number] | null = null
-        for (const c of corridorPolygons) {
-          const [minLng, minLat, maxLng, maxLat] = c.bbox
-          if (m.lng < minLng || m.lng > maxLng || m.lat < minLat || m.lat > maxLat) continue
-          try {
-            const pt = turfPoint([m.lng, m.lat])
-            const poly = turfPolygon([c.ring])
-            if (booleanPointInPolygon(pt, poly)) { match = c; break }
-          } catch {}
-        }
-        if (!match && corridorPolygons.length) {
-          let bestD2 = Infinity
-          for (const c of corridorPolygons) {
-            if (!c.startCoord) continue
-            const dx = c.startCoord[0] - m.lng
-            const dy = c.startCoord[1] - m.lat
-            const d2 = dx * dx + dy * dy
-            if (d2 < bestD2) { bestD2 = d2; match = c }
-          }
-        }
-        out[m.id] = match ? { startCoord: match.startCoord, startName: match.startName } : null
-      }
-      return out
-    },
+    (pts: ReadonlyArray<{ id: string; lng: number; lat: number }>) =>
+      matchPointsToCorridorsPure(pts, corridorPolygons),
     [corridorPolygons],
   )
 
@@ -525,11 +499,17 @@ function App() {
     const api = (window as any)?.electronAPI
     if (api && typeof api.saveKml === 'function') {
       try {
+        // `null` means user cancelled the native save dialog; no duplicate
+        // browser download in that case. Any thrown error is a real failure
+        // (disk full, 50 MB cap, bad IPC) — surface it to the user instead
+        // of silently falling through to a browser download, which would
+        // land in the default Downloads folder behind the user's back.
         await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
-        return
       } catch (err) {
-        console.error('electronAPI.saveKml failed, falling back to browser download:', err)
+        console.error('electronAPI.saveKml failed:', err)
+        alert(err instanceof Error ? err.message : t('errors.exportFailed'))
       }
+      return
     }
     downloadKML(mergedKml, 'corridors_export.kml')
   }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir])
@@ -613,7 +593,11 @@ function App() {
           win.focus()
           win.print()
         } catch (err) {
+          // Match `handlePrintMap` — user should see why print failed, not
+          // just a silent no-op. Common triggers: no printer configured,
+          // iframe contentWindow detached, kiosk-restricted environment.
           console.error('Answer-sheet print failed:', err)
+          alert(err instanceof Error ? err.message : t('errors.printFailed'))
         }
         // Give Electron a moment to present / dismiss the print dialog before
         // the iframe gets torn down.

--- a/frontend/map-corridors/src/__tests__/kmlExport.test.ts
+++ b/frontend/map-corridors/src/__tests__/kmlExport.test.ts
@@ -35,6 +35,33 @@ describe('appendFeaturesToKML', () => {
     expect(result).not.toContain('- photo')
   })
 
+  it('photo markers carry a dedicated photoMarker style with the yellow-pushpin icon', () => {
+    // Feedback 2026-04-23: the shared `labelPoint` style rendered as a grey
+    // placeholder in some KML viewers (missing <Icon href>). Regression
+    // would silently bring that bug back — assert both the style definition
+    // and the per-placemark styleUrl.
+    const kml = loadFixtureText('RED.kml')
+    const markers: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        properties: { name: 'A', role: 'track_photos', label: 'A' },
+        geometry: { type: 'Point', coordinates: [14.0, 50.0] },
+      }],
+    }
+    const result = appendFeaturesToKML(kml, markers, 'test_export')
+    // Assert the href we emit, scoped to the photoMarker style block so the
+    // fixture's own (pre-existing, out-of-our-control) http:// references
+    // don't pollute the check.
+    const photoStyle = result.match(/<Style id="photoMarker">[\s\S]*?<\/Style>/)
+    expect(photoStyle).not.toBeNull()
+    expect(photoStyle![0]).toContain('ylw-pushpin.png')
+    expect(photoStyle![0]).toContain('https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png')
+    expect(photoStyle![0]).not.toContain('<href>http://')
+    // The photo marker references it via styleUrl.
+    expect(result).toMatch(/<styleUrl>#photoMarker<\/styleUrl>/)
+  })
+
   it('does NOT include corridor features when only markers are passed', () => {
     const kml = loadFixtureText('RED.kml')
     const markers: FeatureCollection = {

--- a/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
+++ b/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  matchPointsToCorridors,
+  NEAREST_CORRIDOR_MAX_METERS,
+  type CorridorPolygon,
+} from '../corridors/matchPoints'
+
+// A unit-sized square polygon centered at (lng, lat).
+function squareCorridor(
+  lng: number,
+  lat: number,
+  halfWidth: number,
+  startName: string,
+  startCoord: [number, number] = [lng, lat],
+  name = startName,
+): CorridorPolygon {
+  const ring: [number, number][] = [
+    [lng - halfWidth, lat - halfWidth],
+    [lng + halfWidth, lat - halfWidth],
+    [lng + halfWidth, lat + halfWidth],
+    [lng - halfWidth, lat + halfWidth],
+    [lng - halfWidth, lat - halfWidth],
+  ]
+  return {
+    name,
+    ring,
+    bbox: [lng - halfWidth, lat - halfWidth, lng + halfWidth, lat + halfWidth],
+    startName,
+    startCoord,
+  }
+}
+
+describe('matchPointsToCorridors', () => {
+  it('matches a point inside a polygon to that corridor (containment wins)', () => {
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.05, 'SP'),
+      squareCorridor(15.0, 50.0, 0.05, 'TP1'),
+    ]
+    const out = matchPointsToCorridors([{ id: 'a', lng: 14.01, lat: 50.01 }], corridors)
+    expect(out.a?.startName).toBe('SP')
+  })
+
+  it('returns null for containment AND empty corridor list', () => {
+    const out = matchPointsToCorridors([{ id: 'a', lng: 14.0, lat: 50.0 }], [])
+    expect(out.a).toBeNull()
+  })
+
+  it('falls back to the nearest startCoord when no polygon contains the point', () => {
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.05, 'SP'),
+      squareCorridor(15.0, 50.0, 0.05, 'TP1'),
+    ]
+    // Far outside every polygon but closer to TP1
+    const out = matchPointsToCorridors([{ id: 'far', lng: 14.95, lat: 50.0 }], corridors)
+    expect(out.far?.startName).toBe('TP1')
+  })
+
+  it('lat-aware distance: at 50° N a point 0.05° east-of-TP is closer than 0.05° north-of-SP', () => {
+    // Naive Δlng²+Δlat² (degrees) would tie. With cos(50°) ≈ 0.643 scaling on
+    // Δlng, the east-of-TP candidate wins because 0.05° lng at 50° N is only
+    // ~3.6 km versus 0.05° lat = 5.5 km.
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.001, 'SP'),
+      squareCorridor(15.0, 50.0, 0.001, 'TP1'),
+    ]
+    // Point just above SP by 0.05°, and 0.95° east of SP (0.05° east of TP1)
+    const out = matchPointsToCorridors([{ id: 'p', lng: 15.05, lat: 50.0 }], corridors)
+    expect(out.p?.startName).toBe('TP1')
+  })
+
+  it('skips corridors without startCoord in the fallback loop', () => {
+    // TP1 at (14.6, 50) is ~28.6 km east of the probed point (14.05, 50),
+    // well inside the 50 km fallback cap. SP has no startCoord so it is
+    // silently skipped by the fallback loop.
+    const withStart = squareCorridor(14.6, 50.0, 0.01, 'TP1')
+    const withoutStart: CorridorPolygon = { ...squareCorridor(14.0, 50.0, 0.01, 'SP'), startCoord: undefined }
+    const out = matchPointsToCorridors([{ id: 'p', lng: 14.05, lat: 50.0 }], [withStart, withoutStart])
+    expect(out.p?.startName).toBe('TP1')
+  })
+
+  it('returns null when every corridor lacks startCoord AND no polygon contains the point', () => {
+    const c: CorridorPolygon = { ...squareCorridor(14.0, 50.0, 0.01, 'SP'), startCoord: undefined }
+    const out = matchPointsToCorridors([{ id: 'p', lng: 20.0, lat: 50.0 }], [c])
+    expect(out.p).toBeNull()
+  })
+
+  it('bbox-outside fast path keeps nearest-fallback usable (no polygon evaluated)', () => {
+    // Both corridors' bboxes exclude the point, so the containment loop
+    // never calls booleanPointInPolygon; result comes from the fallback.
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.001, 'SP'),
+      squareCorridor(15.0, 50.0, 0.001, 'TP1'),
+    ]
+    const out = matchPointsToCorridors([{ id: 'p', lng: 15.5, lat: 50.0 }], corridors)
+    expect(out.p?.startName).toBe('TP1')
+  })
+
+  describe('error logging on malformed rings (no silent swallow)', () => {
+    let err: ReturnType<typeof vi.spyOn>
+    beforeEach(() => { err = vi.spyOn(console, 'error').mockImplementation(() => {}) })
+    afterEach(() => { err.mockRestore() })
+
+    it('logs console.error when a ring is too small for turfPolygon to parse', () => {
+      // A 2-point ring inside the bbox forces turfPolygon to throw.
+      const bad: CorridorPolygon = {
+        name: 'bad',
+        ring: [[14.0, 50.0], [14.01, 50.01]],
+        bbox: [14.0, 50.0, 14.01, 50.01],
+        startName: 'SP',
+        startCoord: [14.0, 50.0],
+      }
+      matchPointsToCorridors([{ id: 'p', lng: 14.005, lat: 50.005 }], [bad])
+      expect(err).toHaveBeenCalled()
+      const firstArgs = err.mock.calls[0]
+      expect(firstArgs[0]).toMatch(/matchPointsToCorridors/)
+      expect(firstArgs[1]).toBe('SP')
+    })
+
+    it('falls back to nearest-start after a ring throws, not silently null', () => {
+      const bad: CorridorPolygon = {
+        name: 'bad',
+        ring: [[14.0, 50.0], [14.01, 50.01]],
+        bbox: [13.9, 49.9, 14.1, 50.1],
+        startName: 'SP',
+        startCoord: [14.0, 50.0],
+      }
+      const good = squareCorridor(15.0, 50.0, 0.05, 'TP1')
+      const out = matchPointsToCorridors(
+        [{ id: 'p', lng: 14.0, lat: 50.0 }],
+        [bad, good],
+      )
+      // Containment throws and is logged; fallback picks the nearest startCoord.
+      // Both corridors have startCoords; the `bad` one's is right at the point.
+      expect(err).toHaveBeenCalled()
+      expect(out.p?.startName).toBe('SP')
+    })
+  })
+
+  it('returns a result for every input point in input order', () => {
+    // Three close points (inside / near) plus one wildly far point that
+    // exceeds the 50 km fallback cap and should therefore return null.
+    const corridors = [squareCorridor(14.0, 50.0, 0.05, 'SP')]
+    const out = matchPointsToCorridors(
+      [
+        { id: 'a', lng: 14.01, lat: 50.01 },
+        { id: 'b', lng: 14.02, lat: 50.02 },
+        { id: 'far', lng: 20.0, lat: 60.0 },
+      ],
+      corridors,
+    )
+    expect(Object.keys(out).sort()).toEqual(['a', 'b', 'far'])
+    expect(out.a?.startName).toBe('SP')
+    expect(out.b?.startName).toBe('SP')
+    expect(out.far).toBeNull()
+  })
+
+  describe('50 km sanity cap on the nearest-startCoord fallback', () => {
+    it('exposes the cap constant as 50 000 metres', () => {
+      expect(NEAREST_CORRIDOR_MAX_METERS).toBe(50_000)
+    })
+
+    it('accepts a fallback match 30 km away', () => {
+      // Point 30 km due north of SP startCoord (0.27° lat ≈ 30.0 km).
+      const corridors = [squareCorridor(14.0, 50.0, 0.001, 'SP')]
+      const out = matchPointsToCorridors(
+        [{ id: 'p', lng: 14.0, lat: 50.27 }],
+        corridors,
+      )
+      expect(out.p?.startName).toBe('SP')
+    })
+
+    it('rejects a fallback match 60 km away — returns null, not a wrong attribution', () => {
+      // Point 60 km due north of SP startCoord (0.54° lat ≈ 60.1 km).
+      const corridors = [squareCorridor(14.0, 50.0, 0.001, 'SP')]
+      const out = matchPointsToCorridors(
+        [{ id: 'p', lng: 14.0, lat: 50.54 }],
+        corridors,
+      )
+      expect(out.p).toBeNull()
+    })
+
+    it('containing polygon wins regardless of distance — cap only applies to fallback', () => {
+      // 200 km × 200 km polygon centered on (14, 50). A marker inside this
+      // massive polygon must match even if its center startCoord is >50 km
+      // from some other reference — the cap only kicks in for fallback.
+      const big = squareCorridor(14.0, 50.0, 1.0, 'SP')
+      const out = matchPointsToCorridors(
+        [{ id: 'inside', lng: 14.9, lat: 50.9 }],
+        [big],
+      )
+      expect(out.inside?.startName).toBe('SP')
+    })
+  })
+})

--- a/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
+++ b/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
@@ -11,6 +11,7 @@ import {
   DISCIPLINE_CONFIGS,
 } from '../corridors/preciseCorridor'
 import type { LonLatAlt } from '../corridors/segments'
+import { isTpGatePerpendicular, extractAllSegments } from '../corridors/segments'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,6 +58,16 @@ describe('findNamedPoints', () => {
     expect(r.tps).toHaveLength(2)
   })
 
+  it('recognizes "CP n" Control Points as turning points (rally KMLs from some authoring tools)', () => {
+    const gj = makeGeoJSON([
+      makePointFeature('CP 1', 14.1, 50.1),
+      makePointFeature('CP 15', 14.15, 50.15),
+      makePointFeature('CP10', 14.10, 50.10),
+    ])
+    const r = findNamedPoints(gj)
+    expect(r.tps.map(t => t.name).sort()).toEqual(['CP 1', 'CP 15', 'CP10'].sort())
+  })
+
   it('does NOT recognize SC gates as TPs', () => {
     const gj = makeGeoJSON([
       makePointFeature('SC 01', 14, 50),
@@ -86,6 +97,53 @@ describe('findNamedPoints', () => {
     ])
     const r = findNamedPoints(gj)
     expect(r.tps.map(t => t.name)).toEqual(['TP1', 'TP 2', 'TP 3'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1b. isTpGatePerpendicular — length-based discriminator between TP gate
+// perpendiculars and legitimate 3-vertex track legs. Regression for the
+// 16-section race that hid corridors + TP markers (feedback 2026-04-23).
+// ---------------------------------------------------------------------------
+
+describe('isTpGatePerpendicular', () => {
+  it('flags a short 3-coord perpendicular (~1 km wide) as a gate', () => {
+    const perp: LonLatAlt[] = [
+      [14.9950, 50.0000, 0],
+      [15.0000, 50.0000, 0],
+      [15.0050, 50.0000, 0],
+    ]
+    expect(isTpGatePerpendicular(perp)).toBe(true)
+  })
+
+  it('does NOT flag a long 3-vertex leg (~18 km) as a gate', () => {
+    const leg: LonLatAlt[] = [
+      [14.0, 50.0, 0],
+      [14.1, 50.05, 0],
+      [14.2, 50.1, 0],
+    ]
+    expect(isTpGatePerpendicular(leg)).toBe(false)
+  })
+
+  it('does NOT flag 2-coord or 4+-coord lines', () => {
+    expect(isTpGatePerpendicular([[14, 50], [15, 51]])).toBe(false)
+    expect(isTpGatePerpendicular([[14, 50], [14.1, 50], [14.2, 50], [14.3, 50]])).toBe(false)
+  })
+})
+
+describe('extractAllSegments with long 3-vertex legs', () => {
+  it('keeps 3-vertex track legs as segments instead of dropping them as gates', () => {
+    const course: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[14.0, 50.0], [14.05, 50.02], [14.1, 50.05]] } },
+        { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[14.1, 50.05], [14.15, 50.07], [14.2, 50.1]] } },
+        // plus a real gate perpendicular at TP1 (~1 km total)
+        { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: [[14.095, 50.045], [14.1, 50.05], [14.105, 50.055]] } },
+      ],
+    }
+    const segs = extractAllSegments(course)
+    expect(segs.length).toBe(2)
   })
 })
 

--- a/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
+++ b/frontend/map-corridors/src/__tests__/preciseCorridor.test.ts
@@ -129,6 +129,29 @@ describe('isTpGatePerpendicular', () => {
     expect(isTpGatePerpendicular([[14, 50], [15, 51]])).toBe(false)
     expect(isTpGatePerpendicular([[14, 50], [14.1, 50], [14.2, 50], [14.3, 50]])).toBe(false)
   })
+
+  // Boundary around the 3 km threshold — previously untested, a `<` vs `<=`
+  // regression would silently misclassify a true-3 km gate as a leg and
+  // reopen the 16-section-race bug.
+  it('boundary: 2.89 km perpendicular is classified as a gate (under 3 km)', () => {
+    // half = 0.013° lat ≈ 1.446 km (haversine, R=6371 km). Total ≈ 2.89 km.
+    const perp: LonLatAlt[] = [
+      [14.0, 49.987, 0],
+      [14.0, 50.000, 0],
+      [14.0, 50.013, 0],
+    ]
+    expect(isTpGatePerpendicular(perp)).toBe(true)
+  })
+
+  it('boundary: 3.11 km 3-vertex leg is NOT classified as a gate (over 3 km)', () => {
+    // half = 0.014° lat ≈ 1.557 km. Total ≈ 3.11 km — just above the cut-off.
+    const leg: LonLatAlt[] = [
+      [14.0, 49.986, 0],
+      [14.0, 50.000, 0],
+      [14.0, 50.014, 0],
+    ]
+    expect(isTpGatePerpendicular(leg)).toBe(false)
+  })
 })
 
 describe('extractAllSegments with long 3-vertex legs', () => {

--- a/frontend/map-corridors/src/config/mapProviders.ts
+++ b/frontend/map-corridors/src/config/mapProviders.ts
@@ -155,8 +155,8 @@ export const MAP_STYLE_IDS = [
   'mapy-basic',
   'mapbox-streets',
   'osm-classic',
-  'mapbox-satellite',
   'mapy-aerial',
+  'mapbox-satellite',
   'esri-satellite',
 ] as const
 
@@ -172,9 +172,10 @@ export type MapStyleDef = {
 }
 
 /**
- * Ordered by preference within each category. Mapy.com goes first in Streets
- * because its Czech city/town labels are much denser than Mapbox defaults —
- * which is the whole reason this selector exists (feedback 2026-04-18).
+ * Ordered by preference within each category. Mapy.com goes first in both
+ * categories — its Czech labels are much denser than the alternatives, and
+ * users asked for consistent positioning across the Map/Satellite menus
+ * (feedback 2026-04-23). Mapbox is the universal second choice.
  */
 export const MAP_STYLES: MapStyleDef[] = [
   // Streets
@@ -182,8 +183,8 @@ export const MAP_STYLES: MapStyleDef[] = [
   { id: 'mapbox-streets', label: 'Mapbox Streets', category: 'Streets', requiredToken: 'mapbox', getStyle: () => 'mapbox://styles/mapbox/streets-v12' },
   { id: 'osm-classic', label: 'OpenStreetMap', category: 'Streets', requiredToken: null, getStyle: () => osmClassicStyle },
   // Aerial
-  { id: 'mapbox-satellite', label: 'Mapbox Satellite', category: 'Aerial', requiredToken: 'mapbox', getStyle: () => 'mapbox://styles/mapbox/satellite-v9' },
   { id: 'mapy-aerial', label: 'Mapy.com Aerial', category: 'Aerial', requiredToken: 'mapy', getStyle: () => mapyAerialStyle() },
+  { id: 'mapbox-satellite', label: 'Mapbox Satellite', category: 'Aerial', requiredToken: 'mapbox', getStyle: () => 'mapbox://styles/mapbox/satellite-v9' },
   { id: 'esri-satellite', label: 'ESRI Satellite', category: 'Aerial', requiredToken: null, getStyle: () => esriSatelliteStyle },
 ]
 

--- a/frontend/map-corridors/src/corridors/matchPoints.ts
+++ b/frontend/map-corridors/src/corridors/matchPoints.ts
@@ -1,0 +1,84 @@
+import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
+import { calculateDistance } from './segments'
+
+export type CorridorPolygon = {
+  name: string
+  ring: [number, number][]
+  bbox: [number, number, number, number]
+  startName: string
+  startCoord?: [number, number]
+}
+
+export type PointForMatching = { id: string; lng: number; lat: number }
+export type CorridorMatch = { startCoord?: [number, number]; startName: string }
+
+/**
+ * Maximum haversine distance (metres) from a marker to the chosen
+ * fallback corridor's startCoord. Beyond this, "no attribution" is
+ * preferred over "plausible but wrong attribution" — a marker 60 km
+ * from every corridor almost certainly belongs to none of them, and
+ * surfacing a blank cell is less harmful to the competitor than
+ * printing a spurious "From TP" on the answer sheet.
+ */
+export const NEAREST_CORRIDOR_MAX_METERS = 50_000
+
+/**
+ * For each point, return the corridor that contains it. When no polygon
+ * contains the point, fall back to the corridor whose `startCoord` is
+ * closest — otherwise markers that drift outside the polygon by a metre
+ * would leave the answer sheet distance column blank (feedback 2026-04-23).
+ *
+ * Distance is measured in latitude-scaled degrees (`Δlng · cos(lat)`) so
+ * a marker at 50° N is not biased toward eastward corridors: 1° lng there
+ * is ~71 km while 1° lat is ~111 km. A naive `Δlng² + Δlat²` misattributes
+ * markers by ~35% in Central-European latitudes.
+ *
+ * Polygon evaluation errors are logged (not swallowed). A malformed ring
+ * coming out of `buildPreciseCorridorsAndGates` is a real bug — silent
+ * swallow is the exact pattern the 2026-04-23 feedback round fixed at the
+ * upload path; we apply the same discipline here.
+ */
+export function matchPointsToCorridors(
+  pts: ReadonlyArray<PointForMatching>,
+  corridorPolygons: ReadonlyArray<CorridorPolygon>,
+): Record<string, CorridorMatch | null> {
+  const out: Record<string, CorridorMatch | null> = {}
+  for (const m of pts) {
+    let match: CorridorPolygon | null = null
+    for (const c of corridorPolygons) {
+      const [minLng, minLat, maxLng, maxLat] = c.bbox
+      if (m.lng < minLng || m.lng > maxLng || m.lat < minLat || m.lat > maxLat) continue
+      try {
+        const pt = turfPoint([m.lng, m.lat])
+        const poly = turfPolygon([c.ring])
+        if (booleanPointInPolygon(pt, poly)) { match = c; break }
+      } catch (err) {
+        console.error('[matchPointsToCorridors] polygon eval failed for corridor', c.startName, err)
+      }
+    }
+    if (!match && corridorPolygons.length) {
+      const cosLat = Math.cos((m.lat * Math.PI) / 180) || 1e-9
+      let nearest: CorridorPolygon | null = null
+      let bestD2 = Infinity
+      for (const c of corridorPolygons) {
+        if (!c.startCoord) continue
+        const dx = (c.startCoord[0] - m.lng) * cosLat
+        const dy = c.startCoord[1] - m.lat
+        const d2 = dx * dx + dy * dy
+        if (d2 < bestD2) { bestD2 = d2; nearest = c }
+      }
+      // Accept the nearest only if it's within the sanity cap. Scaled-square
+      // distance is fine for picking the minimum, but the cap must be in
+      // real metres — haversine on the winner, not an approximation.
+      if (nearest && nearest.startCoord) {
+        const meters = calculateDistance(
+          [nearest.startCoord[0], nearest.startCoord[1], 0],
+          [m.lng, m.lat, 0],
+        )
+        if (meters <= NEAREST_CORRIDOR_MAX_METERS) match = nearest
+      }
+    }
+    out[m.id] = match ? { startCoord: match.startCoord, startName: match.startName } : null
+  }
+  return out
+}

--- a/frontend/map-corridors/src/corridors/preciseCorridor.ts
+++ b/frontend/map-corridors/src/corridors/preciseCorridor.ts
@@ -1,7 +1,7 @@
 import type { Feature, FeatureCollection, GeoJSON, LineString, Point, Position } from 'geojson'
 import { lineString, length as turfLength, getCoord, bearing as turfBearing, destination, point, nearestPointOnLine, lineIntersect } from '@turf/turf'
 import type { LonLatAlt, Segment } from './segments'
-import { calculateDistance, buildContinuousTrackWithSources } from './segments'
+import { calculateDistance, buildContinuousTrackWithSources, isTpGatePerpendicular } from './segments'
 
 const DEBUG = (import.meta as any)?.env?.VITE_DEBUG_CORRIDORS === 'true' || (import.meta as any)?.env?.VITE_DEBUG_CORRIDORS === '1'
 const log = (...args: any[]) => { if (DEBUG) console.log(...args) }
@@ -108,7 +108,11 @@ export function findNamedPoints(input: GeoJSON): { sp?: LonLatAlt, tps: Array<{ 
         const c = p.coordinates as LonLatAlt
         if (name === 'SP') out.sp = c
         else if (name === 'FP') out.fp = c
-        else if (/^TP\s?\d/i.test(name)) out.tps.push({ name, coord: c })
+        // Rally/Precision source KMLs name turning points as `TP n` or
+        // `CP n` (Control Point) depending on the authoring tool.
+        // Accept either prefix, optional space, one or more digits
+        // (e.g. `TP1`, `TP 1`, `TP10`, `CP 15`) — feedback 2026-04-23.
+        else if (/^(TP|CP)\s?\d+\b/i.test(name)) out.tps.push({ name, coord: c })
       }
     }
   }
@@ -401,7 +405,7 @@ function extractGateCenterCandidates(input: GeoJSON): Array<{ center: LonLatAlt,
       if (geom?.type === 'LineString') {
         const ls = geom as LineString
         const coords = ls.coordinates as LonLatAlt[]
-        if (coords.length === 3) {
+        if (isTpGatePerpendicular(coords)) {
           const center = coords[1]
           out.push({ center, line: lineString(coords as Position[]) })
         }
@@ -409,7 +413,7 @@ function extractGateCenterCandidates(input: GeoJSON): Array<{ center: LonLatAlt,
     } else if (g.type === 'LineString') {
       const ls = g as LineString
       const coords = ls.coordinates as LonLatAlt[]
-      if (coords.length === 3) {
+      if (isTpGatePerpendicular(coords)) {
         const center = coords[1]
         out.push({ center, line: lineString(coords as Position[]) })
       }

--- a/frontend/map-corridors/src/corridors/segments.ts
+++ b/frontend/map-corridors/src/corridors/segments.ts
@@ -26,6 +26,23 @@ export function isDashedConnectorLine(coords: LonLatAlt[]): boolean {
   return length < 500
 }
 
+/**
+ * A 3-coord LineString in this app's KMLs is almost always a TP gate
+ * perpendicular (left → center → right, ~2 km wide). But rally courses
+ * authored elsewhere sometimes express a straight-ish leg with 3 vertices
+ * (start → waypoint → end), and blindly dropping those hides the whole
+ * track for larger courses (user report 2026-04-23: 16-section race).
+ *
+ * Distinguish by total polyline length: gates are short (≤ 3 km). Real
+ * flight legs are always longer — Rally/Precision minimum leg length is
+ * well above this threshold.
+ */
+export function isTpGatePerpendicular(coords: LonLatAlt[]): boolean {
+  if (coords.length !== 3) return false
+  const total = calculateDistance(coords[0], coords[1]) + calculateDistance(coords[1], coords[2])
+  return total < 3000
+}
+
 export function extractAllSegments(input: GeoJSON): Segment[] {
   const segments: Segment[] = []
   let index = 0
@@ -39,13 +56,13 @@ export function extractAllSegments(input: GeoJSON): Segment[] {
       if (geom?.type === 'LineString') {
         const ls = geom as LineString
         const coords = ls.coordinates as LonLatAlt[]
-        if (coords.length === 3) return
+        if (isTpGatePerpendicular(coords)) return
         segments.push({ index: index++, coordinates: coords })
       }
     } else if (g.type === 'LineString') {
       const ls = g as LineString
       const coords = ls.coordinates as LonLatAlt[]
-      if (coords.length === 3) return
+      if (isTpGatePerpendicular(coords)) return
       segments.push({ index: index++, coordinates: coords })
     }
   }

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -66,6 +66,7 @@
     "photoLabel": "Označení fotky",
     "distance": "Vzdálenost",
     "fromTp": "Od TP",
+    "signs": "Pozemní znaky",
     "print": "Tisk"
   },
   "errors": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -76,6 +76,7 @@
     "setTokenWeb": "Přidejte svůj token do proměnné prostředí VITE_MAPBOX_TOKEN a restartujte aplikaci.",
     "getTokenLink": "Získejte zdarma token na mapbox.com →",
     "noOriginalKml": "Původní KML není k dispozici pro export",
+    "exportFailed": "Export KML selhal",
     "printFailed": "Tisk mapy selhal",
     "someGroundMarkersFailed": "Některé tvary pozemních značek nešlo exportovat do KML a zobrazí se jako výchozí žluté body: {{types}}"
   }

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -76,6 +76,7 @@
     "setTokenWeb": "Add your token to the VITE_MAPBOX_TOKEN environment variable and restart the app.",
     "getTokenLink": "Get a free token at mapbox.com →",
     "noOriginalKml": "Original KML file not available for export",
+    "exportFailed": "KML export failed",
     "printFailed": "Map print failed",
     "someGroundMarkersFailed": "Some ground-marker shapes could not be exported to KML and will appear as default yellow dots: {{types}}"
   }

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -66,6 +66,7 @@
     "photoLabel": "Photo label",
     "distance": "Distance",
     "fromTp": "From TP",
+    "signs": "Ground signs",
     "print": "Print"
   },
   "errors": {

--- a/frontend/map-corridors/src/utils/kmlMerge.ts
+++ b/frontend/map-corridors/src/utils/kmlMerge.ts
@@ -159,7 +159,7 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
   ensureStyle(
     xml,
     'photoMarker',
-    '<IconStyle><color>ff00ffff</color><scale>1.1</scale><Icon><href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href></Icon><hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/></IconStyle><LabelStyle><scale>0.9</scale></LabelStyle>',
+    '<IconStyle><color>ff00ffff</color><scale>1.1</scale><Icon><href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href></Icon><hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/></IconStyle><LabelStyle><scale>0.9</scale></LabelStyle>',
   )
 
   // Register one IconStyle per used ground-marker type (feedback 2026-04-18:

--- a/frontend/map-corridors/src/utils/kmlMerge.ts
+++ b/frontend/map-corridors/src/utils/kmlMerge.ts
@@ -151,6 +151,16 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
   // Ensure styles for appended content
   ensureStyle(xml, 'greenLine', '<LineStyle><color>ff00ff00</color><width>2</width></LineStyle>')
   ensureStyle(xml, 'labelPoint', '<IconStyle><color>ff00ffff</color><scale>0.8</scale></IconStyle><LabelStyle><scale>1</scale></LabelStyle>')
+  // Dedicated style for photo markers — explicit yellow-pushpin href so every
+  // KML viewer (Google Earth, Maps, mobile) shows the same pin the app and
+  // PNG export render. The default `labelPoint` style drops to a grey
+  // placeholder in some viewers because it lacks an `<Icon>` (feedback
+  // 2026-04-23: yellow pin missing from KML, but present in PNG).
+  ensureStyle(
+    xml,
+    'photoMarker',
+    '<IconStyle><color>ff00ffff</color><scale>1.1</scale><Icon><href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href></Icon><hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/></IconStyle><LabelStyle><scale>0.9</scale></LabelStyle>',
+  )
 
   // Register one IconStyle per used ground-marker type (feedback 2026-04-18:
   // KML should show the same shapes as screen + print, not just generic pins).
@@ -181,7 +191,11 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
       const name = typeof rawName === 'string' ? rawName : ((props as any).role || 'point')
       const role = (props as any).role as string | undefined
       const markerType = (props as any).markerType as string | undefined
-      const customStyleId = role === 'ground_markers' && markerType ? groundMarkerStyleIds.get(markerType) : undefined
+      const customStyleId = role === 'ground_markers' && markerType
+        ? groundMarkerStyleIds.get(markerType)
+        : role === 'track_photos'
+          ? 'photoMarker'
+          : undefined
       addPointPlacemark(xml, name, pt.coordinates as any, role, customStyleId, markerType)
     }
   }

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -594,6 +594,12 @@ function AppApi() {
             loading={loading}
             error={error}
             onFilesDropped={(setKey, files) => addPhotosToSet(files, setKey)}
+            /* Initial Rally drop can span 10-18 photos — distribute across
+               both sets instead of overflowing set1 invisibly. Precision stays
+               capped at 9 so single-set flow still applies. */
+            onInitialFilesDropped={isPrecision
+              ? (files) => addPhotosToSet(files, 'set1')
+              : (files) => addPhotosToTurningPoint(files)}
             onPhotoClick={handlePhotoClick}
             onPhotoUpdate={handlePhotoUpdate}
             onPhotoRemove={handlePhotoRemove}
@@ -944,6 +950,7 @@ function AppApi() {
                     <Box sx={{
                       flex: '1 1 65%', // Take 65% of width
                       display: 'flex',
+                      flexDirection: 'column',
                       alignItems: 'center',
                       justifyContent: 'center',
                       bgcolor: 'grey.50',
@@ -962,6 +969,22 @@ function AppApi() {
                         showOriginal={showOriginal}
                         circleMode={circleMode}
                       />
+                      {/* Filename caption under the photo — screen only. */}
+                      {selectedPhoto.photo.filename && (
+                        <Typography
+                          variant="caption"
+                          title={selectedPhoto.photo.filename}
+                          sx={{
+                            mt: 1.5,
+                            fontFamily: 'monospace',
+                            color: 'text.secondary',
+                            userSelect: 'text',
+                            '@media print': { display: 'none' },
+                          }}
+                        >
+                          {selectedPhoto.photo.filename}
+                        </Typography>
+                      )}
                     </Box>
 
                     {/* Right Controls */}

--- a/frontend/photo-helper/src/__tests__/distributeRallyDrop.test.ts
+++ b/frontend/photo-helper/src/__tests__/distributeRallyDrop.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { distributeRallyDrop } from '../utils/distributeRallyDrop';
+
+// Minimal File stand-in; distributeRallyDrop only uses `files.slice` and
+// `files.length`, never File's own API. Plain objects keep the test hermetic.
+function fakeFiles(n: number): File[] {
+  return Array.from({ length: n }, (_, i) => ({ name: `p${i}.jpg` } as unknown as File));
+}
+
+describe('distributeRallyDrop — landscape (9+9 = 18 cap)', () => {
+  it('splits 16 photos across the empty 9/9 grid as 9 + 7', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(16), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(9);
+    expect(r.toSet2).toHaveLength(7);
+    expect(r.maxTotal).toBe(18);
+  });
+
+  it('splits 10 photos as 9 + 1', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(10), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(9);
+    expect(r.toSet2).toHaveLength(1);
+  });
+
+  it('accepts exactly 18 photos (capacity boundary)', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(18), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(9);
+    expect(r.toSet2).toHaveLength(9);
+  });
+
+  it('rejects 19 photos in landscape (over cap)', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(19), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe('overflow');
+    expect(r.maxTotal).toBe(18);
+    expect(r.totalIfAdded).toBe(19);
+  });
+
+  it('respects partially-filled set1: set1Count=5 + drop 10 → 4 remaining to set1, 6 to set2', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(10), layoutMode: 'landscape', set1Count: 5, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(4);
+    expect(r.toSet2).toHaveLength(6);
+  });
+
+  it('set1 already full: drop 8 → 0 to set1, 8 to set2', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(8), layoutMode: 'landscape', set1Count: 9, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(0);
+    expect(r.toSet2).toHaveLength(8);
+  });
+
+  it('set1 over-full (data anomaly): clamps set1Remaining to 0 rather than negative-slicing', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(3), layoutMode: 'landscape', set1Count: 12, set2Count: 0,
+    });
+    // set1Count (12) > maxTotal (18) – files(3) = 15, so overflow check passes.
+    // Math.max(0, 9 - 12) = 0 → everything to set2.
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(0);
+    expect(r.toSet2).toHaveLength(3);
+  });
+});
+
+describe('distributeRallyDrop — portrait (10+10 = 20 cap)', () => {
+  it('splits 16 photos across the empty 10/10 grid as 10 + 6', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(16), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(10);
+    expect(r.toSet2).toHaveLength(6);
+  });
+
+  it('accepts exactly 20 photos (capacity boundary)', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(20), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(10);
+    expect(r.toSet2).toHaveLength(10);
+    expect(r.maxTotal).toBe(20);
+  });
+
+  it('rejects 21 photos in portrait (over cap)', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(21), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe('overflow');
+    expect(r.maxTotal).toBe(20);
+  });
+});
+
+describe('distributeRallyDrop — empty drops', () => {
+  it('zero files returns empty arrays and ok=true', () => {
+    const r = distributeRallyDrop({
+      files: fakeFiles(0), layoutMode: 'landscape', set1Count: 3, set2Count: 2,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.toSet1).toHaveLength(0);
+    expect(r.toSet2).toHaveLength(0);
+  });
+});

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -185,9 +185,10 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
         {gridSlots.map((slot) => {
           const isDragOver = dragOverIndex === slot.index;
           const isDragging = draggedIndex === slot.index;
-          
-          return <Paper
-              key={slot.id}
+
+          return (
+            <Box key={slot.id} sx={{ display: 'flex', flexDirection: 'column' }}>
+            <Paper
               elevation={slot.photo ? 2 : 0}
               draggable={slot.photo ? true : false}
               onDragStart={slot.photo ? (e) => handleDragStart(e, slot.index) : undefined}
@@ -306,7 +307,35 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                 maxFilesRemaining={maxFilesRemaining}
               />
             )}
-          </Paper>;
+            </Paper>
+            {/* Filename caption — screen only; the PDF generator rasterizes
+                canvases by data-photo-id, so this DOM text is never emitted
+                to print. Keeps the photo itself undisturbed for the
+                competitor's view (feedback 2026-04-23). */}
+            {slot.photo?.filename && (
+              <Typography
+                variant="caption"
+                title={slot.photo.filename}
+                sx={{
+                  mt: 0.5,
+                  px: 0.5,
+                  fontFamily: 'monospace',
+                  fontSize: '0.65rem',
+                  color: 'text.secondary',
+                  textAlign: 'center',
+                  lineHeight: 1.2,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  userSelect: 'text',
+                  '@media print': { display: 'none' },
+                }}
+              >
+                {slot.photo.filename}
+              </Typography>
+            )}
+            </Box>
+          );
         })}
         </Box>
       )}

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -13,6 +13,12 @@ interface TurningPointLayoutProps {
   loading: boolean;
   error: string | null;
   onFilesDropped: (setKey: 'set1' | 'set2', files: File[]) => void;
+  /**
+   * Called when the user makes the FIRST (empty-state) drop. In Rally this
+   * can be up to 18 photos and needs to span both sets — the caller is
+   * responsible for distributing. Falls back to set1 drop if omitted.
+   */
+  onInitialFilesDropped?: (files: File[]) => void;
   onPhotoClick: (photo: ApiPhoto, setKey: 'set1' | 'set2') => void;
   onPhotoUpdate: (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => void;
   onPhotoRemove: (setKey: 'set1' | 'set2', photoId: string) => void;
@@ -37,6 +43,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   loading,
   error,
   onFilesDropped,
+  onInitialFilesDropped,
   onPhotoClick,
   onPhotoUpdate,
   onPhotoRemove,
@@ -67,7 +74,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
             </Typography>
           </Box>
           <GridSizedDropZone
-            onFilesDropped={(files) => onFilesDropped('set1', files)}
+            onFilesDropped={(files) => (onInitialFilesDropped || ((f) => onFilesDropped('set1', f)))(files)}
             setName={t('turningpoint.photos')}
             maxPhotos={initialDropMax}
             loading={loading}

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -839,7 +839,27 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // Methods to align with AppApi expectations
     reorderPhotos,
     shufflePhotos,
-    addPhotosToTurningPoint: (async (_files: File[]) => {}) as any,
+    // Rally turning-point initial drop: distribute files across set1 (first 9)
+    // and set2 (remainder). Without this, a 10+ photo drop overflows the
+    // 9-slot set1 grid and later photos become invisible (feedback 2026-04-23).
+    addPhotosToTurningPoint: (async (files: File[]) => {
+      const session = currentCompetition?.session;
+      if (!session) return;
+      const layoutMode = (session as any).layoutMode === 'portrait' ? 'portrait' : 'landscape';
+      const gridCapacity = layoutMode === 'portrait' ? 10 : 9;
+      const maxTotal = gridCapacity * 2;
+      const set1Count = session.sets?.set1?.photos?.length ?? 0;
+      const set2Count = session.sets?.set2?.photos?.length ?? 0;
+      if (set1Count + set2Count + files.length > maxTotal) {
+        setError(`Cannot add ${files.length} photos. Maximum ${maxTotal} photos allowed (${set1Count + set2Count} already added).`);
+        return;
+      }
+      const set1Remaining = Math.max(0, gridCapacity - set1Count);
+      const toSet1 = files.slice(0, set1Remaining);
+      const toSet2 = files.slice(set1Remaining);
+      if (toSet1.length) await addPhotosToSet(toSet1, 'set1');
+      if (toSet2.length) await addPhotosToSet(toSet2, 'set2');
+    }) as any,
     refreshSession: (async () => {}) as any,
     applySettingToAll,
     

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -15,6 +15,7 @@ import { competitionService } from '../services/competitionService';
 import { migrationService } from '../services/migrationService';
 import { useI18n } from '../contexts/I18nContext';
 import { applySettingToAllInSession, type CanvasSetting } from '../utils/canvasStatePatch';
+import { distributeRallyDrop } from '../utils/distributeRallyDrop';
 
 export interface UseCompetitionSystemResult {
   // Current state
@@ -844,21 +845,24 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // 9-slot set1 grid and later photos become invisible (feedback 2026-04-23).
     addPhotosToTurningPoint: (async (files: File[]) => {
       const session = currentCompetition?.session;
-      if (!session) return;
-      const layoutMode = (session as any).layoutMode === 'portrait' ? 'portrait' : 'landscape';
-      const gridCapacity = layoutMode === 'portrait' ? 10 : 9;
-      const maxTotal = gridCapacity * 2;
-      const set1Count = session.sets?.set1?.photos?.length ?? 0;
-      const set2Count = session.sets?.set2?.photos?.length ?? 0;
-      if (set1Count + set2Count + files.length > maxTotal) {
-        setError(`Cannot add ${files.length} photos. Maximum ${maxTotal} photos allowed (${set1Count + set2Count} already added).`);
+      if (!session) {
+        // Asymmetric with the overflow branch below, which surfaces via
+        // `setError`. Silently dropping 10–18 files because the session is
+        // transiently null (initial load, switch-competition in flight) is
+        // the exact silent-failure pattern this PR set out to eliminate.
+        setError('No active competition. Create or select one before adding photos.');
         return;
       }
-      const set1Remaining = Math.max(0, gridCapacity - set1Count);
-      const toSet1 = files.slice(0, set1Remaining);
-      const toSet2 = files.slice(set1Remaining);
-      if (toSet1.length) await addPhotosToSet(toSet1, 'set1');
-      if (toSet2.length) await addPhotosToSet(toSet2, 'set2');
+      const layoutMode = (session as any).layoutMode === 'portrait' ? 'portrait' : 'landscape';
+      const set1Count = session.sets?.set1?.photos?.length ?? 0;
+      const set2Count = session.sets?.set2?.photos?.length ?? 0;
+      const result = distributeRallyDrop({ files, layoutMode, set1Count, set2Count });
+      if (!result.ok) {
+        setError(`Cannot add ${files.length} photos. Maximum ${result.maxTotal} photos allowed (${set1Count + set2Count} already added).`);
+        return;
+      }
+      if (result.toSet1.length) await addPhotosToSet(result.toSet1, 'set1');
+      if (result.toSet2.length) await addPhotosToSet(result.toSet2, 'set2');
     }) as any,
     refreshSession: (async () => {}) as any,
     applySettingToAll,

--- a/frontend/photo-helper/src/utils/distributeRallyDrop.ts
+++ b/frontend/photo-helper/src/utils/distributeRallyDrop.ts
@@ -1,0 +1,43 @@
+export type RallyLayoutMode = 'landscape' | 'portrait';
+
+export type DistributeRallyDropInput = {
+  files: File[];
+  layoutMode: RallyLayoutMode;
+  set1Count: number;
+  set2Count: number;
+};
+
+export type DistributeRallyDropResult =
+  | { ok: true; toSet1: File[]; toSet2: File[]; maxTotal: number }
+  | { ok: false; reason: 'overflow'; maxTotal: number; totalIfAdded: number };
+
+/**
+ * Distribute a Rally turning-point initial drop across set1 (first
+ * `gridCapacity` files) and set2 (the remainder). Without this the 9-slot
+ * set1 grid silently swallowed files 10+ on a 10–18-photo drop (feedback
+ * 2026-04-23).
+ *
+ * Grid capacity is 9 in landscape and 10 in portrait — `maxTotal` is
+ * therefore 18 or 20. Exceeding the total returns `ok: false` so the
+ * caller can surface a user-facing error instead of dropping files.
+ */
+export function distributeRallyDrop({
+  files,
+  layoutMode,
+  set1Count,
+  set2Count,
+}: DistributeRallyDropInput): DistributeRallyDropResult {
+  const gridCapacity = layoutMode === 'portrait' ? 10 : 9;
+  const maxTotal = gridCapacity * 2;
+  const totalIfAdded = set1Count + set2Count + files.length;
+  if (totalIfAdded > maxTotal) {
+    return { ok: false, reason: 'overflow', maxTotal, totalIfAdded };
+  }
+  const set1Remaining = Math.max(0, gridCapacity - set1Count);
+  return {
+    ok: true,
+    toSet1: files.slice(0, set1Remaining),
+    toSet2: files.slice(set1Remaining),
+    maxTotal,
+  };
+}


### PR DESCRIPTION
## Summary

Addresses the 7-item user feedback round plus two discovered bugs.

**Photo helper**
- Filename caption **below** each photo (grid + detail modal), hidden from PDF — leaves the photo fully visible (a)
- Rally TP initial drop now distributes across both sets (was capping at 9 invisibly) (e)

**Map corridors**
- Accept both `TP n` and `CP n` (Control Point) as turning points — fixes courses whose corridors were silently empty (c + RF RED.kml case)
- Length-based gate/leg discrimination (< 3 km = gate perpendicular) replaces the blanket 3-coord filter
- Non-silent error logging on corridor computation failure
- Answer sheet includes new "Ground signs / Pozemní znaky" section with SVG symbols + distance + from-TP (g)
- Nearest-corridor fallback so distances don't go blank when a marker drifts outside the polygon
- Print answer sheet uses hidden `srcdoc` iframe (was racy `window.open` in Electron)
- KML export: explicit yellow-pushpin style for photo markers (d); dialog defaults to the folder the source KML was imported from (b)
- Map/Satellite selector: Mapy.com first in both categories (f)

**Desktop**
- New IPC: `save-kml` (with preferred default dir) and `getPathForFile` bridge via Electron 32+ `webUtils`

## Test plan
- [x] `pnpm --filter @airq/map-corridors test` — 137/137 pass (+6 new)
- [x] `pnpm --filter @airq/photo-helper test` — 54/54 pass
- [x] `pnpm --filter @airq/map-corridors build` + `pnpm --filter @airq/photo-helper build` (via `pnpm --filter @airq/desktop build:apps`)
- [x] Manual: RED.kml + RF 2 RED.kml + RF RED.kml (CP-named) render corridors correctly in Electron
- [x] Manual: answer sheet print dialog appears with signs + distances
- [x] Manual: photo filename caption visible only in UI, not in PDF
- [ ] Manual: verify Rally TP drop of 16 photos distributes 9+7 across set1/set2

🤖 Generated with [Claude Code](https://claude.com/claude-code)