### PR TITLE
chore: gitignore session artifacts and runtime lock files #patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,17 @@ deploy.conf
 public_html
 
 # Claude Code local settings (per-user permissions allowlist)
+# and runtime lock files (e.g. scheduled_tasks.lock)
 .claude/settings.local.json
+.claude/*.lock
+
+# Local PR diff dumps (e.g. pr47.diff, pr50_review.diff) saved during
+# review sessions — never intended for the repo
+/pr*.diff
+
+# Root-level static deploy bundle (built output staged for hosting,
+# distinct from per-app `dist/` already covered above)
+/public/
 
 # Backend photo-helper specific
 backend/photo-helper/venv/


### PR DESCRIPTION
## Summary

Add ignore patterns for four classes of stray artifacts that kept reappearing in \`git status\` during recent PR work, masking real changes:

- \`.claude/*.lock\` — Claude Code scheduled_tasks.lock (runtime state)
- \`/pr*.diff\` — local diff dumps from review sessions
- \`/public/\` — root-level static deploy bundle (Vite hashed output)

Rooted patterns (\`/pr*.diff\`, \`/public/\`) so they only match at repo root — workspace-level \`public/\` source directories (Next.js/CRA convention) and any future \`docs/pr-*.diff\` are unaffected.

## Out of scope (intentionally left untracked)

\`frontend/map-corridors/src/__tests__/fixtures/RF_RED.kml\` and \`RF_2_RED.kml\` are untracked locally but unreferenced by any test (\`loadFixture\` only consumes the committed \`RED.kml\` / \`RED_SC.kml\`). Could be upcoming fixtures or local exploration drops — flagging for human triage rather than guessing.

## Test plan

- [x] \`git check-ignore -v\` confirms all four target paths now match rules
- [x] No tracked files affected (verified with \`git status\` post-edit)
- [x] No new patterns conflict with existing ignored / committed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)