### PR TITLE
fix: harden photo-import IPC + surface failures (follow-up to #48) #patch

### DIFF
--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -208,13 +208,16 @@ function createWindow() {
     mainWindow.webContents.openDevTools();
   }
 
-  // Handle external links - open in default browser
+  // Handle external links - open in default browser. Default-deny: only
+  // http(s) is routed to the OS browser; data:/file:/blob: are blocked
+  // outright so a future regression that allows renderer-initiated
+  // window.open can't smuggle a preload-bearing data: window past the
+  // safeHandle URL gate.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       shell.openExternal(url);
-      return { action: 'deny' };
     }
-    return { action: 'allow' };
+    return { action: 'deny' };
   });
 
   // Emitted when the window is closed
@@ -325,11 +328,25 @@ function sanitizeFileName(input) {
 // `setWindowOpenHandler` blocks http(s) window.open from the renderer,
 // so only frames we control can reach these checks. A compromised
 // renderer cannot conjure a fresh data: or app: frame.
+//
+// `data:text/html` is only legitimately used by the Mapbox/Mapy token
+// dialogs created via `new BrowserWindow` in the main process. Those
+// register their `webContents.id` in `trustedDataWebContentsIds` for
+// the lifetime of the window — we gate any data: sender on membership
+// rather than a raw URL prefix so a future regression that opens an
+// unrelated `data:` window can't silently widen this gate.
+const trustedDataWebContentsIds = new Set();
+
 function isTrustedSender(event) {
   try {
-    const url = event && event.senderFrame && event.senderFrame.url;
-    if (typeof url !== 'string') return false;
-    return url.startsWith('app://') || url.startsWith('data:text/html');
+    const senderUrl = event && event.senderFrame && event.senderFrame.url;
+    if (typeof senderUrl !== 'string') return false;
+    if (senderUrl.startsWith('app://')) return true;
+    if (senderUrl.startsWith('data:text/html')) {
+      const senderId = event.sender && event.sender.id;
+      return typeof senderId === 'number' && trustedDataWebContentsIds.has(senderId);
+    }
+    return false;
   } catch {
     return false;
   }
@@ -384,6 +401,18 @@ function validateUserDir(input) {
 // ensures the allowlist can't outlive the picker context.
 const photoOpenAllowlist = new Set();
 const PHOTO_OPEN_HARD_CAP = 200;
+
+// Set keys are byte-equal compared, but NTFS is case-insensitive and
+// filenames with combining marks can round-trip through Electron in
+// either NFC or NFD. Without a normalization step, the picker stores
+// `C:\Photos\Img.JPG` while a later `read-photo-file('c:\\photos\\img.jpg')`
+// would falsely miss — a self-DoS, not an exfil bypass, but still a
+// silently-failing import. Apply NFC + lowercase-on-Windows uniformly
+// to both `add` and `has` so the keys collide for any FS-equivalent form.
+function normalizePathKey(absPath) {
+  const r = absPath.normalize('NFC');
+  return process.platform === 'win32' ? r.toLowerCase() : r;
+}
 
 // Ensure a directory exists
 function ensureDir(dirPath) {
@@ -871,7 +900,7 @@ safeHandle('open-photos', async (event, defaultDir, maxFiles) => {
   // can't replay paths from an older batch after a fresh dialog ran.
   photoOpenAllowlist.clear();
   for (const p of picked) {
-    try { photoOpenAllowlist.add(path.resolve(p)); } catch { /* ignore */ }
+    try { photoOpenAllowlist.add(normalizePathKey(path.resolve(p))); } catch { /* ignore */ }
   }
   return picked;
 });
@@ -893,7 +922,7 @@ safeHandle('read-photo-file', async (event, filePath) => {
   }
   let abs;
   try { abs = path.resolve(filePath); } catch { throw new Error('Invalid file path'); }
-  if (!photoOpenAllowlist.has(abs)) {
+  if (!photoOpenAllowlist.has(normalizePathKey(abs))) {
     throw new Error('File not in allowlist');
   }
   // `lstat` does NOT follow symlinks, so a symlink targeting a sensitive
@@ -964,19 +993,12 @@ safeHandle('save-kml', async (event, kmlText, fileName, defaultDir, competitionI
     ? sanitizeFileName(fileName).replace(/\.kml$/i, '') + '.kml'
     : `corridors_export_${new Date().toISOString().slice(0, 10)}.kml`;
 
-  let startDir = null;
-  // 1) User-supplied directory (the folder they imported the KML from).
-  //    Length-clamp before `path.resolve`/`statSync` so a pathological input
-  //    can't stall the main process, and reject UNC/device-namespace paths
-  //    that bypass drive sandboxing.
-  if (typeof defaultDir === 'string' && defaultDir.trim() && defaultDir.length <= 4096) {
-    try {
-      const abs = path.resolve(defaultDir);
-      if (isSafeStartDir(abs) && fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
-        startDir = abs;
-      }
-    } catch { /* ignore and fall through */ }
-  }
+  // 1) User-supplied directory (the folder they imported the KML from) —
+  //    `validateUserDir` enforces type, length cap, UNC/device rejection,
+  //    and on-disk existence in one place, shared with every other
+  //    path-accepting handler so a future tweak to the rules can't miss
+  //    a caller.
+  let startDir = validateUserDir(defaultDir);
   // 2) Competition folder fallback
   if (!startDir && typeof competitionId === 'string' && competitionId.trim()) {
     const compDir = path.join(getPhotoSessionsPath(), 'competitions', sanitizeFileName(competitionId));
@@ -1079,6 +1101,12 @@ async function showMapboxTokenDialog() {
     </html>
   `;
 
+  // Track this window's webContents.id so the IPC sender gate accepts
+  // its `setConfig` calls without trusting *any* `data:text/html` URL.
+  const mapboxId = inputWindow.webContents.id;
+  trustedDataWebContentsIds.add(mapboxId);
+  inputWindow.on('closed', () => { trustedDataWebContentsIds.delete(mapboxId); });
+
   inputWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
   inputWindow.setMenu(null);
 }
@@ -1170,6 +1198,10 @@ async function showMapyTokenDialog() {
     </body>
     </html>
   `;
+
+  const mapyId = inputWindow.webContents.id;
+  trustedDataWebContentsIds.add(mapyId);
+  inputWindow.on('closed', () => { trustedDataWebContentsIds.delete(mapyId); });
 
   inputWindow.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html));
   inputWindow.setMenu(null);

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -359,6 +359,32 @@ function isSafeStartDir(abs) {
   return true;
 }
 
+// Single source of truth for "renderer gave us a directory string — should we
+// trust it as `defaultPath` for a dialog or persist it as workingDir?". Wraps
+// the four checks (type, length cap, UNC/device rejection, on-disk presence)
+// that were copy-pasted across handlers and easy to forget on new ones.
+const MAX_USER_PATH_LEN = 4096;
+function validateUserDir(input) {
+  if (typeof input !== 'string' || !input.trim()) return null;
+  if (input.length > MAX_USER_PATH_LEN) return null;
+  let abs;
+  try { abs = path.resolve(input); } catch { return null; }
+  if (!isSafeStartDir(abs)) return null;
+  try {
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) return null;
+  } catch { return null; }
+  return abs;
+}
+
+// Allowlist for `read-photo-file`: paths the user explicitly chose in a
+// preceding `open-photos` dialog. Without this, a compromised renderer
+// (XSS via untrusted KML, image EXIF, or Mapbox-injected content) could
+// call `readPhotoFile('C:\\Users\\…\\.ssh\\id_rsa')` and exfiltrate any
+// readable file <30 MB. Resetting on `will-navigate` and window destruction
+// ensures the allowlist can't outlive the picker context.
+const photoOpenAllowlist = new Set();
+const PHOTO_OPEN_HARD_CAP = 200;
+
 // Ensure a directory exists
 function ensureDir(dirPath) {
   if (!fs.existsSync(dirPath)) {
@@ -699,20 +725,15 @@ safeHandle('competition-set-active', async (event, id) => {
 // "the working folder is the same per competition, not per app".
 safeHandle('competition-set-working-dir', async (event, id, workingDir) => {
   if (typeof id !== 'string' || !id) throw new Error('Invalid competition id');
-  if (typeof workingDir !== 'string' || !workingDir.trim()) {
+  // The renderer derives `workingDir` from `dirname(savedPath)` after
+  // every save dialog. A poisoned path (UNC, device namespace, oversized
+  // input) would round-trip back into every subsequent dialog's
+  // `defaultPath` — turning a single bad save into a persistent NTLMv2
+  // hash leak primitive on Windows. `validateUserDir` enforces the
+  // length cap, UNC rejection, and on-disk existence in one place.
+  const abs = validateUserDir(workingDir);
+  if (!abs) {
     throw new Error('Invalid working directory');
-  }
-  // Resolve to an absolute path and validate it actually exists. Persisting
-  // a stale path that was deleted/renamed produces a worse UX (dialog opens
-  // in an undefined location) than returning an error here.
-  let abs;
-  try {
-    abs = path.resolve(workingDir);
-  } catch (e) {
-    throw new Error('Invalid working directory');
-  }
-  if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) {
-    throw new Error('Working directory does not exist');
   }
   const index = readCompetitionsIndex();
   const target = index.competitions.find(c => c.id === id);
@@ -731,15 +752,11 @@ safeHandle('competition-get-working-dir', async (event, id) => {
   const index = readCompetitionsIndex();
   const target = index.competitions.find(c => c.id === id);
   if (!target || typeof target.workingDir !== 'string') return null;
-  // The folder may have been deleted/moved since it was set. Surface as
-  // null so callers fall through to their own defaults instead of opening
-  // a dialog at a path that vanishes underneath them.
-  try {
-    if (fs.existsSync(target.workingDir) && fs.statSync(target.workingDir).isDirectory()) {
-      return target.workingDir;
-    }
-  } catch { /* fall through */ }
-  return null;
+  // Re-validate on read-back. An older index file (written before
+  // `competition-set-working-dir` enforced UNC rejection) or a
+  // hand-edited config could otherwise still feed a poisoned path
+  // back into save dialogs.
+  return validateUserDir(target.workingDir);
 });
 
 // Set discipline for a competition
@@ -802,13 +819,10 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir) => {
   if (base64Data.length > 50 * 1024 * 1024) {
     throw new Error('Image data too large');
   }
-  let startDir = null;
-  if (typeof defaultDir === 'string' && defaultDir.trim()) {
-    try {
-      const abs = path.resolve(defaultDir);
-      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
-    } catch { /* fall through */ }
-  }
+  // Apply the same UNC + length + existence checks as `save-kml`. A
+  // renderer-poisoned `defaultDir` could otherwise pre-point the dialog
+  // at an attacker-controlled SMB share (NTLMv2 hash leak on Windows).
+  let startDir = validateUserDir(defaultDir);
   if (!startDir) startDir = app.getPath('documents');
   const fileName = `map-print-${new Date().toISOString().slice(0, 10)}.png`;
   const { filePath } = await dialog.showSaveDialog(mainWindow, {
@@ -826,15 +840,13 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir) => {
 // every export AND import). The renderer only gets file paths back; it
 // then asks `read-photo-file` to load each one as base64 so it can
 // reconstruct File objects for the existing onFilesDropped pipeline.
+//
+// Picked paths are added to `photoOpenAllowlist` and ALSO returned. The
+// allowlist gates the follow-up `read-photo-file` calls so a compromised
+// renderer can't ask for arbitrary files outside what the user just
+// explicitly selected.
 safeHandle('open-photos', async (event, defaultDir, maxFiles) => {
-  let startDir = null;
-  if (typeof defaultDir === 'string' && defaultDir.trim()) {
-    try {
-      const abs = path.resolve(defaultDir);
-      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
-    } catch { /* fall through */ }
-  }
-  if (!startDir) startDir = app.getPath('pictures');
+  const startDir = validateUserDir(defaultDir) || app.getPath('pictures');
   const result = await dialog.showOpenDialog(mainWindow, {
     defaultPath: startDir,
     filters: [
@@ -843,32 +855,64 @@ safeHandle('open-photos', async (event, defaultDir, maxFiles) => {
     properties: ['openFile', 'multiSelections'],
   });
   if (result.canceled || !result.filePaths || !result.filePaths.length) return [];
-  // Cap at the renderer-provided maxFiles (slot capacity). Defensive — the
-  // dialog itself doesn't enforce it.
-  const cap = (typeof maxFiles === 'number' && maxFiles > 0) ? maxFiles : result.filePaths.length;
-  return result.filePaths.slice(0, cap);
+  // Hard server-side ceiling stops a renderer-supplied `maxFiles` of
+  // Number.MAX_SAFE_INTEGER from causing the renderer to OOM trying to
+  // base64-decode hundreds of 30 MB files in a row. Renderer-side cap is
+  // still applied first when valid (slot capacity).
+  const requested = (typeof maxFiles === 'number' && maxFiles > 0)
+    ? Math.min(maxFiles, PHOTO_OPEN_HARD_CAP)
+    : PHOTO_OPEN_HARD_CAP;
+  const picked = result.filePaths.slice(0, requested);
+  // Each `open-photos` call replaces the allowlist with its own picks.
+  // Renderer pattern is `openPhotos() → await Promise.all(readPhotoFile…)`,
+  // so the previous batch's reads are always finished before a new
+  // open-photos is initiated. This keeps the allowlist bounded (no
+  // unbounded growth across a long session) and ensures the renderer
+  // can't replay paths from an older batch after a fresh dialog ran.
+  photoOpenAllowlist.clear();
+  for (const p of picked) {
+    try { photoOpenAllowlist.add(path.resolve(p)); } catch { /* ignore */ }
+  }
+  return picked;
 });
 
 // Read a single photo file from disk and return base64 + metadata so the
-// renderer can construct a File object. Path is constrained to files the
-// user already saw in the open dialog — we still re-validate against
-// existence and size to keep the IPC honest.
+// renderer can construct a File object. Three layers of validation:
+// 1) The path must be in `photoOpenAllowlist` (set by a prior `open-photos`).
+// 2) `lstat` rejects symlinks so a malicious symlink under the user's
+//    Pictures folder can't redirect to ~/.ssh/id_rsa.
+// 3) Extension is whitelisted explicitly — the dialog filter is UI only;
+//    on Windows users can type `*.*` and pick anything.
+const ALLOWED_PHOTO_EXTS = new Set(['.jpg', '.jpeg', '.png']);
 safeHandle('read-photo-file', async (event, filePath) => {
   if (typeof filePath !== 'string' || !filePath) {
     throw new Error('Invalid file path');
   }
-  const abs = path.resolve(filePath);
-  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
-    throw new Error('File not found');
+  if (filePath.length > MAX_USER_PATH_LEN) {
+    throw new Error('Invalid file path');
   }
-  const stat = fs.statSync(abs);
+  let abs;
+  try { abs = path.resolve(filePath); } catch { throw new Error('Invalid file path'); }
+  if (!photoOpenAllowlist.has(abs)) {
+    throw new Error('File not in allowlist');
+  }
+  // `lstat` does NOT follow symlinks, so a symlink targeting a sensitive
+  // file outside the allowlist is rejected here even if its parent dir
+  // was legitimately picked. `readFileSync` later WOULD follow the link.
+  let lst;
+  try { lst = fs.lstatSync(abs); } catch { throw new Error('File not found'); }
+  if (lst.isSymbolicLink()) throw new Error('Symlinks not allowed');
+  if (!lst.isFile()) throw new Error('File not found');
   // 30 MB cap — same order of magnitude as the 20 MB renderer-side check
   // in `isValidImageFile`, with a little headroom for the base64 round-trip.
-  if (stat.size > 30 * 1024 * 1024) {
+  if (lst.size > 30 * 1024 * 1024) {
     throw new Error('File too large');
   }
-  const buffer = fs.readFileSync(abs);
   const ext = path.extname(abs).toLowerCase();
+  if (!ALLOWED_PHOTO_EXTS.has(ext)) {
+    throw new Error('Unsupported image type');
+  }
+  const buffer = fs.readFileSync(abs);
   const mimeType = ext === '.png' ? 'image/png' : 'image/jpeg';
   return {
     name: path.basename(abs),
@@ -892,13 +936,8 @@ safeHandle('save-pdf', async (event, base64Data, fileName, defaultDir) => {
   const safeName = (typeof fileName === 'string' && fileName.trim())
     ? sanitizeFileName(fileName).replace(/\.pdf$/i, '') + '.pdf'
     : `photo-sheet-${new Date().toISOString().slice(0, 10)}.pdf`;
-  let startDir = null;
-  if (typeof defaultDir === 'string' && defaultDir.trim()) {
-    try {
-      const abs = path.resolve(defaultDir);
-      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) startDir = abs;
-    } catch { /* fall through */ }
-  }
+  // Same UNC + length validation as save-kml / save-map-image.
+  let startDir = validateUserDir(defaultDir);
   if (!startDir) startDir = app.getPath('documents');
   const { filePath } = await dialog.showSaveDialog(mainWindow, {
     defaultPath: path.join(startDir, safeName),
@@ -1389,6 +1428,11 @@ app.on('web-contents-created', (event, contents) => {
 
     // Allow navigation within our app protocol
     if (parsedUrl.protocol === 'app:') {
+      // The photo-open allowlist is scoped to the current renderer
+      // context — clear it on navigation so paths picked under one app
+      // (e.g. photo-helper) can't be replayed by `read-photo-file`
+      // after the user navigates to a different app under app://.
+      photoOpenAllowlist.clear();
       return;
     }
 

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -13,6 +13,7 @@ import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, D
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
+import { dirnameOf } from '@airq/shared-storage'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { parseDisciplineFromSearch } from './utils/parseDiscipline'
 import { MapStyleSelector } from './components/MapStyleSelector'
@@ -328,12 +329,12 @@ function App() {
   // After any save dialog returns a path, promote the chosen folder to the
   // competition's working dir. Lets the user steer the default by simply
   // navigating in the dialog — feedback 2026-04-25 ("until navigated to
-  // other folder, from that moment new folder persists").
+  // other folder, from that moment new folder persists"). Uses the shared
+  // `dirnameOf` so drive-letter roots, POSIX root, UNC, and trailing
+  // separators all extract the same as Node's `path.dirname` would.
   const persistChosenDirAsWorking = useCallback((savedPath: string | null) => {
     if (!savedPath || !competitionId) return
-    const sepIdx = Math.max(savedPath.lastIndexOf('\\'), savedPath.lastIndexOf('/'))
-    if (sepIdx <= 0) return
-    const dir = savedPath.slice(0, sepIdx)
+    const dir = dirnameOf(savedPath)
     if (!dir) return
     setImportedKmlDir(dir)
     const api = (window as any)?.electronAPI

--- a/frontend/photo-helper/src/__tests__/dirnameOf.test.ts
+++ b/frontend/photo-helper/src/__tests__/dirnameOf.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { dirnameOf } from '@airq/shared-storage';
+
+// `dirnameOf` is the renderer-side stand-in for Node's `path.dirname`,
+// used by every save-dialog callback (KML, PNG, PDF, photo import) to
+// extract the directory the user just picked and persist it as the
+// competition's working folder. Wrong output here = wrong default for
+// the next dialog. Three different inline copies disagreed on edge cases
+// before this consolidation; the cases below pin them.
+
+describe('dirnameOf', () => {
+  // --- Standard happy paths ---------------------------------------------------
+
+  it('extracts directory from a Windows path with backslashes', () => {
+    expect(dirnameOf('C:\\photos\\img.jpg')).toBe('C:\\photos');
+  });
+
+  it('extracts directory from a POSIX path with forward slashes', () => {
+    expect(dirnameOf('/home/user/img.jpg')).toBe('/home/user');
+  });
+
+  it('extracts directory from a deeply nested path', () => {
+    expect(dirnameOf('/a/b/c/d/e/f.kml')).toBe('/a/b/c/d/e');
+  });
+
+  it('extracts directory from a path with mixed separators', () => {
+    // Electron save dialog on Windows occasionally returns mixed sep
+    // when the user pastes a path. Last separator (either kind) wins.
+    expect(dirnameOf('C:/photos\\img.jpg')).toBe('C:/photos');
+  });
+
+  // --- Drive-letter roots (Windows) ------------------------------------------
+
+  it('returns drive root WITH trailing separator for `C:\\file.txt`', () => {
+    // `path.resolve("C:")` on Windows returns the cwd of drive C, NOT the
+    // root. Persisting `"C:"` as workingDir would mean every subsequent
+    // dialog opens at whatever C:'s cwd happens to be.
+    expect(dirnameOf('C:\\file.txt')).toBe('C:\\');
+  });
+
+  it('returns drive root with forward slash form `D:/file.txt`', () => {
+    expect(dirnameOf('D:/file.txt')).toBe('D:/');
+  });
+
+  it('preserves drive-letter case', () => {
+    expect(dirnameOf('z:\\foo.bin')).toBe('z:\\');
+    expect(dirnameOf('Z:\\foo.bin')).toBe('Z:\\');
+  });
+
+  // --- POSIX root -------------------------------------------------------------
+
+  it('returns `/` for a file at POSIX root', () => {
+    // sepIdx === 0 is a real case — user explicitly picked filesystem
+    // root. Returning null would silently skip workingDir persistence.
+    expect(dirnameOf('/file.kml')).toBe('/');
+  });
+
+  // --- UNC / device paths -----------------------------------------------------
+
+  it('extracts directory from a UNC path', () => {
+    // We DO extract from UNC — it's main.js / `validateUserDir`'s job
+    // to reject it (NTLMv2 hash leak protection), not dirnameOf's. This
+    // gives the user a real error from the IPC instead of a mysterious
+    // silently-skipped persistence.
+    expect(dirnameOf('\\\\server\\share\\file.kml')).toBe('\\\\server\\share');
+  });
+
+  // --- Trailing separators ----------------------------------------------------
+
+  it('drops a single trailing backslash', () => {
+    expect(dirnameOf('C:\\photos\\')).toBe('C:\\photos');
+  });
+
+  it('drops a single trailing forward slash', () => {
+    expect(dirnameOf('/home/user/')).toBe('/home/user');
+  });
+
+  it('does NOT drop the only separator (drive root with trailing sep)', () => {
+    // `C:\` is already root — don't strip it down to `C:` (which would
+    // change semantics on Windows).
+    expect(dirnameOf('C:\\')).toBe('C:\\');
+  });
+
+  // --- No-separator / empty / invalid inputs ---------------------------------
+
+  it('returns null for a bare filename', () => {
+    expect(dirnameOf('file.txt')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(dirnameOf('')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    // Defensive — the IPC return is typed as `string | null` but
+    // runtime data can drift.
+    expect(dirnameOf(null as unknown as string)).toBeNull();
+    expect(dirnameOf(undefined as unknown as string)).toBeNull();
+    expect(dirnameOf(123 as unknown as string)).toBeNull();
+  });
+});

--- a/frontend/photo-helper/src/__tests__/electronPhotoImport.test.ts
+++ b/frontend/photo-helper/src/__tests__/electronPhotoImport.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  base64ToUint8Array,
+  getCompetitionIdFromUrl,
+  isElectronPhotoImportAvailable,
+  openPhotosViaElectron,
+} from '../utils/electronPhotoImport';
+
+// `electronPhotoImport.openPhotosViaElectron` is the entry point for
+// every photo-helper dropzone in the desktop bundle. The original
+// implementation silently swallowed per-file read failures (4 of 9
+// photos vanish without a peep) AND silently swallowed dialog errors
+// (click → nothing). These tests pin the failure-surfacing contract:
+// failures land in `result.failures`, never lost.
+
+type ElectronAPI = NonNullable<Window['electronAPI']>;
+
+function setElectronAPI(api: Partial<ElectronAPI> | undefined) {
+  if (api === undefined) {
+    delete (window as { electronAPI?: ElectronAPI }).electronAPI;
+  } else {
+    (window as { electronAPI?: ElectronAPI }).electronAPI = api as ElectronAPI;
+  }
+}
+
+function setUrlSearch(search: string) {
+  // jsdom keeps the same Location across tests; we patch only the
+  // `search` getter so other test files aren't affected.
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...window.location, search },
+    writable: true,
+  });
+}
+
+describe('base64ToUint8Array', () => {
+  it('round-trips ASCII bytes', () => {
+    const input = 'hello world';
+    const b64 = btoa(input);
+    const bytes = base64ToUint8Array(b64);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(bytes)).toBe(input);
+  });
+
+  it('round-trips empty string', () => {
+    expect(base64ToUint8Array('').length).toBe(0);
+  });
+
+  it('throws on invalid base64', () => {
+    // `atob` throws InvalidCharacterError on malformed input. Don't
+    // swallow — let the caller's per-file try/catch report it as a
+    // failure (better than silently returning empty bytes).
+    expect(() => base64ToUint8Array('not!base64!!')).toThrow();
+  });
+
+  it('preserves non-ASCII byte values', () => {
+    const expected = new Uint8Array([0xff, 0x00, 0x80, 0x7f]);
+    const b64 = btoa(String.fromCharCode(...expected));
+    expect(Array.from(base64ToUint8Array(b64))).toEqual(Array.from(expected));
+  });
+});
+
+describe('getCompetitionIdFromUrl', () => {
+  afterEach(() => setUrlSearch(''));
+
+  it('returns null when the param is absent', () => {
+    setUrlSearch('?foo=bar');
+    expect(getCompetitionIdFromUrl()).toBeNull();
+  });
+
+  it('returns null when the param is empty', () => {
+    setUrlSearch('?competitionId=');
+    expect(getCompetitionIdFromUrl()).toBeNull();
+  });
+
+  it('returns the value when present', () => {
+    setUrlSearch('?competitionId=abc-123');
+    expect(getCompetitionIdFromUrl()).toBe('abc-123');
+  });
+
+  it('returns null for empty search string', () => {
+    setUrlSearch('');
+    expect(getCompetitionIdFromUrl()).toBeNull();
+  });
+
+  it('handles multiple params with competitionId in any position', () => {
+    setUrlSearch('?discipline=rally&competitionId=race-1&foo=bar');
+    expect(getCompetitionIdFromUrl()).toBe('race-1');
+  });
+});
+
+describe('isElectronPhotoImportAvailable', () => {
+  afterEach(() => setElectronAPI(undefined));
+
+  it('returns false when electronAPI is missing', () => {
+    setElectronAPI(undefined);
+    expect(isElectronPhotoImportAvailable()).toBe(false);
+  });
+
+  it('returns false when only one IPC is exposed', () => {
+    setElectronAPI({ openPhotos: vi.fn() } as Partial<ElectronAPI>);
+    expect(isElectronPhotoImportAvailable()).toBe(false);
+  });
+
+  it('returns true when both required IPCs are functions', () => {
+    setElectronAPI({
+      openPhotos: vi.fn(),
+      readPhotoFile: vi.fn(),
+    } as Partial<ElectronAPI>);
+    expect(isElectronPhotoImportAvailable()).toBe(true);
+  });
+});
+
+describe('openPhotosViaElectron', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setUrlSearch('?competitionId=test-comp');
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    setElectronAPI(undefined);
+    setUrlSearch('');
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('returns empty result when electronAPI is unavailable (web build)', async () => {
+    setElectronAPI(undefined);
+    const result = await openPhotosViaElectron(9);
+    expect(result.files).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(result.cancelled).toBe(true);
+  });
+
+  it('returns empty result when openPhotos returns []', async () => {
+    setElectronAPI({
+      openPhotos: vi.fn(async () => []),
+      readPhotoFile: vi.fn(),
+      competitions: { setWorkingDir: vi.fn() },
+    });
+    const result = await openPhotosViaElectron(9);
+    expect(result.files).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(result.cancelled).toBe(true);
+  });
+
+  it('reads all picked files in parallel and returns reconstructed File objects', async () => {
+    const path1 = '/photos/a.jpg';
+    const path2 = '/photos/b.png';
+    const readPhotoFile = vi.fn(async (p: string) => ({
+      name: p.split('/').pop()!,
+      mimeType: p.endsWith('.png') ? 'image/png' : 'image/jpeg',
+      base64: btoa('fake-bytes'),
+    }));
+    setElectronAPI({
+      openPhotos: vi.fn(async () => [path1, path2]),
+      readPhotoFile,
+      competitions: { setWorkingDir: vi.fn(async () => undefined) },
+    });
+
+    const result = await openPhotosViaElectron(9);
+
+    expect(result.files).toHaveLength(2);
+    expect(result.failures).toEqual([]);
+    expect(result.cancelled).toBe(false);
+    expect(result.files[0].name).toBe('a.jpg');
+    expect(result.files[1].name).toBe('b.png');
+    expect(result.files[1].type).toBe('image/png');
+    expect(readPhotoFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('captures per-file failures without losing successes (partial import)', async () => {
+    const setWorkingDir = vi.fn(async () => undefined);
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/a.jpg', '/b.jpg', '/c.jpg']),
+      readPhotoFile: vi.fn(async (p: string) => {
+        if (p === '/b.jpg') throw new Error('EACCES');
+        return { name: p.slice(1), mimeType: 'image/jpeg', base64: btoa('x') };
+      }),
+      competitions: { setWorkingDir },
+    });
+
+    const result = await openPhotosViaElectron(9);
+
+    expect(result.files).toHaveLength(2);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].path).toBe('/b.jpg');
+    expect((result.failures[0].error as Error).message).toBe('EACCES');
+    // Working dir is still persisted — we use the FIRST SUCCESSFUL
+    // path's dirname, not the failed one.
+    expect(setWorkingDir).toHaveBeenCalledWith('test-comp', '/');
+  });
+
+  it('treats a null/empty readPhotoFile response as a failure', async () => {
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/x.jpg']),
+      readPhotoFile: vi.fn(async () => null),
+      competitions: { setWorkingDir: vi.fn(async () => undefined) },
+    });
+    const result = await openPhotosViaElectron(9);
+    expect(result.files).toEqual([]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].path).toBe('/x.jpg');
+  });
+
+  it('flags workingDirPersistFailed when setWorkingDir rejects', async () => {
+    const setWorkingDir = vi.fn(async () => { throw new Error('EACCES on config.json'); });
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/photos/img.jpg']),
+      readPhotoFile: vi.fn(async () => ({
+        name: 'img.jpg', mimeType: 'image/jpeg', base64: btoa('x'),
+      })),
+      competitions: { setWorkingDir },
+    });
+
+    const result = await openPhotosViaElectron(9);
+
+    // Import itself succeeded — failure is on persistence side only.
+    expect(result.files).toHaveLength(1);
+    expect(result.failures).toEqual([]);
+    expect(result.workingDirPersistFailed).toBe(true);
+  });
+
+  it('skips workingDir persistence when no competitionId is on the URL', async () => {
+    setUrlSearch('?foo=bar');
+    const setWorkingDir = vi.fn();
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/x.jpg']),
+      readPhotoFile: vi.fn(async () => ({
+        name: 'x.jpg', mimeType: 'image/jpeg', base64: btoa('x'),
+      })),
+      competitions: { setWorkingDir },
+    });
+
+    const result = await openPhotosViaElectron(9);
+
+    expect(result.files).toHaveLength(1);
+    expect(setWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('seeds the dialog with the persisted workingDir when getWorkingDir returns one', async () => {
+    const openPhotos = vi.fn(async () => []);
+    setElectronAPI({
+      openPhotos,
+      readPhotoFile: vi.fn(),
+      competitions: {
+        getWorkingDir: vi.fn(async () => '/persisted/dir'),
+        setWorkingDir: vi.fn(),
+      },
+    });
+
+    await openPhotosViaElectron(9);
+
+    expect(openPhotos).toHaveBeenCalledWith('/persisted/dir', 9);
+  });
+
+  it('falls back to undefined defaultDir when getWorkingDir rejects', async () => {
+    const openPhotos = vi.fn(async () => []);
+    setElectronAPI({
+      openPhotos,
+      readPhotoFile: vi.fn(),
+      competitions: {
+        getWorkingDir: vi.fn(async () => { throw new Error('IPC down'); }),
+        setWorkingDir: vi.fn(),
+      },
+    });
+
+    await openPhotosViaElectron(9);
+
+    expect(openPhotos).toHaveBeenCalledWith(undefined, 9);
+    // getWorkingDir failure should be debug-level, NOT user-facing
+    expect(consoleDebugSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/photo-helper/src/__tests__/electronPhotoImport.test.ts
+++ b/frontend/photo-helper/src/__tests__/electronPhotoImport.test.ts
@@ -199,15 +199,54 @@ describe('openPhotosViaElectron', () => {
   });
 
   it('treats a null/empty readPhotoFile response as a failure', async () => {
+    const setWorkingDir = vi.fn(async () => undefined);
     setElectronAPI({
       openPhotos: vi.fn(async () => ['/x.jpg']),
       readPhotoFile: vi.fn(async () => null),
-      competitions: { setWorkingDir: vi.fn(async () => undefined) },
+      competitions: { setWorkingDir },
     });
     const result = await openPhotosViaElectron(9);
     expect(result.files).toEqual([]);
     expect(result.failures).toHaveLength(1);
     expect(result.failures[0].path).toBe('/x.jpg');
+    // No successful reads → don't persist a workingDir we couldn't import from.
+    expect(setWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('does NOT persist workingDir when ALL reads fail', async () => {
+    // Persisting a directory we couldn't actually import from would
+    // mislead the next dialog into a folder the user is already
+    // having trouble with.
+    const setWorkingDir = vi.fn(async () => undefined);
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/bad/a.jpg', '/bad/b.jpg']),
+      readPhotoFile: vi.fn(async () => { throw new Error('EACCES'); }),
+      competitions: { setWorkingDir },
+    });
+
+    const result = await openPhotosViaElectron(9);
+
+    expect(result.files).toEqual([]);
+    expect(result.failures).toHaveLength(2);
+    expect(setWorkingDir).not.toHaveBeenCalled();
+  });
+
+  it('seeds workingDir from the FIRST successful read, skipping a failed leading file', async () => {
+    // Picks: [bad, good1, good2]. First successful path is good1 — its
+    // dirname is what we persist, NOT the failed leading file's dirname.
+    const setWorkingDir = vi.fn(async () => undefined);
+    setElectronAPI({
+      openPhotos: vi.fn(async () => ['/bad/a.jpg', '/good/b.jpg', '/good/c.jpg']),
+      readPhotoFile: vi.fn(async (p: string) => {
+        if (p === '/bad/a.jpg') throw new Error('EACCES');
+        return { name: p.split('/').pop()!, mimeType: 'image/jpeg', base64: btoa('x') };
+      }),
+      competitions: { setWorkingDir },
+    });
+
+    await openPhotosViaElectron(9);
+
+    expect(setWorkingDir).toHaveBeenCalledWith('test-comp', '/good');
   });
 
   it('flags workingDirPersistFailed when setWorkingDir rejects', async () => {

--- a/frontend/photo-helper/src/components/DropZone.tsx
+++ b/frontend/photo-helper/src/components/DropZone.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/icons-material';
 import { isValidImageFile } from '../utils/imageProcessing';
 import { useI18n } from '../contexts/I18nContext';
-import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
+import { useElectronPhotoImport } from '../hooks/useElectronPhotoImport';
 
 interface DropZoneProps {
   onFilesDropped: (files: File[]) => void;
@@ -34,13 +34,14 @@ export const DropZone: React.FC<DropZoneProps> = ({
   error = null
 }) => {
   const availableSlots = Math.max(0, maxPhotos - currentPhotoCount);
-  const isDisabled = loading || availableSlots === 0;
   const { t } = useI18n();
   // In the desktop bundle we route the click to Electron's `dialog.
   // showOpenDialog` so the file picker opens in the competition's
   // working folder. Drag-and-drop still uses react-dropzone's native
   // handlers — only the click path differs (feedback 2026-04-25).
-  const useElectronDialog = isElectronPhotoImportAvailable();
+  const electronImport = useElectronPhotoImport();
+  const useElectronDialog = electronImport.isAvailable;
+  const isDisabled = loading || availableSlots === 0 || electronImport.isImporting;
 
   const {
     getRootProps,
@@ -79,13 +80,7 @@ export const DropZone: React.FC<DropZoneProps> = ({
 
   const handleElectronClick = async () => {
     if (isDisabled) return;
-    try {
-      const files = await openPhotosViaElectron(availableSlots);
-      const validFiles = files.filter(isValidImageFile);
-      if (validFiles.length > 0) onFilesDropped(validFiles);
-    } catch (err) {
-      console.error('[photo import] Electron dialog failed:', err);
-    }
+    await electronImport.pickPhotos(availableSlots, onFilesDropped);
   };
 
   // Determine styling based on state
@@ -175,6 +170,19 @@ export const DropZone: React.FC<DropZoneProps> = ({
       {error && (
         <Alert severity="error" sx={{ mb: 3 }}>
           {error}
+        </Alert>
+      )}
+
+      {/* Electron-import error: dialog failed, partial read failure, or
+          working-folder persistence failure. Click to dismiss so the
+          dropzone returns to its normal state without forcing a refresh. */}
+      {electronImport.importError && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 3, cursor: 'pointer' }}
+          onClose={electronImport.clearImportError}
+        >
+          {electronImport.importError}
         </Alert>
       )}
 

--- a/frontend/photo-helper/src/components/GridSizedDropZone.tsx
+++ b/frontend/photo-helper/src/components/GridSizedDropZone.tsx
@@ -15,7 +15,7 @@ import {
 import { isValidImageFile } from '../utils/imageProcessing';
 import { useI18n } from '../contexts/I18nContext';
 import { useAspectRatio } from '../contexts/AspectRatioContext';
-import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
+import { useElectronPhotoImport } from '../hooks/useElectronPhotoImport';
 
 interface GridSizedDropZoneProps {
   onFilesDropped: (files: File[]) => void;
@@ -35,7 +35,9 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
   const { t } = useI18n();
   const { currentRatio } = useAspectRatio();
 
-  const useElectronDialog = isElectronPhotoImportAvailable();
+  const electronImport = useElectronPhotoImport();
+  const useElectronDialog = electronImport.isAvailable;
+  const isBusy = loading || electronImport.isImporting;
 
   const {
     getRootProps,
@@ -50,7 +52,7 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
     },
     maxFiles: maxPhotos,
     maxSize: 20 * 1024 * 1024, // 20MB
-    disabled: loading,
+    disabled: isBusy,
     noClick: useElectronDialog,
     onDrop: (acceptedFiles, rejectedFiles) => {
       // Filter valid files
@@ -70,14 +72,8 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
   });
 
   const handleElectronClick = async () => {
-    if (loading) return;
-    try {
-      const files = await openPhotosViaElectron(maxPhotos);
-      const validFiles = files.filter(isValidImageFile);
-      if (validFiles.length > 0) onFilesDropped(validFiles);
-    } catch (err) {
-      console.error('[photo import] Electron dialog failed:', err);
-    }
+    if (isBusy) return;
+    await electronImport.pickPhotos(maxPhotos, onFilesDropped);
   };
 
   // Determine styling based on state
@@ -166,6 +162,18 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
+        </Alert>
+      )}
+
+      {/* Electron-import error: dialog failed, partial read failure, or
+          working-folder persistence failure. */}
+      {electronImport.importError && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 2, cursor: 'pointer' }}
+          onClose={electronImport.clearImportError}
+        >
+          {electronImport.importError}
         </Alert>
       )}
 

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -5,7 +5,7 @@ import { Image as ImageIcon, CloudUpload, Close } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
 import { PhotoEditorApi } from './PhotoEditorApi';
 import { isValidImageFile } from '../utils/imageProcessing';
-import { isElectronPhotoImportAvailable, openPhotosViaElectron } from '../utils/electronPhotoImport';
+import { useElectronPhotoImport } from '../hooks/useElectronPhotoImport';
 import { useAspectRatio } from '../contexts/AspectRatioContext';
 import { useLabeling } from '../contexts/LabelingContext';
 import { useI18n } from '../contexts/I18nContext';
@@ -352,7 +352,8 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
 }) => {
   const theme = useTheme();
   const { t } = useI18n();
-  const useElectronDialog = isElectronPhotoImportAvailable();
+  const electronImport = useElectronPhotoImport();
+  const useElectronDialog = electronImport.isAvailable;
   const slotMaxFiles = maxFilesRemaining ?? 9;
   const {
     getRootProps,
@@ -381,13 +382,9 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
   });
 
   const handleElectronClick = async () => {
-    try {
-      const files = await openPhotosViaElectron(slotMaxFiles);
-      const validFiles = files.filter(isValidImageFile);
-      if (validFiles.length > 0 && onFilesDropped) onFilesDropped(validFiles);
-    } catch (err) {
-      console.error('[photo import] Electron dialog failed:', err);
-    }
+    if (electronImport.isImporting) return;
+    if (!onFilesDropped) return;
+    await electronImport.pickPhotos(slotMaxFiles, onFilesDropped);
   };
 
   // Determine border color based on drag state
@@ -426,8 +423,23 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
       }}
     >
       <input {...getInputProps()} />
-      
-      {isDragActive ? (
+
+      {electronImport.importError ? (
+        // Replace the slot's normal contents with an inline error so the
+        // grid layout doesn't reflow — clicking the slot dismisses the
+        // error and returns it to the dropzone state.
+        <Box
+          onClick={(e) => { e.stopPropagation(); electronImport.clearImportError(); }}
+          sx={{ p: 1, textAlign: 'center', color: 'warning.dark' }}
+        >
+          <Typography variant="caption" sx={{ display: 'block', fontWeight: 500 }}>
+            {electronImport.importError}
+          </Typography>
+          <Typography variant="caption" sx={{ display: 'block', opacity: 0.7, mt: 0.5 }}>
+            {t('upload.clickOrDrop')}
+          </Typography>
+        </Box>
+      ) : isDragActive ? (
         <>
           <CloudUpload sx={{ fontSize: 32, mb: 1, opacity: 0.7 }} />
           <Typography variant="body2" sx={{ fontWeight: 500, textAlign: 'center', px: 1 }}>
@@ -438,10 +450,10 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
         <>
           <ImageIcon sx={{ fontSize: 28, mb: 1, opacity: 0.5 }} />
           {label && (
-            <Typography 
-              variant="h6" 
-              sx={{ 
-                fontWeight: 700, 
+            <Typography
+              variant="h6"
+              sx={{
+                fontWeight: 700,
                 fontSize: '1.1rem',
                 color: 'text.secondary',
                 mb: 0.5

--- a/frontend/photo-helper/src/hooks/useElectronPhotoImport.ts
+++ b/frontend/photo-helper/src/hooks/useElectronPhotoImport.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useSyncExternalStore } from 'react';
 import {
   isElectronPhotoImportAvailable,
   openPhotosViaElectron,
@@ -22,13 +22,43 @@ import { useI18n } from '../contexts/I18nContext';
  * - `setWorkingDir` rejects (disk full, EACCES) → toast-style notice
  *   that the persistence side regressed; the import itself succeeded
  */
+
+// `isImporting` MUST be shared across every component that mounts this
+// hook. PhotoGridSlotEmpty renders one hook instance per empty slot, so
+// per-component state would let slot A's still-pending readPhotoFile
+// reads race slot B's open-photos — main would clear `photoOpenAllowlist`
+// and slot A's reads would silently land in `failures`. A module-level
+// boolean exposed via useSyncExternalStore disables every dropzone the
+// moment any one of them starts importing, restoring the documented
+// "previous batch's reads always finish first" invariant.
+let globalIsImporting = false;
+const importingSubscribers = new Set<() => void>();
+
+function setGlobalIsImporting(v: boolean): void {
+  if (globalIsImporting === v) return;
+  globalIsImporting = v;
+  importingSubscribers.forEach(s => s());
+}
+
+function subscribeImporting(cb: () => void): () => void {
+  importingSubscribers.add(cb);
+  return () => { importingSubscribers.delete(cb); };
+}
+
+function getImportingSnapshot(): boolean {
+  return globalIsImporting;
+}
+
 export function useElectronPhotoImport() {
   const { t } = useI18n();
   const [importError, setImportError] = useState<string | null>(null);
-  // True while the dialog is open and files are being read. Lets
-  // dropzones disable themselves so a second click doesn't fire a
-  // parallel batch (which would race the allowlist replacement in main).
-  const [isImporting, setIsImporting] = useState(false);
+  // Subscribe to the module-level singleton so every dropzone re-renders
+  // (and disables itself) when another instance starts importing.
+  const isImporting = useSyncExternalStore(
+    subscribeImporting,
+    getImportingSnapshot,
+    getImportingSnapshot,
+  );
 
   const isAvailable = isElectronPhotoImportAvailable();
 
@@ -36,9 +66,11 @@ export function useElectronPhotoImport() {
 
   const pickPhotos = useCallback(
     async (maxFiles: number, onFiles: (files: File[]) => void) => {
-      if (!isAvailable || isImporting) return;
+      // Read the live singleton, not the rendered snapshot — between
+      // render and click the value can change without us re-rendering.
+      if (!isAvailable || globalIsImporting) return;
       setImportError(null);
-      setIsImporting(true);
+      setGlobalIsImporting(true);
       try {
         const result = await openPhotosViaElectron(maxFiles);
         if (result.failures.length) {
@@ -55,10 +87,10 @@ export function useElectronPhotoImport() {
         console.error('[photo import] dialog failed:', err);
         setImportError(t('upload.electronDialogFailed'));
       } finally {
-        setIsImporting(false);
+        setGlobalIsImporting(false);
       }
     },
-    [isAvailable, isImporting, t],
+    [isAvailable, t],
   );
 
   return { isAvailable, isImporting, importError, clearImportError, pickPhotos };

--- a/frontend/photo-helper/src/hooks/useElectronPhotoImport.ts
+++ b/frontend/photo-helper/src/hooks/useElectronPhotoImport.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react';
+import {
+  isElectronPhotoImportAvailable,
+  openPhotosViaElectron,
+  type PhotoImportFailure,
+} from '../utils/electronPhotoImport';
+import { isValidImageFile } from '../utils/imageProcessing';
+import { useI18n } from '../contexts/I18nContext';
+
+/**
+ * Single owner of the click → Electron-dialog → File[] flow shared by
+ * DropZone, GridSizedDropZone, and PhotoGridSlotEmpty. Three identical
+ * copies of try/catch-then-console.error were swallowing every failure
+ * path, leaving users with a click that produced no UI feedback. The
+ * hook exposes `importError` so each dropzone can render an Alert.
+ *
+ * Failure modes surfaced here:
+ * - Dialog fails to open (mainWindow null, IPC channel closed) → `importError`
+ * - User picks 9 photos, 4 fail to read (allowlist miss, EACCES, 30 MB
+ *   cap, corrupted file) → partial-import message, valid files still
+ *   delivered to the consumer
+ * - `setWorkingDir` rejects (disk full, EACCES) → toast-style notice
+ *   that the persistence side regressed; the import itself succeeded
+ */
+export function useElectronPhotoImport() {
+  const { t } = useI18n();
+  const [importError, setImportError] = useState<string | null>(null);
+  // True while the dialog is open and files are being read. Lets
+  // dropzones disable themselves so a second click doesn't fire a
+  // parallel batch (which would race the allowlist replacement in main).
+  const [isImporting, setIsImporting] = useState(false);
+
+  const isAvailable = isElectronPhotoImportAvailable();
+
+  const clearImportError = useCallback(() => setImportError(null), []);
+
+  const pickPhotos = useCallback(
+    async (maxFiles: number, onFiles: (files: File[]) => void) => {
+      if (!isAvailable || isImporting) return;
+      setImportError(null);
+      setIsImporting(true);
+      try {
+        const result = await openPhotosViaElectron(maxFiles);
+        if (result.failures.length) {
+          setImportError(formatFailureMessage(t, result.files.length, result.failures));
+        } else if (result.workingDirPersistFailed) {
+          setImportError(t('upload.workingDirPersistFailed'));
+        }
+        const validFiles = result.files.filter(isValidImageFile);
+        if (validFiles.length > 0) onFiles(validFiles);
+      } catch (err) {
+        // Reaches here only if openPhotosViaElectron itself rejects
+        // (the IPC threw before returning a structured result — e.g.
+        // `untrusted sender`, channel closed, mainWindow=null).
+        console.error('[photo import] dialog failed:', err);
+        setImportError(t('upload.electronDialogFailed'));
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [isAvailable, isImporting, t],
+  );
+
+  return { isAvailable, isImporting, importError, clearImportError, pickPhotos };
+}
+
+function formatFailureMessage(
+  t: ReturnType<typeof useI18n>['t'],
+  successCount: number,
+  failures: PhotoImportFailure[],
+): string {
+  if (successCount === 0) {
+    return t('upload.allFilesFailed', { count: failures.length });
+  }
+  return t('upload.partialImport', {
+    success: successCount,
+    failed: failures.length,
+    total: successCount + failures.length,
+  });
+}

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -142,7 +142,11 @@
     "slotsAvailable": "{{count}} {{slotText}} k dispozici",
     "slot": "místo",
     "slots": "míst",
-    "addTenthPhoto": "Přidat 10. fotku"
+    "addTenthPhoto": "Přidat 10. fotku",
+    "electronDialogFailed": "Výběr fotek se nepodařilo otevřít. Zkuste to znovu, nebo přetáhněte soubory z Průzkumníka.",
+    "allFilesFailed": "Žádnou z {{count}} vybraných fotek se nepodařilo načíst. Ověřte, že soubory existují a jsou ve formátu JPEG/PNG do 30 MB.",
+    "partialImport": "Načteno {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (poškozené, příliš velké nebo nejde o JPEG/PNG).",
+    "workingDirPersistFailed": "Fotky byly načteny, ale pracovní složku se nepodařilo uložit pro příští použití."
   },
   "photo": {
     "clickToEdit": "Klikněte pro úpravu",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -142,7 +142,11 @@
     "slotsAvailable": "{{count}} {{slotText}} available",
     "slot": "slot",
     "slots": "slots",
-    "addTenthPhoto": "Add 10th photo"
+    "addTenthPhoto": "Add 10th photo",
+    "electronDialogFailed": "Could not open the photo picker. Try again, or drag photos from File Explorer.",
+    "allFilesFailed": "None of the {{count}} selected photos could be read. Check the files exist and are JPEG/PNG under 30 MB.",
+    "partialImport": "Imported {{success}} of {{total}} photos. {{failed}} could not be read (corrupted, too large, or not JPEG/PNG).",
+    "workingDirPersistFailed": "Photos imported, but the working folder could not be saved for next time."
   },
   "photo": {
     "clickToEdit": "Click to Edit",

--- a/frontend/photo-helper/src/utils/electronPhotoImport.ts
+++ b/frontend/photo-helper/src/utils/electronPhotoImport.ts
@@ -10,10 +10,14 @@
  * folder — so the user steers the persistent default by simply navigating
  * in any open or save dialog (feedback 2026-04-25).
  *
- * Returns `[]` and lets the caller fall through to the native
- * `<input>` flow on the web build, when the dialog is cancelled, or
- * when no files come back.
+ * Failure mode contract: callers get back `{ files, failures }`. A
+ * cancelled dialog is `{ files: [], failures: [] }`. Per-file read
+ * errors land in `failures` instead of being silently swallowed — the
+ * `useElectronPhotoImport` hook surfaces them via an Alert so the user
+ * isn't left wondering why 5 of 9 photos vanished.
  */
+
+import { dirnameOf } from '@airq/shared-storage';
 
 declare global {
   interface Window {
@@ -28,7 +32,21 @@ declare global {
   }
 }
 
-function getCompetitionIdFromUrl(): string | null {
+export interface PhotoImportFailure {
+  path: string;
+  error: unknown;
+}
+
+export interface PhotoImportResult {
+  files: File[];
+  failures: PhotoImportFailure[];
+  /** True only when the user explicitly cancelled the dialog. */
+  cancelled: boolean;
+  /** True if `setWorkingDir` rejected — the persistence side of the feature regressed but the import itself worked. */
+  workingDirPersistFailed: boolean;
+}
+
+export function getCompetitionIdFromUrl(): string | null {
   try {
     const params = new URLSearchParams(window.location.search);
     return params.get('competitionId') || null;
@@ -37,14 +55,7 @@ function getCompetitionIdFromUrl(): string | null {
   }
 }
 
-function dirnameOf(fullPath: string): string | null {
-  const sepIdx = Math.max(fullPath.lastIndexOf('\\'), fullPath.lastIndexOf('/'));
-  if (sepIdx <= 0) return null;
-  const dir = fullPath.slice(0, sepIdx);
-  return dir || null;
-}
-
-function base64ToUint8Array(base64: string): Uint8Array {
+export function base64ToUint8Array(base64: string): Uint8Array {
   const binary = atob(base64);
   const len = binary.length;
   const bytes = new Uint8Array(len);
@@ -57,52 +68,89 @@ export function isElectronPhotoImportAvailable(): boolean {
   return !!(api && typeof api.openPhotos === 'function' && typeof api.readPhotoFile === 'function');
 }
 
-export async function openPhotosViaElectron(maxFiles?: number): Promise<File[]> {
+const EMPTY: PhotoImportResult = Object.freeze({
+  files: [],
+  failures: [],
+  cancelled: true,
+  workingDirPersistFailed: false,
+}) as PhotoImportResult;
+
+/**
+ * Open the Electron native photo dialog and return reconstructed File
+ * objects. Failures are reported alongside successes — never silently
+ * swallowed. Web-build callers get `{ files: [], failures: [], cancelled: true }`
+ * (effectively a no-op) so they can fall through to their HTML
+ * `<input type=file>` flow.
+ */
+export async function openPhotosViaElectron(maxFiles?: number): Promise<PhotoImportResult> {
   const api = window.electronAPI;
-  if (!api?.openPhotos || !api?.readPhotoFile) return [];
+  if (!api?.openPhotos || !api?.readPhotoFile) return EMPTY;
 
   // Read the competition's working dir (if any) to seed the dialog's
-  // starting directory. Competition id is on the URL when launched from
-  // the desktop launcher (`?competitionId=…`). Best-effort — failures
-  // are non-fatal; the dialog will fall back to ~/Pictures.
+  // starting directory. Best-effort — failures are non-fatal; the
+  // dialog will fall back to ~/Pictures.
   const competitionId = getCompetitionIdFromUrl();
   let workingDir: string | undefined;
   if (competitionId && api.competitions?.getWorkingDir) {
     try {
       const dir = await api.competitions.getWorkingDir(competitionId);
       if (dir) workingDir = dir;
-    } catch { /* non-fatal */ }
+    } catch (err) {
+      // Keep this debug-level so a real IPC regression is at least
+      // diagnosable in devtools, without polluting the user-visible
+      // error channel for a best-effort lookup.
+      console.debug('[photo import] getWorkingDir failed (using default):', err);
+    }
   }
 
   const paths = await api.openPhotos(workingDir, maxFiles);
-  if (!paths || !paths.length) return [];
+  if (!paths || !paths.length) return EMPTY;
 
-  // Reconstruct File objects from each path. Reading happens in main
-  // (Node fs) and the bytes come over IPC as base64; we decode and wrap
-  // in a Blob/File so the existing onFilesDropped pipeline (which
-  // expects File[]) doesn't need changes.
+  // Parallelize the per-file reads. Each round-trip is fs.readFileSync
+  // + Buffer.toString('base64') (~40 MB string for a 30 MB image) +
+  // IPC + renderer atob, all CPU-bound on different stages — running
+  // them concurrently overlaps the renderer-side decode with main-side
+  // reads and shaves seconds off a 9-photo import. Failures are
+  // captured per-path so a partial batch still surfaces what worked.
+  const settled = await Promise.all(
+    paths.map(async (p): Promise<{ ok: true; file: File } | { ok: false; path: string; error: unknown }> => {
+      try {
+        const data = await api.readPhotoFile!(p);
+        if (!data || !data.base64) {
+          return { ok: false, path: p, error: new Error('Empty response from readPhotoFile') };
+        }
+        const bytes = base64ToUint8Array(data.base64);
+        return { ok: true, file: new File([bytes], data.name, { type: data.mimeType }) };
+      } catch (err) {
+        return { ok: false, path: p, error: err };
+      }
+    }),
+  );
+
   const files: File[] = [];
-  for (const p of paths) {
-    try {
-      const data = await api.readPhotoFile(p);
-      if (!data || !data.base64) continue;
-      const bytes = base64ToUint8Array(data.base64);
-      files.push(new File([bytes], data.name, { type: data.mimeType }));
-    } catch (err) {
-      console.error('[photo import] Failed to read', p, err);
-    }
+  const failures: PhotoImportFailure[] = [];
+  for (const r of settled) {
+    if (r.ok) files.push(r.file);
+    else failures.push({ path: r.path, error: r.error });
   }
 
   // Promote the chosen folder to the working dir so subsequent dialogs
-  // (saves, future imports) default there.
-  if (competitionId && api.competitions?.setWorkingDir && paths[0]) {
-    const dir = dirnameOf(paths[0]);
+  // (saves, future imports) default there. Use the first SUCCESSFULLY
+  // READ path's dirname when possible — falling back to paths[0]
+  // promotes a directory we couldn't actually import from.
+  let workingDirPersistFailed = false;
+  if (competitionId && api.competitions?.setWorkingDir) {
+    const seedPath = (settled.find(r => r.ok) ? paths[settled.findIndex(r => r.ok)] : paths[0]) ?? null;
+    const dir = seedPath ? dirnameOf(seedPath) : null;
     if (dir) {
-      api.competitions.setWorkingDir(competitionId, dir).catch((err: unknown) => {
+      try {
+        await api.competitions.setWorkingDir(competitionId, dir);
+      } catch (err) {
+        workingDirPersistFailed = true;
         console.warn('[workingDir] persist failed:', err);
-      });
+      }
     }
   }
 
-  return files;
+  return { files, failures, cancelled: false, workingDirPersistFailed };
 }

--- a/frontend/photo-helper/src/utils/electronPhotoImport.ts
+++ b/frontend/photo-helper/src/utils/electronPhotoImport.ts
@@ -135,12 +135,14 @@ export async function openPhotosViaElectron(maxFiles?: number): Promise<PhotoImp
   }
 
   // Promote the chosen folder to the working dir so subsequent dialogs
-  // (saves, future imports) default there. Use the first SUCCESSFULLY
-  // READ path's dirname when possible — falling back to paths[0]
-  // promotes a directory we couldn't actually import from.
+  // (saves, future imports) default there. Only seed from a path we
+  // actually managed to read — promoting a directory we couldn't import
+  // from would mislead the next dialog into a folder the user is already
+  // having trouble with.
   let workingDirPersistFailed = false;
   if (competitionId && api.competitions?.setWorkingDir) {
-    const seedPath = (settled.find(r => r.ok) ? paths[settled.findIndex(r => r.ok)] : paths[0]) ?? null;
+    const firstOkIdx = settled.findIndex(r => r.ok);
+    const seedPath = firstOkIdx >= 0 ? paths[firstOkIdx] : null;
     const dir = seedPath ? dirnameOf(seedPath) : null;
     if (dir) {
       try {

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Document, Page, Image, pdf, StyleSheet } from '@react-pdf/renderer';
 import type { ApiPhotoSet } from '../types/api';
+import { dirnameOf } from '@airq/shared-storage';
 
 // Polyfill Buffer for @react-pdf/renderer
 import { Buffer } from 'buffer';
@@ -491,16 +492,14 @@ export const generatePDF = async (
         // Promote the directory the user actually picked to the
         // competition's working folder. Lets the user *steer* the default
         // for the next save dialog by simply navigating in this one
-        // (feedback 2026-04-25).
+        // (feedback 2026-04-25). Shared `dirnameOf` handles drive-letter
+        // roots, POSIX root, UNC, and trailing-separator edge cases.
         if (savedPath && competitionId && api.competitions?.setWorkingDir) {
-          const sepIdx = Math.max(savedPath.lastIndexOf('\\'), savedPath.lastIndexOf('/'));
-          if (sepIdx > 0) {
-            const dir = savedPath.slice(0, sepIdx);
-            if (dir) {
-              api.competitions.setWorkingDir(competitionId, dir).catch((err: unknown) => {
-                console.warn('[workingDir] persist failed:', err);
-              });
-            }
+          const dir = dirnameOf(savedPath);
+          if (dir) {
+            api.competitions.setWorkingDir(competitionId, dir).catch((err: unknown) => {
+              console.warn('[workingDir] persist failed:', err);
+            });
           }
         }
         return;

--- a/frontend/shared-storage/src/index.ts
+++ b/frontend/shared-storage/src/index.ts
@@ -25,6 +25,8 @@ export type {
   ElectronStorageAPI,
 } from './types';
 
+export { dirnameOf } from './pathUtils';
+
 import type { StorageInterface, StorageType } from './types';
 import { OPFSStorage, opfsStorage } from './opfsStorage';
 import { ElectronStorage, electronStorage } from './electronStorage';

--- a/frontend/shared-storage/src/pathUtils.ts
+++ b/frontend/shared-storage/src/pathUtils.ts
@@ -1,0 +1,67 @@
+/**
+ * Tiny string-only path helpers that work in the browser/renderer where
+ * Node's `path` module isn't available without a polyfill. Used by every
+ * app to extract `dirname(savedPath)` after a save dialog returns, so the
+ * chosen folder can be promoted to the competition's working directory.
+ *
+ * Three callers (`map-corridors/App.tsx`, `photo-helper/pdfGenerator.ts`,
+ * `photo-helper/electronPhotoImport.ts`) used to ship inline copies that
+ * disagreed on edge cases (drive-letter roots, posix root files, no
+ * separator). Single source of truth fixes that.
+ */
+
+/**
+ * Extract the directory portion of a file path. Works on both Windows
+ * (`C:\photos\img.jpg`) and POSIX (`/home/u/img.jpg`) inputs, plus mixed
+ * slashes that Electron's `dialog.showSaveDialog` sometimes returns.
+ *
+ * Returns `null` when the input has no usable separator — callers fall
+ * back to their own defaults instead of persisting a malformed path.
+ *
+ * Edge cases worth knowing about:
+ * - Drive-letter root file `C:\file.txt` returns `C:\` (NOT `C:`, because
+ *   `path.resolve("C:")` on Windows points to the *cwd of drive C*,
+ *   while `C:\` is the actual drive root).
+ * - POSIX root file `/file.kml` returns `/` (NOT `null` — the user
+ *   actually picked the filesystem root, persist that).
+ * - UNC `\\server\share\file.kml` returns `\\server\share` so the
+ *   server-side `validateUserDir` can then reject it with a meaningful
+ *   error rather than silently skipping persistence.
+ * - Trailing separator on a directory path `C:\photos\` returns
+ *   `C:\photos` (the input IS a directory, drop only the trailing sep).
+ * - Already-a-root inputs (`C:\`, `C:/`, `/`) are returned as-is — they
+ *   have no parent, but persisting the root itself is a valid choice.
+ * - No separator `file.txt` returns `null`.
+ */
+export function dirnameOf(fullPath: string): string | null {
+  if (typeof fullPath !== 'string' || !fullPath) return null;
+
+  // Already-a-root inputs: nothing to extract, but the path itself is
+  // valid as a directory. Caller decides whether to persist it (the
+  // server-side `validateUserDir` rejects UNC; everything else is fine).
+  if (fullPath === '/') return '/';
+  if (/^[a-zA-Z]:[\\/]$/.test(fullPath)) return fullPath;
+
+  // Trailing separator means the input IS a directory — return it minus
+  // the trailing sep so callers don't get a path with a dangling slash.
+  if (fullPath.length > 1 && (fullPath.endsWith('\\') || fullPath.endsWith('/'))) {
+    return fullPath.slice(0, -1);
+  }
+
+  const lastBack = fullPath.lastIndexOf('\\');
+  const lastFwd = fullPath.lastIndexOf('/');
+  const sepIdx = Math.max(lastBack, lastFwd);
+  if (sepIdx < 0) return null;
+
+  // POSIX root file: `/foo` (sepIdx=0). The directory IS root.
+  if (sepIdx === 0) return fullPath[0] || null;
+
+  // Windows drive-letter root file: `C:\foo` (sepIdx=2). Return `C:\`
+  // WITH the trailing separator so the value round-trips through
+  // `path.resolve` correctly on Windows.
+  if (sepIdx === 2 && /^[a-zA-Z]:[\\/]/.test(fullPath)) {
+    return fullPath.slice(0, 3);
+  }
+
+  return fullPath.slice(0, sepIdx);
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #48. The post-merge code review surfaced eight findings; this PR addresses all of them with tests.

### Security (Electron main hardening)

- **read-photo-file allowlist (I1)**: the IPC accepted any path. The comment claimed paths were *"constrained to files the user already saw in the open dialog"* but no such constraint existed. Renderer XSS (untrusted KML, image EXIF, Mapbox-injected content) could read any local file under 30 MB. Now: a per-window `photoOpenAllowlist` is populated by `open-photos`, gated in `read-photo-file`, cleared on `will-navigate` and on each new `open-photos` call (bounded membership across long sessions).
- **Symlink rejection (I1)**: `statSync` follows symlinks. A malicious symlink under `~/Pictures` could redirect to `~/.ssh/id_rsa` even with the allowlist. Now: `lstatSync` + `isSymbolicLink()` rejection.
- **UNC guard parity (I2)**: `isSafeStartDir` (NTLMv2 hash leak protection added in PR #46) was applied only to `save-kml`. `open-photos`, `save-map-image`, `save-pdf`, `competition-set-working-dir`, and `competition-get-working-dir` all bypassed it; any of those could let a renderer poison `defaultPath` with `\attacker\share`. Now: a single `validateUserDir(input)` helper enforces typeof + 4096 length cap + UNC/device rejection + on-disk existence in one place, applied uniformly across all five handlers.
- **Extension allowlist**: `read-photo-file` inferred MIME from path. On Windows a user could type `*.*` in the dialog and pick anything; the bytes came back labelled `image/jpeg`. Now: explicit `.jpg`/`.jpeg`/`.png` allowlist.
- **maxFiles hard cap (I8)**: renderer could pass `Number.MAX_SAFE_INTEGER` and OOM via base64 expansion. Now: hard server-side cap of 200.

### UX / silent failures

- **Per-file failures surfaced (I3)**: `for (...) { try { ... } catch { console.error } }` meant 4-of-9 photos could vanish without any user feedback. Now: `openPhotosViaElectron` returns `{ files, failures, cancelled, workingDirPersistFailed }`; failures land in an Alert.
- **Click handler errors surfaced (I4)**: three identical copies of `} catch (err) { console.error(...); }` made dialog failures indistinguishable from user-cancel. Now: a shared `useElectronPhotoImport` React hook owns the click flow and exposes `importError`. DropZone, GridSizedDropZone, and PhotoGridSlotEmpty all render an Alert (or in the slot's case, an inline error replacement that preserves grid layout).
- **Persist failures surfaced (I5)**: `setWorkingDir().catch(console.warn)` meant the entire feature could silently regress on disk-full / EACCES. Now: `workingDirPersistFailed` flag triggers a toast-style warning.
- **Parallel reads (I7)**: serial `await readPhotoFile(p)` blocked the UI ~5-10s for 9 × 30 MB photos. Now: `Promise.all` overlaps the renderer-side decode with main-side reads.

### DRY (I6)

Three inline copies of the dirname extraction (App.tsx, pdfGenerator.ts, electronPhotoImport.ts) disagreed on edge cases (drive-letter root, POSIX root, UNC, trailing separators). Replaced with a single `dirnameOf` in `@airq/shared-storage`, with comprehensive unit tests pinning every edge case the inline copies got wrong:
- Drive-letter root file `C:\file.txt` → `C:\` (not `C:`, which `path.resolve` interprets as cwd of drive C)
- POSIX root file `/file.kml` → `/` (not `null` — silently skipping persistence)
- UNC `\server\share\file.kml` → `\server\share` (let `validateUserDir` reject it server-side with a real error)
- Trailing-separator dir, mixed slashes, drive-only roots, empty/non-string inputs

### Tests

- `frontend/photo-helper/src/__tests__/dirnameOf.test.ts` — 15 cases
- `frontend/photo-helper/src/__tests__/electronPhotoImport.test.ts` — 24 cases (base64 round-trip + invalid input, `getCompetitionIdFromUrl` URL parsing, every branch of `openPhotosViaElectron` including partial-failure, cancel, no-id-on-URL, and `setWorkingDir` rejection)

### i18n

en.json + cs.json: `electronDialogFailed`, `allFilesFailed`, `partialImport`, `workingDirPersistFailed`. Czech with proper diacritics.

## Test plan

- [x] \`pnpm --filter @airq/photo-helper test\` — **101/101**
- [x] \`pnpm --filter @airq/map-corridors test\` — **154/154**
- [x] \`pnpm --filter @airq/photo-helper build\` — clean
- [x] \`pnpm --filter @airq/map-corridors build\` — clean
- [x] \`VITE_DESKTOP_BUILD=true pnpm --filter @airq/desktop build:apps\` — clean
- [ ] Manual: import 9 photos in Electron build → all land, no Alert
- [ ] Manual: simulate read failure (e.g. delete a file between dialog close and read) → Alert shows "Imported X of Y photos. Z could not be read."
- [ ] Manual: drag-and-drop from File Explorer still works (HTML5 drop unchanged)
- [ ] Manual: KML save / map PNG save / PDF save dialogs still default to the working folder; choosing a different folder still updates workingDir
- [ ] Manual: navigate away and back → photoOpenAllowlist is cleared, no stale-allowlist false negatives