### PR TITLE
fix(i18n): translate photo-set overflow error messages

### DIFF
--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -403,7 +403,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2') => {
     if (!currentCompetition?.session) {
       console.error('No current competition or session available');
-      setError('No active competition to add photos to');
+      setError(t('errors.noActiveCompetition'));
       return;
     }
 
@@ -420,9 +420,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       const current = sess.sets?.[setKey]?.photos?.length ?? 0;
       if (current + files.length > ABSOLUTE_MAX) {
         const allowed = Math.max(0, ABSOLUTE_MAX - current);
+        const setLabel = setKey === 'set1' ? '1' : '2';
         setError(allowed === 0
-          ? `Set ${setKey === 'set1' ? '1' : '2'} is full. Remove a photo first.`
-          : `Set ${setKey === 'set1' ? '1' : '2'} can take only ${allowed} more photo(s).`);
+          ? t('errors.photoSetFull', { set: setLabel })
+          : t('errors.photoSetCapacityRemaining', { set: setLabel, count: allowed }));
         return;
       }
     }
@@ -478,7 +479,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       };
     }, { updatePhotos: true });
-  }, [updateCurrentCompetition, currentCompetition]);
+  }, [updateCurrentCompetition, currentCompetition, t]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {
     await updateCurrentCompetition(session => {

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -249,11 +249,14 @@
   },
   "errors": {
     "sessionNotFound": "Relace nenalezena",
-    "uploadFailed": "Nahrávání selhalo", 
+    "uploadFailed": "Nahrávání selhalo",
     "pdfGenerationFailed": "Vytvoření PDF selhalo",
     "photoUpdateFailed": "Nepodařilo se aktualizovat fotografii",
     "photoRemovalFailed": "Nepodařilo se odebrat fotografii",
-    "shuffleFailed": "Nepodařilo se zamíchat fotografie"
+    "shuffleFailed": "Nepodařilo se zamíchat fotografie",
+    "noActiveCompetition": "Není zvolena žádná aktivní soutěž, do které by šlo přidat fotografie.",
+    "photoSetFull": "Sada {{set}} je plná. Nejprve odeberte fotografii.",
+    "photoSetCapacityRemaining": "Sada {{set}} přijme už jen {{count}} dalších fotografií."
   },
   "common": {
     "loading": "Načítání...",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -250,11 +250,14 @@
   },
   "errors": {
     "sessionNotFound": "Session not found",
-    "uploadFailed": "Upload failed", 
+    "uploadFailed": "Upload failed",
     "pdfGenerationFailed": "PDF generation failed",
     "photoUpdateFailed": "Failed to update photo",
     "photoRemovalFailed": "Failed to remove photo",
-    "shuffleFailed": "Failed to shuffle photos"
+    "shuffleFailed": "Failed to shuffle photos",
+    "noActiveCompetition": "No active competition to add photos to",
+    "photoSetFull": "Set {{set}} is full. Remove a photo first.",
+    "photoSetCapacityRemaining": "Set {{set}} can take only {{count}} more photo(s)."
   },
   "common": {
     "loading": "Loading...",


### PR DESCRIPTION
## Summary
PR #47 review follow-up. The defensive `ABSOLUTE_MAX = 10` guard added to `addPhotosToSet` surfaced its error via hardcoded English strings, while every other user-facing message in the same hook (e.g. `competition.numbered`) goes through the i18n layer. Czech users saw English errors on overflow.

## Changes
- `frontend/photo-helper/src/locales/{cs,en}.json` — three new keys under `errors.*`:
  - `errors.noActiveCompetition`
  - `errors.photoSetFull` (params: `set`)
  - `errors.photoSetCapacityRemaining` (params: `set`, `count`)
- `frontend/photo-helper/src/hooks/useCompetitionSystem.ts` — route the three `setError(...)` calls in `addPhotosToSet` through `t()`. Add `t` to the `useCallback` deps.

No behaviour change beyond the translated text. Patch-level — no `#minor` / `#major` flag.

## Test plan
- [x] `pnpm --filter @airq/photo-helper test` — 65/65 passing
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual: switch UI to Czech, drop 11 photos onto a single set in Rally TP → translated overflow message appears
- [ ] Manual: switch UI to English, same flow → English message reads identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)