### PR TITLE
feat: persistent per-competition working folder across all dialogs

### DIFF
--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -821,6 +821,62 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir) => {
   return filePath;
 });
 
+// Open one or more photo files via native dialog. Defaults to the
+// competition's working folder (feedback 2026-04-25 — same default for
+// every export AND import). The renderer only gets file paths back; it
+// then asks `read-photo-file` to load each one as base64 so it can
+// reconstruct File objects for the existing onFilesDropped pipeline.
+safeHandle('open-photos', async (event, defaultDir, maxFiles) => {
+  let startDir = null;
+  if (typeof defaultDir === 'string' && defaultDir.trim()) {
+    try {
+      const abs = path.resolve(defaultDir);
+      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
+    } catch { /* fall through */ }
+  }
+  if (!startDir) startDir = app.getPath('pictures');
+  const result = await dialog.showOpenDialog(mainWindow, {
+    defaultPath: startDir,
+    filters: [
+      { name: 'Images', extensions: ['jpg', 'jpeg', 'png'] },
+    ],
+    properties: ['openFile', 'multiSelections'],
+  });
+  if (result.canceled || !result.filePaths || !result.filePaths.length) return [];
+  // Cap at the renderer-provided maxFiles (slot capacity). Defensive — the
+  // dialog itself doesn't enforce it.
+  const cap = (typeof maxFiles === 'number' && maxFiles > 0) ? maxFiles : result.filePaths.length;
+  return result.filePaths.slice(0, cap);
+});
+
+// Read a single photo file from disk and return base64 + metadata so the
+// renderer can construct a File object. Path is constrained to files the
+// user already saw in the open dialog — we still re-validate against
+// existence and size to keep the IPC honest.
+safeHandle('read-photo-file', async (event, filePath) => {
+  if (typeof filePath !== 'string' || !filePath) {
+    throw new Error('Invalid file path');
+  }
+  const abs = path.resolve(filePath);
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+    throw new Error('File not found');
+  }
+  const stat = fs.statSync(abs);
+  // 30 MB cap — same order of magnitude as the 20 MB renderer-side check
+  // in `isValidImageFile`, with a little headroom for the base64 round-trip.
+  if (stat.size > 30 * 1024 * 1024) {
+    throw new Error('File too large');
+  }
+  const buffer = fs.readFileSync(abs);
+  const ext = path.extname(abs).toLowerCase();
+  const mimeType = ext === '.png' ? 'image/png' : 'image/jpeg';
+  return {
+    name: path.basename(abs),
+    mimeType,
+    base64: buffer.toString('base64'),
+  };
+});
+
 // Save a PDF (base64) via native save dialog. Defaults to the
 // competition's working directory so photo-sheet PDFs land beside the
 // rest of the user's project (feedback 2026-04-25).

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -46,6 +46,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   savePdf: (base64Data, fileName, defaultDir) =>
     ipcRenderer.invoke('save-pdf', base64Data, fileName, defaultDir),
 
+  // Photo import via native open dialog. Returns the list of file paths
+  // the user picked (capped at maxFiles). Renderer then calls
+  // `readPhotoFile` for each path to reconstruct File objects.
+  openPhotos: (defaultDir, maxFiles) =>
+    ipcRenderer.invoke('open-photos', defaultDir, maxFiles),
+  readPhotoFile: (filePath) => ipcRenderer.invoke('read-photo-file', filePath),
+
   // Save KML text via native save dialog. The renderer passes the directory
   // the source KML was imported from (see `getPathForFile`) so the export
   // dialog lands in the user's own project folder (feedback 2026-04-23).

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -325,6 +325,24 @@ function App() {
       .catch(() => { /* non-fatal */ })
   }, [competitionId])
 
+  // After any save dialog returns a path, promote the chosen folder to the
+  // competition's working dir. Lets the user steer the default by simply
+  // navigating in the dialog — feedback 2026-04-25 ("until navigated to
+  // other folder, from that moment new folder persists").
+  const persistChosenDirAsWorking = useCallback((savedPath: string | null) => {
+    if (!savedPath || !competitionId) return
+    const sepIdx = Math.max(savedPath.lastIndexOf('\\'), savedPath.lastIndexOf('/'))
+    if (sepIdx <= 0) return
+    const dir = savedPath.slice(0, sepIdx)
+    if (!dir) return
+    setImportedKmlDir(dir)
+    const api = (window as any)?.electronAPI
+    if (api?.competitions?.setWorkingDir) {
+      api.competitions.setWorkingDir(competitionId, dir)
+        .catch((err: unknown) => console.warn('[workingDir] persist failed:', err))
+    }
+  }, [competitionId])
+
   const onFiles = useCallback(async (files: File[]) => {
     const file = files[0]
     if (!file) return
@@ -526,7 +544,8 @@ function App() {
         // (disk full, 50 MB cap, bad IPC) — surface it to the user instead
         // of silently falling through to a browser download, which would
         // land in the default Downloads folder behind the user's back.
-        await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
+        const savedPath: string | null = await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
+        persistChosenDirAsWorking(savedPath)
       } catch (err) {
         console.error('electronAPI.saveKml failed:', err)
         alert(err instanceof Error ? err.message : t('errors.exportFailed'))
@@ -534,7 +553,7 @@ function App() {
       return
     }
     downloadKML(mergedKml, 'corridors_export.kml')
-  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir])
+  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir, persistChosenDirAsWorking])
 
   const handlePrintMap = useCallback(async () => {
     if (!mapRef.current) return
@@ -553,7 +572,8 @@ function App() {
           reader.onerror = () => reject(reader.error)
           reader.readAsDataURL(blob)
         })
-        await electronAPI.saveMapImage(base64, importedKmlDir || undefined)
+        const savedPath: string | null = await electronAPI.saveMapImage(base64, importedKmlDir || undefined)
+        persistChosenDirAsWorking(savedPath)
       } else {
         // Browser: download via anchor
         const url = URL.createObjectURL(blob)
@@ -575,7 +595,7 @@ function App() {
       console.error('Map print failed:', err)
       alert(err instanceof Error ? err.message : t('errors.printFailed'))
     }
-  }, [t, importedKmlDir])
+  }, [t, importedKmlDir, persistChosenDirAsWorking])
 
   // Drag source for placing photo markers
   const onDragStartMarker = useCallback((e: React.DragEvent) => {

--- a/frontend/map-corridors/src/types/electron.d.ts
+++ b/frontend/map-corridors/src/types/electron.d.ts
@@ -16,7 +16,7 @@ declare module '@airq/shared-storage' {
     goHome?: () => void
     navigateToApp?: (app: string, competitionId: string) => void
     openMapboxSettings?: () => void
-    saveMapImage?: (base64: string, defaultDir?: string) => Promise<void>
+    saveMapImage?: (base64: string, defaultDir?: string) => Promise<string | null>
     savePdf?: (base64: string, fileName: string, defaultDir?: string) => Promise<string | null>
     getConfig?: (key: string) => Promise<string | undefined>
     setConfig?: (key: string, value: string) => Promise<void>

--- a/frontend/photo-helper/src/components/DropZone.tsx
+++ b/frontend/photo-helper/src/components/DropZone.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/icons-material';
 import { isValidImageFile } from '../utils/imageProcessing';
 import { useI18n } from '../contexts/I18nContext';
+import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
 
 interface DropZoneProps {
   onFilesDropped: (files: File[]) => void;
@@ -35,6 +36,11 @@ export const DropZone: React.FC<DropZoneProps> = ({
   const availableSlots = Math.max(0, maxPhotos - currentPhotoCount);
   const isDisabled = loading || availableSlots === 0;
   const { t } = useI18n();
+  // In the desktop bundle we route the click to Electron's `dialog.
+  // showOpenDialog` so the file picker opens in the competition's
+  // working folder. Drag-and-drop still uses react-dropzone's native
+  // handlers — only the click path differs (feedback 2026-04-25).
+  const useElectronDialog = isElectronPhotoImportAvailable();
 
   const {
     getRootProps,
@@ -50,10 +56,14 @@ export const DropZone: React.FC<DropZoneProps> = ({
     maxFiles: availableSlots,
     maxSize: 20 * 1024 * 1024, // 20MB
     disabled: isDisabled,
+    // `noClick` disables react-dropzone's auto-trigger of the hidden
+    // `<input type=file>` on click — we provide our own click handler
+    // below that calls Electron's native dialog instead.
+    noClick: useElectronDialog,
     onDrop: (acceptedFiles, rejectedFiles) => {
       // Filter valid files
       const validFiles = acceptedFiles.filter(isValidImageFile);
-      
+
       if (validFiles.length > 0) {
         onFilesDropped(validFiles);
       }
@@ -66,6 +76,17 @@ export const DropZone: React.FC<DropZoneProps> = ({
       }
     }
   });
+
+  const handleElectronClick = async () => {
+    if (isDisabled) return;
+    try {
+      const files = await openPhotosViaElectron(availableSlots);
+      const validFiles = files.filter(isValidImageFile);
+      if (validFiles.length > 0) onFilesDropped(validFiles);
+    } catch (err) {
+      console.error('[photo import] Electron dialog failed:', err);
+    }
+  };
 
   // Determine styling based on state
   const getDropZoneStyles = () => {
@@ -159,7 +180,7 @@ export const DropZone: React.FC<DropZoneProps> = ({
 
       {/* Drop Zone */}
       <Paper
-        {...getRootProps()}
+        {...getRootProps({ onClick: useElectronDialog ? handleElectronClick : undefined })}
         elevation={isDragActive ? 4 : 1}
         sx={{
           border: 2,

--- a/frontend/photo-helper/src/components/GridSizedDropZone.tsx
+++ b/frontend/photo-helper/src/components/GridSizedDropZone.tsx
@@ -15,6 +15,7 @@ import {
 import { isValidImageFile } from '../utils/imageProcessing';
 import { useI18n } from '../contexts/I18nContext';
 import { useAspectRatio } from '../contexts/AspectRatioContext';
+import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
 
 interface GridSizedDropZoneProps {
   onFilesDropped: (files: File[]) => void;
@@ -34,6 +35,8 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
   const { t } = useI18n();
   const { currentRatio } = useAspectRatio();
 
+  const useElectronDialog = isElectronPhotoImportAvailable();
+
   const {
     getRootProps,
     getInputProps,
@@ -48,10 +51,11 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
     maxFiles: maxPhotos,
     maxSize: 20 * 1024 * 1024, // 20MB
     disabled: loading,
+    noClick: useElectronDialog,
     onDrop: (acceptedFiles, rejectedFiles) => {
       // Filter valid files
       const validFiles = acceptedFiles.filter(isValidImageFile);
-      
+
       if (validFiles.length > 0) {
         onFilesDropped(validFiles);
       }
@@ -64,6 +68,17 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
       }
     }
   });
+
+  const handleElectronClick = async () => {
+    if (loading) return;
+    try {
+      const files = await openPhotosViaElectron(maxPhotos);
+      const validFiles = files.filter(isValidImageFile);
+      if (validFiles.length > 0) onFilesDropped(validFiles);
+    } catch (err) {
+      console.error('[photo import] Electron dialog failed:', err);
+    }
+  };
 
   // Determine styling based on state
   const getDropZoneStyles = () => {
@@ -156,7 +171,7 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
 
       {/* Grid-Sized Drop Zone */}
       <Paper
-        {...getRootProps()}
+        {...getRootProps({ onClick: useElectronDialog ? handleElectronClick : undefined })}
         elevation={isDragActive ? 4 : 1}
         sx={{
           width: '100%',

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -5,6 +5,7 @@ import { Image as ImageIcon, CloudUpload, Close } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
 import { PhotoEditorApi } from './PhotoEditorApi';
 import { isValidImageFile } from '../utils/imageProcessing';
+import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
 import { useAspectRatio } from '../contexts/AspectRatioContext';
 import { useLabeling } from '../contexts/LabelingContext';
 import { useI18n } from '../contexts/I18nContext';
@@ -351,6 +352,8 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
 }) => {
   const theme = useTheme();
   const { t } = useI18n();
+  const useElectronDialog = isElectronPhotoImportAvailable();
+  const slotMaxFiles = maxFilesRemaining ?? 9;
   const {
     getRootProps,
     getInputProps,
@@ -362,10 +365,11 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
       'image/jpeg': ['.jpg', '.jpeg'],
       'image/png': ['.png']
     },
-    maxFiles: maxFilesRemaining ?? 9, // Respect layout-dependent remaining capacity
+    maxFiles: slotMaxFiles, // Respect layout-dependent remaining capacity
+    noClick: useElectronDialog,
     onDrop: (acceptedFiles, rejectedFiles) => {
       console.log('Drop event - Accepted:', acceptedFiles, 'Rejected:', rejectedFiles);
-      
+
       if (acceptedFiles.length > 0 && onFilesDropped) {
         // Filter out valid files
         const validFiles = acceptedFiles.filter(file => isValidImageFile(file));
@@ -375,6 +379,16 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
       }
     }
   });
+
+  const handleElectronClick = async () => {
+    try {
+      const files = await openPhotosViaElectron(slotMaxFiles);
+      const validFiles = files.filter(isValidImageFile);
+      if (validFiles.length > 0 && onFilesDropped) onFilesDropped(validFiles);
+    } catch (err) {
+      console.error('[photo import] Electron dialog failed:', err);
+    }
+  };
 
   // Determine border color based on drag state
   const borderColor = isDragActive 
@@ -389,7 +403,7 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
 
   return (
     <Box
-      {...getRootProps()}
+      {...getRootProps({ onClick: useElectronDialog ? handleElectronClick : undefined })}
       sx={{
         width: '100%',
         height: '100%',

--- a/frontend/photo-helper/src/utils/electronPhotoImport.ts
+++ b/frontend/photo-helper/src/utils/electronPhotoImport.ts
@@ -1,0 +1,108 @@
+/**
+ * Photo import via Electron's native open dialog. Used by all three
+ * dropzone surfaces in the photo-helper (DropZone, GridSizedDropZone,
+ * PhotoGridSlotEmpty) to bypass the HTML `<input type=file>` whose
+ * starting directory cannot be programmatically seeded.
+ *
+ * The dialog defaults to the active competition's working folder, which
+ * is also where KML / PNG / PDF exports default to. After the user picks
+ * files, the dirname of the first selection becomes the new working
+ * folder — so the user steers the persistent default by simply navigating
+ * in any open or save dialog (feedback 2026-04-25).
+ *
+ * Returns `[]` and lets the caller fall through to the native
+ * `<input>` flow on the web build, when the dialog is cancelled, or
+ * when no files come back.
+ */
+
+declare global {
+  interface Window {
+    electronAPI?: {
+      openPhotos?: (defaultDir?: string, maxFiles?: number) => Promise<string[]>;
+      readPhotoFile?: (filePath: string) => Promise<{ name: string; mimeType: string; base64: string } | null>;
+      competitions?: {
+        getWorkingDir?: (id: string) => Promise<string | null>;
+        setWorkingDir?: (id: string, dir: string) => Promise<unknown>;
+      };
+    };
+  }
+}
+
+function getCompetitionIdFromUrl(): string | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('competitionId') || null;
+  } catch {
+    return null;
+  }
+}
+
+function dirnameOf(fullPath: string): string | null {
+  const sepIdx = Math.max(fullPath.lastIndexOf('\\'), fullPath.lastIndexOf('/'));
+  if (sepIdx <= 0) return null;
+  const dir = fullPath.slice(0, sepIdx);
+  return dir || null;
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export function isElectronPhotoImportAvailable(): boolean {
+  const api = window.electronAPI;
+  return !!(api && typeof api.openPhotos === 'function' && typeof api.readPhotoFile === 'function');
+}
+
+export async function openPhotosViaElectron(maxFiles?: number): Promise<File[]> {
+  const api = window.electronAPI;
+  if (!api?.openPhotos || !api?.readPhotoFile) return [];
+
+  // Read the competition's working dir (if any) to seed the dialog's
+  // starting directory. Competition id is on the URL when launched from
+  // the desktop launcher (`?competitionId=…`). Best-effort — failures
+  // are non-fatal; the dialog will fall back to ~/Pictures.
+  const competitionId = getCompetitionIdFromUrl();
+  let workingDir: string | undefined;
+  if (competitionId && api.competitions?.getWorkingDir) {
+    try {
+      const dir = await api.competitions.getWorkingDir(competitionId);
+      if (dir) workingDir = dir;
+    } catch { /* non-fatal */ }
+  }
+
+  const paths = await api.openPhotos(workingDir, maxFiles);
+  if (!paths || !paths.length) return [];
+
+  // Reconstruct File objects from each path. Reading happens in main
+  // (Node fs) and the bytes come over IPC as base64; we decode and wrap
+  // in a Blob/File so the existing onFilesDropped pipeline (which
+  // expects File[]) doesn't need changes.
+  const files: File[] = [];
+  for (const p of paths) {
+    try {
+      const data = await api.readPhotoFile(p);
+      if (!data || !data.base64) continue;
+      const bytes = base64ToUint8Array(data.base64);
+      files.push(new File([bytes], data.name, { type: data.mimeType }));
+    } catch (err) {
+      console.error('[photo import] Failed to read', p, err);
+    }
+  }
+
+  // Promote the chosen folder to the working dir so subsequent dialogs
+  // (saves, future imports) default there.
+  if (competitionId && api.competitions?.setWorkingDir && paths[0]) {
+    const dir = dirnameOf(paths[0]);
+    if (dir) {
+      api.competitions.setWorkingDir(competitionId, dir).catch((err: unknown) => {
+        console.warn('[workingDir] persist failed:', err);
+      });
+    }
+  }
+
+  return files;
+}

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -487,7 +487,22 @@ export const generatePDF = async (
           reader.onerror = () => reject(reader.error);
           reader.readAsDataURL(blob);
         });
-        await api.savePdf(base64, fileName, workingDir || undefined);
+        const savedPath: string | null = await api.savePdf(base64, fileName, workingDir || undefined);
+        // Promote the directory the user actually picked to the
+        // competition's working folder. Lets the user *steer* the default
+        // for the next save dialog by simply navigating in this one
+        // (feedback 2026-04-25).
+        if (savedPath && competitionId && api.competitions?.setWorkingDir) {
+          const sepIdx = Math.max(savedPath.lastIndexOf('\\'), savedPath.lastIndexOf('/'));
+          if (sepIdx > 0) {
+            const dir = savedPath.slice(0, sepIdx);
+            if (dir) {
+              api.competitions.setWorkingDir(competitionId, dir).catch((err: unknown) => {
+                console.warn('[workingDir] persist failed:', err);
+              });
+            }
+          }
+        }
         return;
       } catch (err) {
         console.error('electronAPI.savePdf failed, falling back to browser download:', err);


### PR DESCRIPTION
## Summary

Closes the feedback loop on per-competition working folder UX:

> "user selects folder once → it persists across all components → updates whenever the user navigates to a new folder in any dialog"

### Save dialogs now write `workingDir`

After every save (KML, map PNG, photo-sheet PDF) the renderer extracts `dirname(savedPath)` and calls `competitions.setWorkingDir(id, dir)` via the IPC introduced in #47. So the user can **steer** the persistent default just by navigating in any save dialog — the next dialog opens there.

- Map Corridors: refactored to a single `persistChosenDirAsWorking` helper used by both KML and PNG paths.
- Photo Helper: same pattern in `pdfGenerator.ts`.
- Tightened `electronAPI.saveMapImage` typing to `Promise<string | null>` so the renderer can read the path.

### Photo import now goes through Electron's native dialog

New IPCs:
- `open-photos(defaultDir, maxFiles)` → `dialog.showOpenDialog` with the working folder as `defaultPath`, JPG/PNG filters, multi-select. Falls back to `~/Pictures` if the persisted folder no longer exists.
- `read-photo-file(path)` → reads from disk in main (30 MB cap + path/file checks), returns `{ name, mimeType, base64 }`. Renderer rebuilds `File` objects so the existing `onFilesDropped` pipeline doesn't change.

Shared helper `frontend/photo-helper/src/utils/electronPhotoImport.ts`:
- Reads `competitionId` off the URL (so the three dropzone components don't need new props).
- Opens the dialog → hydrates `File[]` from selected paths → persists chosen dirname as the new working folder.

All three dropzones (`DropZone`, `GridSizedDropZone`, `PhotoGridSlotEmpty`) set `noClick: true` when in Electron and re-route the click to the helper. **Drag-and-drop is unchanged** — react-dropzone's HTML5 drop event handlers stay live, only click-to-open is rerouted. **Web build is untouched** — the helper short-circuits when `electronAPI.openPhotos` is absent.

## Test plan

- [x] `pnpm --filter @airq/photo-helper test` — 65/65
- [x] `pnpm --filter @airq/map-corridors test` — 154/154
- [x] `pnpm --filter @airq/desktop build:apps` (with `VITE_DESKTOP_BUILD=true`)
- [ ] Manual: create competition, import KML in map-corridors → KML save dialog opens at the KML's folder
- [ ] Manual: navigate to a *different* folder in the save dialog and save → next save (KML/PNG/PDF) defaults to the new folder
- [ ] Manual: in photo-helper, click an empty dropzone → Electron `Open` dialog opens at working folder
- [ ] Manual: pick photos from a different folder → that folder becomes the new working folder for subsequent dialogs (any app)
- [ ] Manual: drag-and-drop from File Explorer still works without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)