### PR TITLE
fix: round-4 user feedback (rally cap to 20, scenic-leg attribution, launcher folder picker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ downloads/
 eggs/
 .eggs/
 lib/
+# But our Electron desktop package has a `lib/` directory of pure
+# CommonJS helpers (path validators, etc.) that DOES need to be tracked.
+!frontend/desktop/lib/
+!frontend/desktop/lib/**
 lib64/
 parts/
 sdist/

--- a/frontend/desktop/__tests__/pathValidation.test.js
+++ b/frontend/desktop/__tests__/pathValidation.test.js
@@ -1,0 +1,248 @@
+// Path-validation regression suite. The validators are the load-bearing
+// security boundary for every Electron IPC handler that touches the
+// filesystem (`competition-create`, `pick-directory`, `read-photo-file`).
+// A regression in any of them lets a compromised renderer escape the
+// per-user storage root, so these tests pin the behaviour.
+//
+// The helpers live in `lib/pathValidation.js` (pure CommonJS) — extracted
+// from `main.js` specifically so they could be tested without spinning
+// up Electron. The test file uses ESM-style `import` for vitest (required
+// by vitest 4) but the module under test stays CommonJS — Node ESM-CJS
+// interop handles the bridge.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  MAX_USER_PATH_LEN,
+  sanitizeFileName,
+  isSafeStartDir,
+  validateUserDir,
+  validateStoragePath,
+} = require('../lib/pathValidation');
+
+describe('sanitizeFileName', () => {
+  it('passes through clean ASCII identifiers unchanged', () => {
+    expect(sanitizeFileName('comp-1234567890-abc123')).toBe('comp-1234567890-abc123');
+    expect(sanitizeFileName('photo.jpg')).toBe('photo.jpg');
+    expect(sanitizeFileName('My_File-2026.kml')).toBe('My_File-2026.kml');
+  });
+
+  it('returns "file" for non-string inputs', () => {
+    // Defensive: a renderer that bypasses preload (somehow) shouldn't
+    // crash main.js. Returning a safe placeholder lets the caller proceed
+    // to validateStoragePath which will reject the resulting path.
+    expect(sanitizeFileName(null)).toBe('file');
+    expect(sanitizeFileName(undefined)).toBe('file');
+    expect(sanitizeFileName(42)).toBe('file');
+    expect(sanitizeFileName({})).toBe('file');
+  });
+
+  it('replaces path separators with dashes (path traversal containment)', () => {
+    // Both POSIX and Windows separators must die. The output is then fed
+    // to `path.join`, where a remaining `..` segment would still be a
+    // traversal attempt — so the strict allowlist below ALSO catches `..`
+    // in the form of `..-..--evil` rather than letting it through.
+    expect(sanitizeFileName('a/b')).toBe('a-b');
+    expect(sanitizeFileName('a\\b')).toBe('a-b');
+    expect(sanitizeFileName('../../etc/passwd')).toBe('..-..-etc-passwd');
+    expect(sanitizeFileName('..\\..\\Windows\\System32')).toBe('..-..-Windows-System32');
+  });
+
+  it('strips control characters (NUL through 0x1F and 0x7F)', () => {
+    // Null bytes are particularly dangerous — they truncate paths in
+    // some lower-level APIs. Strip every control char to be safe.
+    expect(sanitizeFileName('foo\x00bar')).toBe('foobar');
+    expect(sanitizeFileName('foo\x1Fbar')).toBe('foobar');
+    expect(sanitizeFileName('foo\x7Fbar')).toBe('foobar');
+    expect(sanitizeFileName('foo\nbar\tbaz')).toBe('foobarbaz');
+  });
+
+  it('replaces all non-allowlisted chars with dashes', () => {
+    // Allowlist is `[A-Za-z0-9._-]`. Czech diacritics, spaces, emojis,
+    // shell metacharacters all become dashes.
+    // 'ě' and 'ž' are non-allowlisted (each → '-'), the space is also '-',
+    // so 'soutěž 2026' becomes 'sout---2026' (three dashes).
+    expect(sanitizeFileName('soutěž 2026')).toBe('sout---2026');
+    expect(sanitizeFileName('a&b|c;d')).toBe('a-b-c-d');
+    // 'foo;rm -rf /' → step 1 turns '/' into '-' (trailing dash), step 4
+    // turns ';' and the two spaces into dashes, producing two trailing dashes
+    // (one from the space-before-`/`-was-already-`-`, one from the original `/`).
+    expect(sanitizeFileName('foo;rm -rf /')).toBe('foo-rm--rf--');
+  });
+
+  it('truncates to 128 characters', () => {
+    const long = 'a'.repeat(500);
+    const out = sanitizeFileName(long);
+    expect(out.length).toBe(128);
+    expect(out).toBe('a'.repeat(128));
+  });
+
+  it('returns "file" when every character gets stripped', () => {
+    // All-whitespace, all-control-char inputs yield empty after sanitisation.
+    expect(sanitizeFileName('   ')).toBe('file');
+    expect(sanitizeFileName('\x00\x01\x02')).toBe('file');
+    expect(sanitizeFileName('')).toBe('file');
+  });
+
+  it('preserves the documented allowlisted characters intact', () => {
+    expect(sanitizeFileName('a-b_c.d')).toBe('a-b_c.d');
+    expect(sanitizeFileName('ABC-xyz_123.ext')).toBe('ABC-xyz_123.ext');
+  });
+});
+
+describe('isSafeStartDir', () => {
+  it('rejects non-string and empty inputs', () => {
+    expect(isSafeStartDir(null)).toBe(false);
+    expect(isSafeStartDir(undefined)).toBe(false);
+    expect(isSafeStartDir('')).toBe(false);
+    expect(isSafeStartDir(42)).toBe(false);
+  });
+
+  it('rejects UNC paths (\\\\server\\share)', () => {
+    // The NTLMv2 leak vector — a UNC default path triggers an SMB
+    // handshake to the attacker-controlled host on Windows.
+    expect(isSafeStartDir('\\\\fileserver\\public')).toBe(false);
+    expect(isSafeStartDir('\\\\evil.example.com\\share')).toBe(false);
+  });
+
+  it('rejects POSIX-style UNC representations (//server/share)', () => {
+    // path.resolve normalises some of these on certain runtimes; the
+    // validator catches both styles upfront.
+    expect(isSafeStartDir('//fileserver/public')).toBe(false);
+  });
+
+  it('rejects Windows device namespaces (\\\\?\\..., \\\\.\\..., )', () => {
+    // The `\\?\` namespace bypasses MAX_PATH and skips Win32 path
+    // normalisation; `\\.\` reaches device drivers directly. Either is a
+    // long-tail bypass surface — neither should ever land in a save
+    // dialog default.
+    expect(isSafeStartDir('\\\\?\\C:\\Windows')).toBe(false);
+    expect(isSafeStartDir('\\\\.\\PhysicalDrive0')).toBe(false);
+  });
+
+  it('accepts ordinary local paths', () => {
+    expect(isSafeStartDir('C:\\Users\\alice\\Documents')).toBe(true);
+    expect(isSafeStartDir('/home/alice/Documents')).toBe(true);
+    expect(isSafeStartDir('D:\\rally-2026')).toBe(true);
+  });
+});
+
+describe('validateUserDir', () => {
+  let tmpDir;
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'airq-pathval-'));
+  });
+  afterAll(() => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('accepts an existing local directory', () => {
+    expect(validateUserDir(tmpDir)).toBe(path.resolve(tmpDir));
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(validateUserDir(null)).toBeNull();
+    expect(validateUserDir(undefined)).toBeNull();
+    expect(validateUserDir(42)).toBeNull();
+  });
+
+  it('rejects empty / whitespace-only strings', () => {
+    expect(validateUserDir('')).toBeNull();
+    expect(validateUserDir('   ')).toBeNull();
+  });
+
+  it('rejects strings longer than MAX_USER_PATH_LEN', () => {
+    expect(MAX_USER_PATH_LEN).toBe(4096);
+    const tooLong = 'a' + '/b'.repeat(MAX_USER_PATH_LEN);
+    expect(validateUserDir(tooLong)).toBeNull();
+  });
+
+  it('rejects non-existent paths', () => {
+    const ghost = path.join(tmpDir, 'definitely-does-not-exist-' + Date.now());
+    expect(validateUserDir(ghost)).toBeNull();
+  });
+
+  it('rejects paths that exist but are not directories', () => {
+    const file = path.join(tmpDir, 'a-file.txt');
+    fs.writeFileSync(file, 'hello', 'utf8');
+    expect(validateUserDir(file)).toBeNull();
+  });
+
+  it('rejects UNC paths', () => {
+    // Even if a UNC path happens to resolve, validateUserDir blocks it
+    // via isSafeStartDir BEFORE touching the filesystem.
+    expect(validateUserDir('\\\\fileserver\\share')).toBeNull();
+    expect(validateUserDir('//fileserver/share')).toBeNull();
+  });
+
+  it('rejects Windows device namespaces', () => {
+    expect(validateUserDir('\\\\?\\C:\\Windows')).toBeNull();
+    expect(validateUserDir('\\\\.\\PhysicalDrive0')).toBeNull();
+  });
+});
+
+describe('validateStoragePath', () => {
+  let storageRoot;
+  beforeAll(() => {
+    storageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'airq-storage-root-'));
+  });
+  afterAll(() => {
+    try { fs.rmSync(storageRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('accepts a path strictly inside the storage root', () => {
+    const inside = path.join(storageRoot, 'competitions', 'comp-123');
+    expect(validateStoragePath(inside, storageRoot)).toBe(path.resolve(inside));
+  });
+
+  it('accepts the storage root itself', () => {
+    // The convention: `path.startsWith(root + sep)` would NOT match the
+    // root directly, so the validator has an explicit `=== rootPath`
+    // branch. Pin it.
+    expect(validateStoragePath(storageRoot, storageRoot)).toBe(path.resolve(storageRoot));
+  });
+
+  it('rejects a `..` traversal attempt that escapes the root', () => {
+    const escape = path.join(storageRoot, '..', 'evil');
+    expect(() => validateStoragePath(escape, storageRoot)).toThrow(/Access denied/);
+  });
+
+  it('rejects a path lexically outside the root (no shared prefix)', () => {
+    expect(() => validateStoragePath('/tmp/elsewhere', storageRoot)).toThrow(/Access denied/);
+  });
+
+  it('rejects a prefix-confusion neighbour (root + extra letters)', () => {
+    // Round-5 test for the "/foo/bar matches /foo/barbaz" class: the
+    // validator uses `startsWith(root + path.sep)` precisely to block
+    // this. A regression that drops the trailing separator would
+    // accept `<root>BAD` as if it were inside the root.
+    const neighbour = path.resolve(storageRoot) + 'BAD';
+    expect(() => validateStoragePath(neighbour, storageRoot)).toThrow(/Access denied/);
+  });
+
+  it('normalises before comparing (./, redundant separators)', () => {
+    // `path.resolve` collapses `./` and double separators. A path that's
+    // truly inside the root after normalisation is accepted.
+    const messy = path.join(storageRoot, '.', 'sub', '.', 'leaf');
+    const expected = path.resolve(path.join(storageRoot, 'sub', 'leaf'));
+    expect(validateStoragePath(messy, storageRoot)).toBe(expected);
+  });
+
+  it('an embedded `..` that resolves back inside the root is accepted post-normalisation', () => {
+    // Some validators are fooled by `<root>/sub/../leaf` (which resolves
+    // BACK inside the root). Lexical `path.resolve` correctly normalises
+    // this to `<root>/leaf`, which IS inside the root — so this test
+    // pins the documented behaviour rather than asserting rejection.
+    // What matters is that the resolved path lives under the root, NOT
+    // the literal string the caller supplied.
+    const stillInside = path.join(storageRoot, 'sub', '..', 'leaf');
+    expect(validateStoragePath(stillInside, storageRoot)).toBe(
+      path.resolve(path.join(storageRoot, 'leaf'))
+    );
+  });
+});

--- a/frontend/desktop/lib/pathValidation.js
+++ b/frontend/desktop/lib/pathValidation.js
@@ -1,0 +1,79 @@
+// Pure path-validation helpers shared by the Electron main process and the
+// test suite. Extracted from main.js so the lexical containment, UNC
+// rejection, and filename sanitisation rules can be unit-tested directly
+// without spinning up Electron — the validators are the load-bearing
+// security boundary for every IPC handler that touches the filesystem
+// (`competition-create`, `pick-directory`, `read-photo-file`, etc.), and a
+// regression in any of them would let a compromised renderer escape the
+// per-user storage root.
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_USER_PATH_LEN = 4096;
+
+// Strip path separators, control chars, and non-`[A-Za-z0-9._-]` content,
+// then truncate to 128. Falls back to `'file'` if every char gets stripped
+// (e.g. an all-whitespace input).
+function sanitizeFileName(input) {
+  if (typeof input !== 'string') return 'file';
+  // Order matters: replace separators with `-` BEFORE the strict allowlist
+  // pass below so a `..\..\evil` payload becomes `..-..--evil`, not `evil`.
+  const stripped = input
+    .replace(/[\\/]/g, '-')
+    .replace(new RegExp('[\\u0000-\\u001F\\u007F]', 'g'), '')
+    .trim();
+  const normalized = stripped.replace(/[^A-Za-z0-9._-]/g, '-');
+  const truncated = normalized.slice(0, 128);
+  return truncated.length > 0 ? truncated : 'file';
+}
+
+// Reject UNC paths (`\\server\share`, `//server/share`) and Windows device
+// namespaces (`\\?\`, `\\.\`). A renderer-supplied UNC path as the save
+// dialog's `defaultPath` would pre-point the user at an attacker-controlled
+// SMB share — one click later the KML lands remote and, on Windows, an
+// NTLMv2 handshake to the attacker's host leaks the user's hashed creds.
+function isSafeStartDir(abs) {
+  if (typeof abs !== 'string' || !abs) return false;
+  if (/^(\\\\|\/\/)/.test(abs)) return false;
+  if (/^\\\\[?.]\\/.test(abs)) return false;
+  return true;
+}
+
+// Single source of truth for "renderer gave us a directory string — should we
+// trust it as `defaultPath` for a dialog or persist it as workingDir?". Wraps
+// the four checks (type, length cap, UNC/device rejection, on-disk presence)
+// that were copy-pasted across handlers and easy to forget on new ones.
+function validateUserDir(input) {
+  if (typeof input !== 'string' || !input.trim()) return null;
+  if (input.length > MAX_USER_PATH_LEN) return null;
+  let abs;
+  try { abs = path.resolve(input); } catch { return null; }
+  if (!isSafeStartDir(abs)) return null;
+  try {
+    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) return null;
+  } catch { return null; }
+  return abs;
+}
+
+// Validate that a path is within the allowed storage directory (prevent path
+// traversal). Lexical containment via `path.resolve` + `startsWith(rootPath +
+// path.sep)` — the trailing-separator check prevents prefix-confusion bugs
+// like `/foo/bar` matching `/foo/barbaz`. Accepts a `rootPath` so tests can
+// inject a tmpdir without depending on Electron's `app.getPath('userData')`.
+function validateStoragePath(inputPath, rootPath) {
+  const resolvedRoot = path.resolve(rootPath);
+  const resolved = path.resolve(inputPath);
+  if (!resolved.startsWith(resolvedRoot + path.sep) && resolved !== resolvedRoot) {
+    throw new Error('Access denied: path outside storage directory');
+  }
+  return resolved;
+}
+
+module.exports = {
+  MAX_USER_PATH_LEN,
+  sanitizeFileName,
+  isSafeStartDir,
+  validateUserDir,
+  validateStoragePath,
+};

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -308,16 +308,29 @@ function getPhotoSessionsPath() {
   return path.join(app.getPath('userData'), 'photo-sessions');
 }
 
-// Sanitize filename to prevent path traversal
-function sanitizeFileName(input) {
-  const removedUnsafe = input
-    .replace(/[\\/]/g, '-')
-    .replace(/[\u0000-\u001F\u007F]/g, '')
-    .trim();
-  const normalized = removedUnsafe.replace(/[^A-Za-z0-9._-]/g, '-');
-  const truncated = normalized.slice(0, 128);
-  return truncated.length > 0 ? truncated : 'file';
+// Path validators (sanitizeFileName, validateUserDir, validateStoragePath,
+// isSafeStartDir, MAX_USER_PATH_LEN) live in `lib/pathValidation.js` so they
+// can be unit-tested directly. The implementations are unchanged — only the
+// home is different.
+const {
+  MAX_USER_PATH_LEN,
+  sanitizeFileName: sanitizeFileNamePure,
+  isSafeStartDir,
+  validateUserDir,
+  validateStoragePath: validateStoragePathPure,
+} = require('./lib/pathValidation');
+
+// Convenience wrapper that pins the storage root to the photo-sessions
+// directory — every existing call site uses this root.
+function validateStoragePath(inputPath) {
+  return validateStoragePathPure(inputPath, getPhotoSessionsPath());
 }
+
+// Sanitize filename to prevent path traversal — delegates to the lib helper.
+function sanitizeFileName(input) {
+  return sanitizeFileNamePure(input);
+}
+
 
 // Defense-in-depth: only accept IPC from frames WE created.
 // - `app://` = our main window + sub-apps (photo-helper, map-corridors)
@@ -364,35 +377,6 @@ function safeHandle(channel, fn) {
   });
 }
 
-// Reject UNC paths (`\\server\share`, `//server/share`) and Windows device
-// namespaces (`\\?\`, `\\.\`). A renderer-supplied UNC path as the save
-// dialog's `defaultPath` would pre-point the user at an attacker-controlled
-// SMB share — one click later the KML lands remote and, on Windows, an
-// NTLMv2 handshake to the attacker's host leaks the user's hashed creds.
-function isSafeStartDir(abs) {
-  if (typeof abs !== 'string' || !abs) return false;
-  if (/^(\\\\|\/\/)/.test(abs)) return false;
-  if (/^\\\\[?.]\\/.test(abs)) return false;
-  return true;
-}
-
-// Single source of truth for "renderer gave us a directory string — should we
-// trust it as `defaultPath` for a dialog or persist it as workingDir?". Wraps
-// the four checks (type, length cap, UNC/device rejection, on-disk presence)
-// that were copy-pasted across handlers and easy to forget on new ones.
-const MAX_USER_PATH_LEN = 4096;
-function validateUserDir(input) {
-  if (typeof input !== 'string' || !input.trim()) return null;
-  if (input.length > MAX_USER_PATH_LEN) return null;
-  let abs;
-  try { abs = path.resolve(input); } catch { return null; }
-  if (!isSafeStartDir(abs)) return null;
-  try {
-    if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) return null;
-  } catch { return null; }
-  return abs;
-}
-
 // Allowlist for `read-photo-file`: paths the user explicitly chose in a
 // preceding `open-photos` dialog. Without this, a compromised renderer
 // (XSS via untrusted KML, image EXIF, or Mapbox-injected content) could
@@ -420,17 +404,6 @@ function ensureDir(dirPath) {
     fs.mkdirSync(dirPath, { recursive: true });
   }
   return dirPath;
-}
-
-// Validate that a path is within the allowed storage directory (prevent path traversal)
-function validateStoragePath(inputPath) {
-  const rootPath = path.resolve(getPhotoSessionsPath());
-  const resolved = path.resolve(inputPath);
-
-  if (!resolved.startsWith(rootPath + path.sep) && resolved !== rootPath) {
-    throw new Error(`Access denied: path outside storage directory`);
-  }
-  return resolved;
 }
 
 // Initialize storage - create root and sessions directories
@@ -744,9 +717,21 @@ safeHandle('competition-create', async (event, name, workingDir) => {
   // "select TRACK FOLDER when creating a new track"). Same UNC + length
   // validation as `competition-set-working-dir` so a poisoned path can't
   // ride in via the create call instead of the dedicated setter.
+  //
+  // If the user-supplied path is rejected (UNC, device-namespace, length cap,
+  // doesn't exist, raced-deleted between pick and create), the create still
+  // succeeds — but we attach `workingDirRejected: true` to the returned
+  // metadata so the renderer can surface a non-blocking warning. Without
+  // this flag the renderer interpreted "no workingDir on metadata" as
+  // "user didn't pick one" and the user's real pick disappeared silently
+  // (round-5 follow-up to feedback 2026-05-03).
   if (typeof workingDir === 'string' && workingDir.trim()) {
     const abs = validateUserDir(workingDir);
-    if (abs) metadata.workingDir = abs;
+    if (abs) {
+      metadata.workingDir = abs;
+    } else {
+      metadata.workingDirRejected = true;
+    }
   }
   index.competitions.push(metadata);
   index.activeCompetitionId = id;
@@ -760,9 +745,17 @@ safeHandle('competition-create', async (event, name, workingDir) => {
 
 // Native folder-picker dialog. Used by the launcher's "New competition"
 // flow so the user can lock in their project folder up front (feedback
-// 2026-05-03). Returns null if the user cancels. The path is NOT
-// persisted here — caller is responsible for passing it to
-// `competition-create` or `competition-set-working-dir`.
+// 2026-05-03). The path is NOT persisted here — caller is responsible for
+// passing it to `competition-create` or `competition-set-working-dir`.
+//
+// Returns a discriminated result so the renderer can distinguish between
+// (a) the user clicking Cancel, (b) the user picking a folder we had to
+// reject (UNC, device namespace, length cap, vanished from disk), and
+// (c) a successful pick. Round-5 follow-up: the previous shape returned
+// `null` for both cancel AND validation rejection, so a UNC pick (a normal
+// thing on a corporate network drive) was indistinguishable from cancel
+// and the renderer flipped the OK button to "Vytvořit bez složky" without
+// telling the user why.
 safeHandle('pick-directory', async (event, defaultDir, title) => {
   const startDir = validateUserDir(defaultDir) || app.getPath('documents');
   const result = await dialog.showOpenDialog(mainWindow, {
@@ -770,11 +763,20 @@ safeHandle('pick-directory', async (event, defaultDir, title) => {
     defaultPath: startDir,
     properties: ['openDirectory', 'createDirectory'],
   });
-  if (result.canceled || !result.filePaths || !result.filePaths.length) return null;
+  if (result.canceled || !result.filePaths || !result.filePaths.length) {
+    return { canceled: true };
+  }
   // Re-validate the picked path so a UNC / device-namespace pick can't
-  // round-trip back into the index. Same rule as setWorkingDir.
-  const abs = validateUserDir(result.filePaths[0]);
-  return abs || null;
+  // round-trip back into the index. Same rule as setWorkingDir. If
+  // validation rejects, surface `error: 'invalid-path'` so the renderer
+  // can show a real "this kind of folder isn't supported" message
+  // instead of treating it as cancel.
+  const raw = result.filePaths[0];
+  const abs = validateUserDir(raw);
+  if (!abs) {
+    return { canceled: false, error: 'invalid-path', raw };
+  }
+  return { canceled: false, path: abs };
 });
 
 // Set active competition

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -677,7 +677,7 @@ safeHandle('competition-list', async () => {
 });
 
 // Create a new competition
-safeHandle('competition-create', async (event, name) => {
+safeHandle('competition-create', async (event, name, workingDir) => {
   const id = `comp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const now = new Date().toISOString();
   const index = readCompetitionsIndex();
@@ -686,7 +686,24 @@ safeHandle('competition-create', async (event, name) => {
   const competitionsDir = path.join(getPhotoSessionsPath(), 'competitions');
   ensureDir(competitionsDir);
   const compDir = validateStoragePath(path.join(competitionsDir, sanitizeFileName(id)));
+  // Defensive scrub (feedback 2026-05-03): the user expects a brand-new
+  // competition to start with zero photos / corridors / markers — no
+  // bleed-through from any prior session. The id is freshly generated
+  // (`Date.now()` + 8 chars random), so collision is astronomically
+  // unlikely, but a previous crashed run could still have left files
+  // behind under a colliding id, and we'd rather wipe them than serve a
+  // surprising "old photos appeared in my new competition" experience.
+  // `rmSync` with `force: true` is a no-op on non-existent paths.
+  if (fs.existsSync(compDir)) {
+    fs.rmSync(compDir, { recursive: true, force: true });
+  }
   ensureDir(compDir);
+  // Empty `photos/` so photo-helper's first save lands in a clean slot
+  // grid. The `corridors/` subdir is intentionally NOT pre-created — it
+  // gets initialised on demand by `useCorridorSessionOPFS` the first
+  // time the user opens map-corridors for this competition. If we
+  // pre-created it with a stale `session.json`, the corridors session
+  // would carry forward markers/discipline from whatever was there.
   ensureDir(path.join(compDir, 'photos'));
 
   // Write empty session.json for photo-helper
@@ -723,6 +740,14 @@ safeHandle('competition-create', async (event, name) => {
     photoCount: 0,
     isActive: true
   };
+  // Optional working folder picked on the launcher (feedback 2026-05-03 —
+  // "select TRACK FOLDER when creating a new track"). Same UNC + length
+  // validation as `competition-set-working-dir` so a poisoned path can't
+  // ride in via the create call instead of the dedicated setter.
+  if (typeof workingDir === 'string' && workingDir.trim()) {
+    const abs = validateUserDir(workingDir);
+    if (abs) metadata.workingDir = abs;
+  }
   index.competitions.push(metadata);
   index.activeCompetitionId = id;
   writeCompetitionsIndex(index);
@@ -731,6 +756,25 @@ safeHandle('competition-create', async (event, name) => {
   setConfigValue('activeCompetitionId', id);
 
   return metadata;
+});
+
+// Native folder-picker dialog. Used by the launcher's "New competition"
+// flow so the user can lock in their project folder up front (feedback
+// 2026-05-03). Returns null if the user cancels. The path is NOT
+// persisted here — caller is responsible for passing it to
+// `competition-create` or `competition-set-working-dir`.
+safeHandle('pick-directory', async (event, defaultDir, title) => {
+  const startDir = validateUserDir(defaultDir) || app.getPath('documents');
+  const result = await dialog.showOpenDialog(mainWindow, {
+    title: typeof title === 'string' && title.trim() ? title : undefined,
+    defaultPath: startDir,
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  if (result.canceled || !result.filePaths || !result.filePaths.length) return null;
+  // Re-validate the picked path so a UNC / device-namespace pick can't
+  // round-trip back into the index. Same rule as setWorkingDir.
+  const abs = validateUserDir(result.filePaths[0]);
+  return abs || null;
 });
 
 // Set active competition

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -12,7 +12,8 @@
     "build:map-corridors": "cross-env VITE_DESKTOP_BUILD=true pnpm --filter @airq/map-corridors build",
     "package": "pnpm run build:apps && pnpm exec electron-builder --win",
     "package:dir": "pnpm run build:apps && pnpm exec electron-builder --win --dir",
-    "dev": "pnpm run build:apps && electron ."
+    "dev": "pnpm run build:apps && electron .",
+    "test": "vitest run"
   },
   "build": {
     "appId": "com.airq.competition-helpers",
@@ -59,6 +60,7 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "electron": "39.8.8",
-    "electron-builder": "^26.0.12"
+    "electron-builder": "^26.0.12",
+    "vitest": "4.1.4"
   }
 }

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.8.0",
+  "version": "2.8.2",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -43,7 +43,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Native folder-picker dialog. Used by the launcher's "New competition"
   // flow (feedback 2026-05-03) so the user picks the project folder up
-  // front. Returns the absolute path or null if cancelled.
+  // front. Returns a discriminated object so the renderer can distinguish
+  // between cancel and validation rejection:
+  //   • { canceled: true }                                  — user clicked Cancel
+  //   • { canceled: false, error: 'invalid-path', raw }     — picked but rejected (UNC, device-ns, vanished)
+  //   • { canceled: false, path: '<abs>' }                  — picked and validated
   pickDirectory: (defaultDir, title) => ipcRenderer.invoke('pick-directory', defaultDir, title),
 
   // Save map print image via native save dialog

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -28,7 +28,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Competition management
   competitions: {
     list: () => ipcRenderer.invoke('competition-list'),
-    create: (name) => ipcRenderer.invoke('competition-create', name),
+    // `workingDir` (optional, feedback 2026-05-03): folder picked on the
+    // launcher's New-competition flow. Persists immediately so subsequent
+    // export dialogs default there before the user even imports a KML.
+    create: (name, workingDir) => ipcRenderer.invoke('competition-create', name, workingDir),
     setActive: (id) => ipcRenderer.invoke('competition-set-active', id),
     setDiscipline: (id, discipline) => ipcRenderer.invoke('competition-set-discipline', id, discipline),
     delete: (id) => ipcRenderer.invoke('competition-delete', id),
@@ -37,6 +40,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     setWorkingDir: (id, workingDir) => ipcRenderer.invoke('competition-set-working-dir', id, workingDir),
     getWorkingDir: (id) => ipcRenderer.invoke('competition-get-working-dir', id),
   },
+
+  // Native folder-picker dialog. Used by the launcher's "New competition"
+  // flow (feedback 2026-05-03) so the user picks the project folder up
+  // front. Returns the absolute path or null if cancelled.
+  pickDirectory: (defaultDir, title) => ipcRenderer.invoke('pick-directory', defaultDir, title),
 
   // Save map print image via native save dialog
   saveMapImage: (base64Data, defaultDir) => ipcRenderer.invoke('save-map-image', base64Data, defaultDir),

--- a/frontend/desktop/renderer/app.js
+++ b/frontend/desktop/renderer/app.js
@@ -32,7 +32,11 @@ const translations = {
     'competition.createConfirmNoFolder': 'Vytvořit bez složky',
     'competition.pickFolder': 'Vybrat složku',
     'competition.noFolder': '(žádná složka)',
-    'competition.folderSet': '{path}'
+    'competition.folderSet': '{path}',
+    'competition.folderRejected': 'Složku se nepodařilo nastavit. Síťové cesty (\\\\server\\sdílené) ani systémové cesty (\\\\?\\…) nejsou podporovány — vyberte prosím lokální složku.',
+    'competition.folderPickFailed': 'Otevření dialogu se nezdařilo: {error}',
+    'competition.createFailed': 'Vytvoření soutěže selhalo: {error}',
+    'competition.workingDirDropped': 'Soutěž byla vytvořena, ale vybranou složku se nepodařilo uložit (neplatná cesta). Použijte nabídku „Pracovní složka" pro nový pokus.'
   },
   en: {
     title: 'Navigation Flying Tools',
@@ -66,7 +70,11 @@ const translations = {
     'competition.createConfirmNoFolder': 'Create without folder',
     'competition.pickFolder': 'Pick folder',
     'competition.noFolder': '(no folder)',
-    'competition.folderSet': '{path}'
+    'competition.folderSet': '{path}',
+    'competition.folderRejected': 'That folder could not be used. Network paths (\\\\server\\share) and device paths (\\\\?\\…) are not supported — please pick a local folder.',
+    'competition.folderPickFailed': 'Folder picker failed: {error}',
+    'competition.createFailed': 'Failed to create competition: {error}',
+    'competition.workingDirDropped': 'Competition was created, but the chosen folder could not be saved (invalid path). Use the "Working folder" menu to try again.'
   }
 };
 
@@ -329,23 +337,66 @@ function hideCreateForm() {
   attemptedAutoPick = false;
 }
 
+// Discriminated result so callers can tell cancel apart from real failure
+// and from validation rejection (UNC / device path):
+//   • { ok: true, path: '<abs>' }   — user picked and main.js validated
+//   • { ok: true, path: null }      — user clicked Cancel (genuine cancel)
+//   • { ok: false, reason, message? } — real error or validation rejection;
+//     `reason` is one of 'unavailable' | 'invalid-path' | 'error'.
+//
+// Round-5 fix: the previous shape returned `null` for cancel AND validation
+// rejection AND real failures, and the caller treated all three as "user
+// cancelled". A UNC pick (a normal corporate-network choice) silently
+// flipped the OK button to "Vytvořit bez složky" with no explanation.
 async function pickFolder(opts = {}) {
-  if (!window.electronAPI?.pickDirectory) return null;
+  if (!window.electronAPI?.pickDirectory) return { ok: false, reason: 'unavailable' };
+  const dialogTitle = opts.title || (currentLocale === 'cs'
+    ? `Vyberte složku pro soutěž "${nameInput.value.trim() || ''}"`.trim()
+    : `Pick folder for competition "${nameInput.value.trim() || ''}"`.trim());
+  let picked;
   try {
-    const dialogTitle = opts.title || (currentLocale === 'cs'
-      ? `Vyberte složku pro soutěž "${nameInput.value.trim() || ''}"`.trim()
-      : `Pick folder for competition "${nameInput.value.trim() || ''}"`.trim());
-    const picked = await window.electronAPI.pickDirectory(pendingWorkingDir, dialogTitle);
-    if (picked) {
-      pendingWorkingDir = picked;
-      updateFolderDisplay();
-      return picked;
-    }
-    return null;
+    picked = await window.electronAPI.pickDirectory(pendingWorkingDir, dialogTitle);
   } catch (err) {
     console.error('Folder pick failed:', err);
-    return null;
+    return { ok: false, reason: 'error', message: err instanceof Error ? err.message : String(err) };
   }
+  // Backward-compat: old main.js returned a bare string|null. New main.js
+  // returns the discriminated object. Accept either so a stale Electron
+  // build paired with new renderer doesn't hard-crash.
+  if (typeof picked === 'string' && picked) {
+    pendingWorkingDir = picked;
+    updateFolderDisplay();
+    return { ok: true, path: picked };
+  }
+  if (picked === null || picked === undefined) {
+    return { ok: true, path: null };
+  }
+  if (picked.canceled === true) {
+    return { ok: true, path: null };
+  }
+  if (picked.canceled === false && picked.error === 'invalid-path') {
+    return { ok: false, reason: 'invalid-path', raw: picked.raw };
+  }
+  if (picked.canceled === false && typeof picked.path === 'string' && picked.path) {
+    pendingWorkingDir = picked.path;
+    updateFolderDisplay();
+    return { ok: true, path: picked.path };
+  }
+  // Unknown shape — treat as failure rather than silent no-op so a future
+  // protocol drift surfaces instead of producing a stuck launcher.
+  return { ok: false, reason: 'error', message: 'unexpected pick-directory response' };
+}
+
+// Show a localized error to the user when an IPC operation fails. We use
+// a plain alert() rather than a toast widget because the launcher renderer
+// is intentionally framework-free (vanilla JS) and adding a notification
+// system here just for two error paths would be disproportionate. The
+// messages live in the translation tables so the user sees them in the
+// language they picked, not console-only English.
+function showError(key, vars = {}) {
+  let msg = t(key);
+  for (const [k, v] of Object.entries(vars)) msg = msg.replace(`{${k}}`, String(v));
+  alert(msg);
 }
 
 async function confirmCreate() {
@@ -366,12 +417,27 @@ async function confirmCreate() {
     if (!pendingWorkingDir && !attemptedAutoPick) {
       attemptedAutoPick = true;
       const picked = await pickFolder();
-      if (!picked) {
-        // User cancelled — leave the form open so they can re-pick
+      if (!picked.ok) {
+        // Real failure (IPC threw, validation rejected). Surface a
+        // localized message so the user knows their pick wasn't lost
+        // to a silent cancel — round-5 follow-up to feedback 2026-05-03.
+        if (picked.reason === 'invalid-path') {
+          showError('competition.folderRejected');
+        } else if (picked.reason !== 'unavailable') {
+          showError('competition.folderPickFailed', { error: picked.message || picked.reason });
+        }
+        // Reset so the next OK click re-opens the picker rather than
+        // committing without a folder; the user has signalled they want
+        // a folder by triggering this branch.
+        attemptedAutoPick = false;
+        updateFolderDisplay();
+        return;
+      }
+      if (picked.path === null) {
+        // Genuine cancel — leave the form open so the user can re-pick
         // ("Změnit") or click OK again to commit without a folder.
-        // The button label (re-rendered by pickFolder → updateFolderDisplay)
-        // now reads "Vytvořit bez složky", so the next click is
-        // intentional, not a continuation of the same action.
+        // The button label now reads "Vytvořit bez složky", so the next
+        // click is intentional, not a continuation of the same action.
         updateFolderDisplay();
         return;
       }
@@ -384,8 +450,15 @@ async function confirmCreate() {
     selectEl.value = metadata.id;
     activeCompetitionId = metadata.id;
     updateCardsState();
+    // Surface workingDirRejected (main.js sets this when validateUserDir
+    // refuses the pick at create time — e.g. the folder vanished between
+    // pick and create). Without this, the user's pick disappears silently.
+    if (metadata && metadata.workingDirRejected) {
+      showError('competition.workingDirDropped');
+    }
   } catch (err) {
     console.error('Failed to create competition:', err);
+    showError('competition.createFailed', { error: err instanceof Error ? err.message : String(err) });
   } finally {
     confirmInFlight = false;
   }
@@ -394,7 +467,13 @@ async function confirmCreate() {
 newBtn.addEventListener('click', showCreateForm);
 cancelBtn.addEventListener('click', hideCreateForm);
 confirmBtn.addEventListener('click', confirmCreate);
-if (pickFolderBtn) pickFolderBtn.addEventListener('click', () => pickFolder());
+if (pickFolderBtn) pickFolderBtn.addEventListener('click', async () => {
+  const r = await pickFolder();
+  if (!r.ok) {
+    if (r.reason === 'invalid-path') showError('competition.folderRejected');
+    else if (r.reason !== 'unavailable') showError('competition.folderPickFailed', { error: r.message || r.reason });
+  }
+});
 nameInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter') confirmCreate();
   if (e.key === 'Escape') hideCreateForm();

--- a/frontend/desktop/renderer/app.js
+++ b/frontend/desktop/renderer/app.js
@@ -22,7 +22,17 @@ const translations = {
     'competition.cleanupMsg': '{count} soutěží je starších než 30 dní. Chcete je smazat?',
     'competition.cleanupExcess': 'Máte {count} soutěží (max 10). Zvažte smazání starších.',
     'discipline.precision': 'Precision',
-    'discipline.rally': 'Rally'
+    'discipline.rally': 'Rally',
+    'competition.createTitle': 'Nová soutěž',
+    'competition.folderLabel': 'Složka:',
+    'competition.folderHint': '(vybere se po stisku Enter)',
+    'competition.changeFolder': 'Změnit',
+    'competition.createConfirm': 'Vytvořit a vybrat složku',
+    'competition.createConfirmReady': 'Vytvořit',
+    'competition.createConfirmNoFolder': 'Vytvořit bez složky',
+    'competition.pickFolder': 'Vybrat složku',
+    'competition.noFolder': '(žádná složka)',
+    'competition.folderSet': '{path}'
   },
   en: {
     title: 'Navigation Flying Tools',
@@ -46,7 +56,17 @@ const translations = {
     'competition.cleanupMsg': '{count} competitions are older than 30 days. Delete them?',
     'competition.cleanupExcess': 'You have {count} competitions (max 10). Consider deleting older ones.',
     'discipline.precision': 'Precision',
-    'discipline.rally': 'Rally'
+    'discipline.rally': 'Rally',
+    'competition.createTitle': 'New competition',
+    'competition.folderLabel': 'Folder:',
+    'competition.folderHint': '(chosen after pressing Enter)',
+    'competition.changeFolder': 'Change',
+    'competition.createConfirm': 'Create & pick folder',
+    'competition.createConfirmReady': 'Create',
+    'competition.createConfirmNoFolder': 'Create without folder',
+    'competition.pickFolder': 'Pick folder',
+    'competition.noFolder': '(no folder)',
+    'competition.folderSet': '{path}'
   }
 };
 
@@ -247,6 +267,49 @@ const barCreate = document.getElementById('competition-bar-create');
 const nameInput = document.getElementById('competition-name-input');
 const confirmBtn = document.getElementById('competition-create-confirm');
 const cancelBtn = document.getElementById('competition-create-cancel');
+const pickFolderBtn = document.getElementById('competition-pick-folder');
+const folderText = document.getElementById('competition-folder-text');
+
+// Folder picked for the next-created competition. Persists only across
+// the create form's lifetime — reset on every showCreateForm() so a
+// stale pick from a previous "+ New" doesn't silently apply later.
+let pendingWorkingDir = null;
+// Tracks whether the auto-open picker has already been attempted for
+// this create session. After a cancel, the OK button flips to
+// "Vytvořit bez složky" so the user has a single deliberate path to
+// commit without a folder — without it, repeatedly hitting Enter just
+// re-opens the cancelled dialog (feedback 2026-05-03 follow-up: user
+// shouldn't have to click an explicit "pick folder" button).
+let attemptedAutoPick = false;
+// Guard against re-entering the OK handler while the native folder
+// dialog is open (Enter held down, double-click on OK).
+let confirmInFlight = false;
+
+function updateFolderDisplay() {
+  if (pendingWorkingDir) {
+    folderText.textContent = t('competition.folderSet').replace('{path}', pendingWorkingDir);
+    folderText.title = pendingWorkingDir;
+    folderText.classList.add('has-folder');
+  } else {
+    folderText.textContent = t('competition.folderHint');
+    folderText.removeAttribute('title');
+    folderText.classList.remove('has-folder');
+  }
+  // Mirror the OK button label so the user always knows what their next
+  // click does:
+  //   • folder picked          → "Vytvořit"               (creates with folder)
+  //   • no folder, no attempt  → "Vytvořit a vybrat složku" (auto-opens picker)
+  //   • no folder, picker cancelled → "Vytvořit bez složky" (commits w/o folder)
+  if (confirmBtn) {
+    if (pendingWorkingDir) {
+      confirmBtn.textContent = t('competition.createConfirmReady');
+    } else if (attemptedAutoPick) {
+      confirmBtn.textContent = t('competition.createConfirmNoFolder');
+    } else {
+      confirmBtn.textContent = t('competition.createConfirm');
+    }
+  }
+}
 
 function showCreateForm() {
   barSelect.classList.add('hidden');
@@ -254,20 +317,68 @@ function showCreateForm() {
   nameInput.value = t('competition.defaultName');
   nameInput.focus();
   nameInput.select();
+  pendingWorkingDir = null;
+  attemptedAutoPick = false;
+  updateFolderDisplay();
 }
 
 function hideCreateForm() {
   barCreate.classList.add('hidden');
   barSelect.classList.remove('hidden');
+  pendingWorkingDir = null;
+  attemptedAutoPick = false;
+}
+
+async function pickFolder(opts = {}) {
+  if (!window.electronAPI?.pickDirectory) return null;
+  try {
+    const dialogTitle = opts.title || (currentLocale === 'cs'
+      ? `Vyberte složku pro soutěž "${nameInput.value.trim() || ''}"`.trim()
+      : `Pick folder for competition "${nameInput.value.trim() || ''}"`.trim());
+    const picked = await window.electronAPI.pickDirectory(pendingWorkingDir, dialogTitle);
+    if (picked) {
+      pendingWorkingDir = picked;
+      updateFolderDisplay();
+      return picked;
+    }
+    return null;
+  } catch (err) {
+    console.error('Folder pick failed:', err);
+    return null;
+  }
 }
 
 async function confirmCreate() {
+  if (confirmInFlight) return;
   const name = nameInput.value.trim();
   if (!name) return;
   if (!window.electronAPI?.competitions) return;
 
+  confirmInFlight = true;
   try {
-    const metadata = await window.electronAPI.competitions.create(name);
+    // Auto-open the folder dialog the FIRST time OK / Enter fires. If
+    // the user cancels, `attemptedAutoPick` flips and the next OK
+    // commits without a folder (the button label flips too — see
+    // updateFolderDisplay). The dedicated "Změnit" button remains
+    // available for users who change their mind during the create
+    // session. Feedback 2026-05-03: "the folder dialog should open
+    // automatically, with appropriate title".
+    if (!pendingWorkingDir && !attemptedAutoPick) {
+      attemptedAutoPick = true;
+      const picked = await pickFolder();
+      if (!picked) {
+        // User cancelled — leave the form open so they can re-pick
+        // ("Změnit") or click OK again to commit without a folder.
+        // The button label (re-rendered by pickFolder → updateFolderDisplay)
+        // now reads "Vytvořit bez složky", so the next click is
+        // intentional, not a continuation of the same action.
+        updateFolderDisplay();
+        return;
+      }
+    }
+    // Pass workingDir if user picked one — main.js validates it again
+    // (UNC, length, on-disk) before persisting.
+    const metadata = await window.electronAPI.competitions.create(name, pendingWorkingDir || undefined);
     hideCreateForm();
     await loadCompetitions();
     selectEl.value = metadata.id;
@@ -275,12 +386,15 @@ async function confirmCreate() {
     updateCardsState();
   } catch (err) {
     console.error('Failed to create competition:', err);
+  } finally {
+    confirmInFlight = false;
   }
 }
 
 newBtn.addEventListener('click', showCreateForm);
 cancelBtn.addEventListener('click', hideCreateForm);
 confirmBtn.addEventListener('click', confirmCreate);
+if (pickFolderBtn) pickFolderBtn.addEventListener('click', () => pickFolder());
 nameInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter') confirmCreate();
   if (e.key === 'Escape') hideCreateForm();

--- a/frontend/desktop/renderer/index.html
+++ b/frontend/desktop/renderer/index.html
@@ -47,11 +47,19 @@
         <button id="competition-new" class="btn btn-new" data-i18n="competition.new" title="Nova soutez">+ Nova soutez</button>
         <button id="competition-delete" class="btn btn-delete" data-i18n="competition.deleteBtn" title="Smazat" disabled>X</button>
       </div>
-      <div class="competition-bar hidden" id="competition-bar-create">
-        <label class="competition-label" data-i18n="competition.promptName" for="competition-name-input">Nazev nove souteze:</label>
-        <input id="competition-name-input" class="competition-input" type="text" maxlength="60" autocomplete="off" />
-        <button id="competition-create-confirm" class="btn btn-new">OK</button>
-        <button id="competition-create-cancel" class="btn">X</button>
+      <div class="competition-create-card hidden" id="competition-bar-create">
+        <h2 class="competition-create-title" data-i18n="competition.createTitle">Nová soutěž</h2>
+        <label class="competition-create-label" data-i18n="competition.promptName" for="competition-name-input">Název nové soutěže:</label>
+        <input id="competition-name-input" class="competition-create-input" type="text" maxlength="60" autocomplete="off" />
+        <div class="competition-create-folder-row">
+          <span class="competition-create-folder-label" data-i18n="competition.folderLabel">Složka:</span>
+          <span id="competition-folder-text" class="competition-folder-text" data-i18n="competition.folderHint">(vybere se po stisku Enter)</span>
+          <button id="competition-pick-folder" class="btn btn-small-link" data-i18n="competition.changeFolder" title="Vyberte složku trati">Změnit</button>
+        </div>
+        <div class="competition-create-actions">
+          <button id="competition-create-cancel" class="btn" data-i18n="competition.cancelDelete">Zrušit</button>
+          <button id="competition-create-confirm" class="btn btn-new btn-create-ok" data-i18n="competition.createConfirm">Vytvořit a vybrat složku</button>
+        </div>
       </div>
       <div class="competition-bar hidden" id="competition-bar-delete">
         <span class="competition-label delete-warning" id="delete-confirm-text"></span>

--- a/frontend/desktop/renderer/styles.css
+++ b/frontend/desktop/renderer/styles.css
@@ -63,37 +63,39 @@ header p {
   color: #4A5568;
 }
 
-/* Competition selector */
+/* Competition selector — widened 720→1040 (feedback 2026-05-03: bar
+   was cramped, Rally button getting clipped). */
 .competition-section {
-  max-width: 720px;
-  margin: 20px auto 0;
+  max-width: 1040px;
+  margin: 28px auto 0;
   padding: 0 16px;
 }
 
 .competition-bar {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 18px;
-  border-radius: 12px;
+  gap: 16px;
+  padding: 18px 24px;
+  border-radius: 14px;
   background: #FFFFFF;
   border: 1px solid #E2E8F0;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
 }
 
 .competition-label {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1.05rem;
   white-space: nowrap;
   color: #2D3748;
 }
 
 .competition-select {
   flex: 1;
-  padding: 8px 12px;
-  font-size: 0.95rem;
+  min-width: 0;
+  padding: 11px 14px;
+  font-size: 1rem;
   border: 1px solid #E2E8F0;
-  border-radius: 8px;
+  border-radius: 10px;
   background: #F8FAFC;
   color: #1A202C;
   cursor: pointer;
@@ -132,23 +134,131 @@ header p {
   box-shadow: 0 0 0 2px rgba(25,118,210,0.15);
 }
 
+/* New-competition card (feedback 2026-05-03 — was cramped horizontal
+   bar; user has plenty of vertical space on the launcher home). */
+.competition-create-card {
+  max-width: 560px;
+  margin: 8px auto 0;
+  padding: 28px 32px 24px;
+  border-radius: 14px;
+  background: #FFFFFF;
+  border: 1px solid #E2E8F0;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.competition-create-title {
+  margin: 0 0 4px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #1A202C;
+}
+
+.competition-create-label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #2D3748;
+  margin-bottom: -8px;
+}
+
+.competition-create-input {
+  padding: 12px 14px;
+  font-size: 1.05rem;
+  border: 1px solid #E2E8F0;
+  border-radius: 10px;
+  background: #fff;
+  color: #1A202C;
+  outline: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.competition-create-input:focus {
+  border-color: #1976D2;
+  box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.18);
+}
+
+.competition-create-folder-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: #F7FAFC;
+  border: 1px dashed #CBD5E0;
+  border-radius: 10px;
+  font-size: 0.9rem;
+}
+
+.competition-create-folder-label {
+  font-weight: 600;
+  color: #4A5568;
+  flex-shrink: 0;
+}
+
+.competition-folder-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.9rem;
+  color: #718096;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl; /* show the END of long paths so the leaf folder is visible */
+  text-align: left;
+}
+
+.competition-folder-text.has-folder {
+  color: #1A202C;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.btn-small-link {
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  border-color: transparent;
+  background: transparent;
+  color: #1976D2;
+}
+
+.btn-small-link:hover {
+  background: #EBF5FF;
+  border-color: #BEE3F8;
+}
+
+.competition-create-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+
+.btn-create-ok {
+  min-width: 220px;
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
 /* Discipline toggle */
 .discipline-toggle {
   display: flex;
+  flex-shrink: 0;
   border: 1px solid #E2E8F0;
-  border-radius: 8px;
+  border-radius: 10px;
   overflow: hidden;
 }
 
 .discipline-btn {
-  padding: 6px 14px;
-  font-size: 0.85rem;
+  padding: 10px 18px;
+  font-size: 0.95rem;
   font-weight: 500;
   border: none;
   background: #F8FAFC;
   color: #4A5568;
   cursor: pointer;
   transition: all 120ms ease;
+  white-space: nowrap;
 }
 
 .discipline-btn:not(:last-child) {
@@ -169,16 +279,17 @@ header p {
 }
 
 .btn {
-  padding: 8px 16px;
-  font-size: 0.9rem;
+  padding: 11px 18px;
+  font-size: 1rem;
   font-weight: 500;
   border: 1px solid #E2E8F0;
-  border-radius: 8px;
+  border-radius: 10px;
   background: #FFFFFF;
   color: #2D3748;
   cursor: pointer;
   white-space: nowrap;
   transition: all 120ms ease;
+  flex-shrink: 0;
 }
 
 .btn:hover {

--- a/frontend/desktop/vitest.config.js
+++ b/frontend/desktop/vitest.config.js
@@ -1,0 +1,13 @@
+// Minimal vitest config for the desktop package's path-validation
+// helpers. The Electron main-process bundle (`main.js`) is NOT under
+// test — only the pure CommonJS helpers in `lib/` are. They share no
+// runtime dependency on Electron, so vitest in `node` env runs them
+// directly.
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['__tests__/**/*.test.{js,ts}'],
+  },
+});

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -13,7 +13,6 @@ import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, D
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
-import { dirnameOf } from '@airq/shared-storage'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { parseDisciplineFromSearch } from './utils/parseDiscipline'
 import { MapStyleSelector } from './components/MapStyleSelector'
@@ -28,8 +27,8 @@ import {
   type MapStyleId,
 } from './config/mapProviders'
 import { calculateDistance } from './corridors/segments'
-import { matchPointsToCorridors as matchPointsToCorridorsPure } from './corridors/matchPoints'
-import { extractStartName } from './corridors/extractStartName'
+import { matchPointsToCorridors as matchPointsToCorridorsPure, legKey } from './corridors/matchPoints'
+import { extractStartName, extractEndName } from './corridors/extractStartName'
 import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
 import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
@@ -241,13 +240,69 @@ function App() {
     return res
   }, [session?.leftSegments, session?.rightSegments, session?.exactPoints])
 
+  // Ordered route waypoints (SP, TP1, TP2, …, TPn, FP). Used by the
+  // matcher's leg-projection fallback (feedback 2026-05-03): when the
+  // corridor between TPn and TPn+1 was dropped because the leg is a
+  // dashed/scenic chain, photos in the gap need to be attributed to TPn
+  // (the preceding TP of the leg they're actually on), not to the
+  // geographically-closer TPn+1 startCoord of the NEXT corridor.
+  const routeWaypoints = useMemo(() => {
+    const out: Array<{ name: string; coord: [number, number] }> = []
+    const features = (session?.exactPoints as any)?.features
+    if (!Array.isArray(features)) return out
+    for (const f of features) {
+      const role = f?.properties?.role
+      const name = f?.properties?.name
+      const coords = f?.geometry?.coordinates
+      if (role !== 'exact' || typeof name !== 'string' || !Array.isArray(coords) || coords.length < 2) continue
+      out.push({ name, coord: [Number(coords[0]), Number(coords[1])] })
+    }
+    // Order: SP first, FP last, TPs sorted numerically in between. Other
+    // names (rare authoring quirk) fall after — leg projection skips
+    // unknown adjacency anyway because perpendicular distances will be
+    // larger than to the real legs.
+    const tpNum = (s: string) => {
+      const m = s.match(/(\d+)/)
+      return m ? parseInt(m[1], 10) : NaN
+    }
+    out.sort((a, b) => {
+      if (a.name === 'SP') return -1
+      if (b.name === 'SP') return 1
+      if (a.name === 'FP') return 1
+      if (b.name === 'FP') return -1
+      const an = tpNum(a.name)
+      const bn = tpNum(b.name)
+      if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
+      return a.name.localeCompare(b.name)
+    })
+    return out
+  }, [session?.exactPoints])
+
+  // Set of legs already covered by a corridor, keyed `${from}→${to}`.
+  // The leg-projection fallback skips these so a marker outside any
+  // polygon only attaches to a SCENIC leg (one whose corridor was
+  // dropped because the leg is a chain of dashed connectors) — feedback
+  // 2026-05-03 follow-up: "outside corridor → assigned to nearest leg
+  // WITHOUT a corridor". Built from the corridor names directly so a
+  // future change to the naming template only needs to update the
+  // `extractStartName`/`extractEndName` parsers.
+  const coveredLegs = useMemo(() => {
+    const set = new Set<string>()
+    for (const c of corridorPolygons) {
+      const from = extractStartName(c.name)
+      const to = extractEndName(c.name)
+      if (from && to) set.add(legKey(from, to))
+    }
+    return set
+  }, [corridorPolygons])
+
   // Delegates to the pure helper in `corridors/matchPoints.ts` (unit-tested
   // there). Kept as a hook-level `useCallback` so the `useMemo`s below get a
   // stable reference.
   const matchPointsToCorridors = useCallback(
     (pts: ReadonlyArray<{ id: string; lng: number; lat: number }>) =>
-      matchPointsToCorridorsPure(pts, corridorPolygons),
-    [corridorPolygons],
+      matchPointsToCorridorsPure(pts, corridorPolygons, routeWaypoints, coveredLegs),
+    [corridorPolygons, routeWaypoints, coveredLegs],
   )
 
   const markerCorridorMatchById = useMemo(
@@ -324,23 +379,20 @@ function App() {
       .catch(() => { /* non-fatal */ })
   }, [competitionId])
 
-  // After any save dialog returns a path, promote the chosen folder to the
-  // competition's working dir. Lets the user steer the default by simply
-  // navigating in the dialog — feedback 2026-04-25 ("until navigated to
-  // other folder, from that moment new folder persists"). Uses the shared
-  // `dirnameOf` so drive-letter roots, POSIX root, UNC, and trailing
-  // separators all extract the same as Node's `path.dirname` would.
-  const persistChosenDirAsWorking = useCallback((savedPath: string | null) => {
-    if (!savedPath || !competitionId) return
-    const dir = dirnameOf(savedPath)
-    if (!dir) return
-    setImportedKmlDir(dir)
-    const api = (window as any)?.electronAPI
-    if (api?.competitions?.setWorkingDir) {
-      api.competitions.setWorkingDir(competitionId, dir)
-        .catch((err: unknown) => console.warn('[workingDir] persist failed:', err))
-    }
-  }, [competitionId])
+  // No-op kept for call-site compatibility. Feedback 2026-05-03 reverses
+  // the prior behaviour: the working dir is now anchored to (a) the
+  // folder picked on the launcher's New-competition flow and (b) the
+  // folder the source KML was imported from — NOT to whichever folder
+  // the user last navigated to in a save dialog. Overwriting on every
+  // save was confusing users who picked a one-off export location and
+  // then found later exports defaulting somewhere else. The function is
+  // retained as a no-op so existing call-sites can stay structurally
+  // unchanged; if the workingDir gets out of sync, re-importing the KML
+  // (or editing the launcher's folder pick) is the explicit way to
+  // update it.
+  const persistChosenDirAsWorking = useCallback((_savedPath: string | null) => {
+    /* intentionally a no-op — see comment above */
+  }, [])
 
   const onFiles = useCallback(async (files: File[]) => {
     const file = files[0]

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { calculateDistance } from './corridors/segments'
 import { matchPointsToCorridors as matchPointsToCorridorsPure, legKey } from './corridors/matchPoints'
 import { extractStartName, extractEndName } from './corridors/extractStartName'
+import { buildRouteWaypoints } from './corridors/buildRouteWaypoints'
 import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
 import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
@@ -246,37 +247,9 @@ function App() {
   // dashed/scenic chain, photos in the gap need to be attributed to TPn
   // (the preceding TP of the leg they're actually on), not to the
   // geographically-closer TPn+1 startCoord of the NEXT corridor.
-  const routeWaypoints = useMemo(() => {
-    const out: Array<{ name: string; coord: [number, number] }> = []
-    const features = (session?.exactPoints as any)?.features
-    if (!Array.isArray(features)) return out
-    for (const f of features) {
-      const role = f?.properties?.role
-      const name = f?.properties?.name
-      const coords = f?.geometry?.coordinates
-      if (role !== 'exact' || typeof name !== 'string' || !Array.isArray(coords) || coords.length < 2) continue
-      out.push({ name, coord: [Number(coords[0]), Number(coords[1])] })
-    }
-    // Order: SP first, FP last, TPs sorted numerically in between. Other
-    // names (rare authoring quirk) fall after — leg projection skips
-    // unknown adjacency anyway because perpendicular distances will be
-    // larger than to the real legs.
-    const tpNum = (s: string) => {
-      const m = s.match(/(\d+)/)
-      return m ? parseInt(m[1], 10) : NaN
-    }
-    out.sort((a, b) => {
-      if (a.name === 'SP') return -1
-      if (b.name === 'SP') return 1
-      if (a.name === 'FP') return 1
-      if (b.name === 'FP') return -1
-      const an = tpNum(a.name)
-      const bn = tpNum(b.name)
-      if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
-      return a.name.localeCompare(b.name)
-    })
-    return out
-  }, [session?.exactPoints])
+  // Helper extracted to `corridors/buildRouteWaypoints.ts` so the ordering
+  // rule and the NaN-coord filter are unit-testable.
+  const routeWaypoints = useMemo(() => buildRouteWaypoints(session?.exactPoints), [session?.exactPoints])
 
   // Set of legs already covered by a corridor, keyed `${from}→${to}`.
   // The leg-projection fallback skips these so a marker outside any
@@ -379,20 +352,15 @@ function App() {
       .catch(() => { /* non-fatal */ })
   }, [competitionId])
 
-  // No-op kept for call-site compatibility. Feedback 2026-05-03 reverses
-  // the prior behaviour: the working dir is now anchored to (a) the
-  // folder picked on the launcher's New-competition flow and (b) the
-  // folder the source KML was imported from — NOT to whichever folder
-  // the user last navigated to in a save dialog. Overwriting on every
-  // save was confusing users who picked a one-off export location and
-  // then found later exports defaulting somewhere else. The function is
-  // retained as a no-op so existing call-sites can stay structurally
-  // unchanged; if the workingDir gets out of sync, re-importing the KML
-  // (or editing the launcher's folder pick) is the explicit way to
-  // update it.
-  const persistChosenDirAsWorking = useCallback((_savedPath: string | null) => {
-    /* intentionally a no-op — see comment above */
-  }, [])
+  // Round-5 follow-up to feedback 2026-05-03: previously this was a
+  // useCallback that promoted whatever folder the user navigated to in a
+  // save dialog into the competition's workingDir. Then it was reduced to
+  // a no-op for call-site compatibility, which silently discarded its
+  // argument and made the underlying drift mode invisible. We removed it
+  // entirely — the only canonical sources of truth for workingDir are now
+  // (a) the folder picked on the launcher's New-competition flow and
+  // (b) the folder a KML was imported from. If those drift, re-import or
+  // re-pick is the explicit fix path.
 
   const onFiles = useCallback(async (files: File[]) => {
     const file = files[0]
@@ -595,8 +563,11 @@ function App() {
         // (disk full, 50 MB cap, bad IPC) — surface it to the user instead
         // of silently falling through to a browser download, which would
         // land in the default Downloads folder behind the user's back.
-        const savedPath: string | null = await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
-        persistChosenDirAsWorking(savedPath)
+        // Round-5: we no longer promote the chosen save folder to the
+        // competition's working dir (see comment near top of this file).
+        // The return value is intentionally unused here; null vs path
+        // only matters for diagnostics.
+        await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
       } catch (err) {
         console.error('electronAPI.saveKml failed:', err)
         alert(err instanceof Error ? err.message : t('errors.exportFailed'))
@@ -604,7 +575,7 @@ function App() {
       return
     }
     downloadKML(mergedKml, 'corridors_export.kml')
-  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir, persistChosenDirAsWorking])
+  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir])
 
   const handlePrintMap = useCallback(async () => {
     if (!mapRef.current) return
@@ -623,8 +594,8 @@ function App() {
           reader.onerror = () => reject(reader.error)
           reader.readAsDataURL(blob)
         })
-        const savedPath: string | null = await electronAPI.saveMapImage(base64, importedKmlDir || undefined)
-        persistChosenDirAsWorking(savedPath)
+        // Round-5: chosen folder is no longer auto-promoted to workingDir.
+        await electronAPI.saveMapImage(base64, importedKmlDir || undefined)
       } else {
         // Browser: download via anchor
         const url = URL.createObjectURL(blob)
@@ -646,7 +617,7 @@ function App() {
       console.error('Map print failed:', err)
       alert(err instanceof Error ? err.message : t('errors.printFailed'))
     }
-  }, [t, importedKmlDir, persistChosenDirAsWorking])
+  }, [t, importedKmlDir])
 
   // Drag source for placing photo markers
   const onDragStartMarker = useCallback((e: React.DragEvent) => {

--- a/frontend/map-corridors/src/__tests__/buildRouteWaypoints.test.ts
+++ b/frontend/map-corridors/src/__tests__/buildRouteWaypoints.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { buildRouteWaypoints } from '../corridors/buildRouteWaypoints'
+
+// Minimal GeoJSON-feature shape that satisfies the helper's narrow lookups.
+function feature(role: string, name: unknown, coords: unknown) {
+  return {
+    type: 'Feature',
+    properties: { role, name },
+    geometry: { type: 'Point', coordinates: coords },
+  }
+}
+
+describe('buildRouteWaypoints', () => {
+  // Silence the NaN-coord warning so test output stays clean. Restored
+  // after each test so a real warning in unrelated code still surfaces.
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns empty array on null/undefined input', () => {
+    expect(buildRouteWaypoints(null)).toEqual([])
+    expect(buildRouteWaypoints(undefined)).toEqual([])
+    expect(buildRouteWaypoints({})).toEqual([])
+  })
+
+  it('returns empty array when features is not an array', () => {
+    expect(buildRouteWaypoints({ features: 'not-an-array' })).toEqual([])
+    expect(buildRouteWaypoints({ features: 42 })).toEqual([])
+  })
+
+  it('returns SP, TP1..TPn, FP in the documented order', () => {
+    // Intentionally shuffled input so the sort logic does work.
+    const features = [
+      feature('exact', 'TP3', [16.0, 50.0]),
+      feature('exact', 'FP', [17.0, 50.0]),
+      feature('exact', 'TP1', [14.5, 50.0]),
+      feature('exact', 'SP', [14.0, 50.0]),
+      feature('exact', 'TP2', [15.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['SP', 'TP1', 'TP2', 'TP3', 'FP'])
+    expect(out[0].coord).toEqual([14.0, 50.0])
+    expect(out[4].coord).toEqual([17.0, 50.0])
+  })
+
+  it('sorts TPs numerically (TP10 after TP9, not lex-sorted)', () => {
+    // TP10 sorts AFTER TP9 numerically. A future refactor to plain
+    // localeCompare would lex-sort TP10 before TP2 — surface here.
+    const features = [
+      feature('exact', 'TP10', [16.0, 50.0]),
+      feature('exact', 'TP2', [15.0, 50.0]),
+      feature('exact', 'TP9', [15.5, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['TP2', 'TP9', 'TP10'])
+  })
+
+  it('drops features with role !== "exact"', () => {
+    const features = [
+      feature('start', 'SP', [14.0, 50.0]),
+      feature('exact', 'TP1', [15.0, 50.0]),
+      feature('photo_marker', 'TPx', [15.5, 50.0]),
+      feature('exact', 'FP', [17.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['TP1', 'FP'])
+  })
+
+  it('drops features with non-string or empty name', () => {
+    const features = [
+      feature('exact', '', [14.0, 50.0]),
+      feature('exact', null, [15.0, 50.0]),
+      feature('exact', 42, [16.0, 50.0]),
+      feature('exact', 'TP1', [17.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['TP1'])
+  })
+
+  it('drops features whose coordinates array has fewer than 2 entries', () => {
+    const features = [
+      feature('exact', 'SP', [14.0]),
+      feature('exact', 'TP1', []),
+      feature('exact', 'TP2', null),
+      feature('exact', 'TP3', [15.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['TP3'])
+  })
+
+  // Round-5 fix for the silent NaN-attribution bug. A malformed KML with
+  // non-numeric coords used to push `[NaN, NaN]` straight to
+  // pointToLineDistance, which silently excluded the leg from leg-
+  // projection without any user-visible signal. The filter drops the
+  // bad waypoint AND warns.
+  it('drops features with non-finite coords and emits a console.warn', () => {
+    const features = [
+      feature('exact', 'SP', ['abc', 50.0]),
+      feature('exact', 'TP1', [14.0, NaN]),
+      feature('exact', 'TP2', [Infinity, 50.0]),
+      feature('exact', 'TP3', [-Infinity, 50.0]),
+      feature('exact', 'FP', [17.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['FP'])
+    // One warn per dropped waypoint — verifies the user gets visibility.
+    expect(warnSpy).toHaveBeenCalledTimes(4)
+  })
+
+  it('coerces numeric-string coords (real-world Number() semantics) — finite is OK', () => {
+    // GeoJSON parsers sometimes produce coords as numeric strings. The
+    // helper's `Number(coords[0])` accepts those because Number("14.5")
+    // is 14.5. Only NaN/Infinity are rejected.
+    const features = [
+      feature('exact', 'SP', ['14.0', '50.0']),
+      feature('exact', 'TP1', ['15.5', '50.0']),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out).toEqual([
+      { name: 'SP', coord: [14.0, 50.0] },
+      { name: 'TP1', coord: [15.5, 50.0] },
+    ])
+  })
+
+  it('places non-SP, non-FP, non-numeric names after numeric TPs', () => {
+    // "Other names (rare authoring quirk)" — they fall after numeric TPs
+    // via localeCompare. This pins the documented behaviour.
+    const features = [
+      feature('exact', 'TP1', [14.5, 50.0]),
+      feature('exact', 'XPoint', [15.0, 50.0]),
+      feature('exact', 'SP', [14.0, 50.0]),
+    ]
+    const out = buildRouteWaypoints({ features })
+    expect(out.map((w) => w.name)).toEqual(['SP', 'TP1', 'XPoint'])
+  })
+
+  it('returns empty array when no features match', () => {
+    const features = [
+      feature('photo_marker', 'M1', [14.0, 50.0]),
+      feature('ground_marker', 'G1', [15.0, 50.0]),
+    ]
+    expect(buildRouteWaypoints({ features })).toEqual([])
+  })
+})

--- a/frontend/map-corridors/src/__tests__/extractStartName.test.ts
+++ b/frontend/map-corridors/src/__tests__/extractStartName.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractStartName } from '../corridors/extractStartName'
+import { extractStartName, extractEndName } from '../corridors/extractStartName'
 
 /**
  * Pins the parser at App.tsx:236-239 (now extracted). The 2026-04-26 user
@@ -94,5 +94,35 @@ describe('extractStartName', () => {
       // the LAST after- segment is used as the startName.
       expect(extractStartName('1NM-after-something-after-TP3→TP4')).toBe('TP3')
     })
+  })
+})
+
+// `extractEndName` was added 2026-05-03 follow-up to support filtering
+// legs-with-corridors out of the leg-projection fallback. It mirrors
+// `extractStartName` but reads the post-arrow side of the corridor name.
+describe('extractEndName', () => {
+  it('returns the post-arrow target for {N}NM-after-X→Y corridors', () => {
+    expect(extractEndName('5NM-after-SP→TP1')).toBe('TP1')
+    expect(extractEndName('1NM-after-TP1→TP2')).toBe('TP2')
+    expect(extractEndName('1NM-after-TP9→TP10')).toBe('TP10')
+    expect(extractEndName('1NM-after-TP4→FP')).toBe('FP')
+  })
+
+  it('returns empty string when the name has no arrow', () => {
+    // Empty endName signals "no covered pair" to the leg-projection
+    // filter — the corresponding leg is left eligible. Safer to leave
+    // a leg eligible than to spuriously skip it.
+    expect(extractEndName('SP')).toBe('')
+    expect(extractEndName('TP1')).toBe('')
+    expect(extractEndName('')).toBe('')
+  })
+
+  it('trims whitespace around the post-arrow segment', () => {
+    expect(extractEndName('1NM-after-TP1→ TP2 ')).toBe('TP2')
+  })
+
+  it('handles non-string-ish inputs without throwing', () => {
+    expect(extractEndName(null as unknown as string)).toBe('')
+    expect(extractEndName(undefined as unknown as string)).toBe('')
   })
 })

--- a/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
+++ b/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   matchPointsToCorridors,
+  legKey,
   NEAREST_CORRIDOR_MAX_METERS,
   type CorridorPolygon,
 } from '../corridors/matchPoints'
@@ -92,6 +93,111 @@ describe('matchPointsToCorridors', () => {
     // Far outside every polygon but closer to TP1
     const out = matchPointsToCorridors([{ id: 'far', lng: 14.95, lat: 50.0 }], corridors)
     expect(out.far?.startName).toBe('TP1')
+  })
+
+  // Regression for the dashed/scenic-leg gap (feedback 2026-05-03).
+  // When the corridor between TPn and TPn+1 is dropped because the leg
+  // is a chain of dashed connectors, markers in the gap have no polygon
+  // match. The legacy nearest-startCoord fallback locks onto whichever
+  // endpoint is geographically closer — usually the FOLLOWING TP — and
+  // the answer sheet shows the wrong "Od TP". The leg-projection
+  // fallback fixes this by attributing markers to the leg they actually
+  // lie on, regardless of which endpoint they're closer to.
+  it('attributes a marker on a missing-corridor leg to the PRECEDING waypoint', () => {
+    // Only TP7→TP8 and TP9→TP10 corridors exist; TP8→TP9 is the scenic
+    // leg, dropped by the dashed-connector logic. The marker sits
+    // between TP8 and TP9 but is geographically closer to TP9.
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.001, 'TP7', [14.0, 50.0], '1NM-after-TP7→TP8'),
+      squareCorridor(16.0, 50.0, 0.001, 'TP9', [16.0, 50.0], '1NM-after-TP9→TP10'),
+    ]
+    const waypoints = [
+      { name: 'TP7', coord: [14.0, 50.0] as [number, number] },
+      { name: 'TP8', coord: [14.5, 50.0] as [number, number] },
+      { name: 'TP9', coord: [16.0, 50.0] as [number, number] },
+      { name: 'TP10', coord: [17.0, 50.0] as [number, number] },
+    ]
+    // Covered legs: TP7→TP8 and TP9→TP10. The TP8→TP9 leg is the
+    // scenic leg with no corridor — leg-projection can pick it.
+    const covered = new Set<string>([legKey('TP7', 'TP8'), legKey('TP9', 'TP10')])
+    // Marker at lng=15.4, slightly off the leg axis. It's closer to TP9
+    // (15.4 → 16.0 is 0.6° lng) than to TP8 (15.4 → 14.5 is 0.9° lng),
+    // so the legacy nearest-startCoord fallback would pick TP9. Leg
+    // projection attributes it to TP8 (preceding waypoint of the
+    // TP8→TP9 leg the marker is actually on).
+    const out = matchPointsToCorridors(
+      [{ id: 'scenic', lng: 15.4, lat: 50.001 }],
+      corridors,
+      waypoints,
+      covered,
+    )
+    expect(out.scenic?.startName).toBe('TP8')
+  })
+
+  // Strict variant of the rule (2026-05-03 follow-up): "photo outside
+  // corridor must be assigned to nearest leg WITHOUT a corridor". A
+  // marker that overshoots its own leg's corridor must NOT snap back
+  // onto that leg via projection — the leg has a corridor, so the
+  // matcher must keep looking.
+  it('with coveredLegs supplied, leg-projection skips legs that have a corridor', () => {
+    const waypoints = [
+      { name: 'TP7', coord: [14.0, 50.0] as [number, number] },
+      { name: 'TP8', coord: [15.0, 50.0] as [number, number] },
+      { name: 'TP9', coord: [17.0, 50.0] as [number, number] },
+    ]
+    // TP7→TP8 is covered (has corridor); TP8→TP9 is the scenic leg.
+    // Polygon is intentionally tiny so the marker is NOT inside it,
+    // forcing the fallback chain.
+    const corridors = [
+      squareCorridor(14.5, 50.0, 0.001, 'TP7', [14.0, 50.0], '1NM-after-TP7→TP8'),
+    ]
+    const covered = new Set<string>([legKey('TP7', 'TP8')])
+    // Marker at lng=14.7: closer to the TP7→TP8 leg axis (perpendicular
+    // distance ~0) than to the TP8→TP9 leg axis. Without the
+    // `coveredLegs` filter the projector would pick TP7. With the
+    // filter, the TP7→TP8 leg is skipped and the only remaining leg is
+    // TP8→TP9, so the marker is attributed to TP8.
+    const out = matchPointsToCorridors(
+      [{ id: 'overshoot', lng: 14.7, lat: 50.05 }],
+      corridors,
+      waypoints,
+      covered,
+    )
+    expect(out.overshoot?.startName).toBe('TP8')
+  })
+
+  it('without waypoints, retains the legacy nearest-startCoord fallback', () => {
+    // Same corridor setup, no waypoints arg — verifies callers that
+    // don't supply ordered waypoints still get the old behaviour. The
+    // old fallback picks TP9 because its startCoord is closer.
+    const corridors = [
+      squareCorridor(14.0, 50.0, 0.001, 'TP7'),
+      squareCorridor(16.0, 50.0, 0.001, 'TP9'),
+    ]
+    const out = matchPointsToCorridors(
+      [{ id: 'scenic', lng: 15.4, lat: 50.001 }],
+      corridors,
+    )
+    expect(out.scenic?.startName).toBe('TP9')
+  })
+
+  it('without coveredLegs, leg-projection treats every leg as eligible', () => {
+    // Backward-compat: tests that don't care about coverage filtering
+    // can omit `coveredLegs` and the projector keeps its pre-filter
+    // behaviour (every leg considered).
+    const waypoints = [
+      { name: 'TP1', coord: [14.0, 50.0] as [number, number] },
+      { name: 'TP2', coord: [15.0, 50.0] as [number, number] },
+      { name: 'TP3', coord: [16.0, 50.0] as [number, number] },
+    ]
+    const out = matchPointsToCorridors(
+      [{ id: 'p', lng: 14.5, lat: 50.0 }],
+      [],
+      waypoints,
+    )
+    // Marker mid-leg between TP1 and TP2 — projects onto TP1→TP2,
+    // attributed to TP1.
+    expect(out.p?.startName).toBe('TP1')
   })
 
   it('lat-aware distance: at 50° N a point 0.05° east-of-TP is closer than 0.05° north-of-SP', () => {

--- a/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
+++ b/frontend/map-corridors/src/__tests__/matchPointsToCorridors.test.ts
@@ -200,6 +200,62 @@ describe('matchPointsToCorridors', () => {
     expect(out.p?.startName).toBe('TP1')
   })
 
+  // Round-5 follow-up: the leg-projection fallback's 50 km cap was
+  // untested. Without this guard, a marker far from every scenic leg
+  // would silently snap to whichever leg happened to be closest,
+  // producing a wildly wrong "Od TP" answer-sheet entry. The cap
+  // shares NEAREST_CORRIDOR_MAX_METERS with the legacy nearest-startCoord
+  // fallback so both branches honour the same "no attribution" rule.
+  it('returns null when the marker is farther than NEAREST_CORRIDOR_MAX_METERS from every leg', () => {
+    // Single uncovered leg from (14, 50) to (15, 50), ~71 km long at 50°N.
+    // Place the marker > 50 km north of the leg (50.5°N → 0.5° lat = ~55 km
+    // perpendicular distance, beyond the cap).
+    const waypoints = [
+      { name: 'TP1', coord: [14.0, 50.0] as [number, number] },
+      { name: 'TP2', coord: [15.0, 50.0] as [number, number] },
+    ]
+    const out = matchPointsToCorridors(
+      [{ id: 'far', lng: 14.5, lat: 50.5 }],
+      [],
+      waypoints,
+    )
+    // Sanity-pin the cap against the exported constant so a future change
+    // to NEAREST_CORRIDOR_MAX_METERS makes this test surface intentionally.
+    expect(NEAREST_CORRIDOR_MAX_METERS).toBe(50_000)
+    expect(out.far).toBeNull()
+  })
+
+  // Round-5 follow-up: when EVERY leg is covered by a corridor, the
+  // leg-projection branch returns null (no eligible scenic leg) and the
+  // matcher falls through to the legacy nearest-startCoord branch. This
+  // graceful-degradation is documented in the matcher's comments but
+  // wasn't pinned by a test — a future refactor that short-circuits to
+  // null on bestIdx<0 would break the fall-through silently.
+  it('falls through to legacy nearest-startCoord when every leg is covered', () => {
+    const waypoints = [
+      { name: 'TP1', coord: [14.0, 50.0] as [number, number] },
+      { name: 'TP2', coord: [15.0, 50.0] as [number, number] },
+    ]
+    // The TP1→TP2 leg has a corridor (registered in coveredLegs).
+    // Polygon is intentionally tiny (0.001°) so the marker at lng=14.95
+    // is OUTSIDE every polygon, forcing the fallback chain. Leg-
+    // projection skips TP1→TP2 (covered), bestIdx stays -1, returns
+    // null — and the matcher then runs the legacy nearest-startCoord
+    // branch which picks TP2 (closest startCoord).
+    const corridors = [
+      squareCorridor(14.5, 50.0, 0.001, 'TP1', [14.0, 50.0], '1NM-after-TP1→TP2'),
+      squareCorridor(15.0, 50.0, 0.001, 'TP2', [15.0, 50.0], 'TP2'),
+    ]
+    const covered = new Set<string>([legKey('TP1', 'TP2')])
+    const out = matchPointsToCorridors(
+      [{ id: 'fallthrough', lng: 14.95, lat: 50.0 }],
+      corridors,
+      waypoints,
+      covered,
+    )
+    expect(out.fallthrough?.startName).toBe('TP2')
+  })
+
   it('lat-aware distance: at 50° N a point 0.05° east-of-TP is closer than 0.05° north-of-SP', () => {
     // Naive Δlng²+Δlat² (degrees) would tie. With cos(50°) ≈ 0.643 scaling on
     // Δlng, the east-of-TP candidate wins because 0.05° lng at 50° N is only

--- a/frontend/map-corridors/src/corridors/buildRouteWaypoints.ts
+++ b/frontend/map-corridors/src/corridors/buildRouteWaypoints.ts
@@ -1,0 +1,64 @@
+import type { RouteWaypoint } from './matchPoints'
+
+/**
+ * Build the ordered route-waypoint list (SP, TP1, TP2, …, TPn, FP) used by
+ * the leg-projection fallback in `matchPointsToCorridors` (feedback
+ * 2026-05-03). Extracted from `App.tsx` so the ordering rule and the
+ * NaN-coord filter are unit-testable without mounting the React tree.
+ *
+ * Input is whatever shape `session.exactPoints` carries — typically a
+ * GeoJSON `FeatureCollection`, but the call site historically casts it
+ * through `as any` so we accept `unknown` and defensively pull out the
+ * `features` array.
+ *
+ * Filters dropped on each feature:
+ *   • `properties.role` must be `'exact'`
+ *   • `properties.name` must be a non-empty string
+ *   • `geometry.coordinates[0..1]` must coerce to finite numbers — round-5
+ *     fix: `Number("abc")` → NaN was previously pushed straight through to
+ *     `pointToLineDistance`, which propagates NaN silently and excluded the
+ *     bad leg from leg-projection without any signal to the user. With the
+ *     filter we drop the malformed waypoint and `console.warn` so the
+ *     issue is visible during a KML import that has bad coords.
+ *
+ * Sort: SP first, FP last, TPs sorted numerically in between (so "TP10"
+ * sorts after "TP9", not lex-sorted). Names that don't fit the pattern
+ * (rare authoring quirk) fall after the numeric block — leg projection
+ * skips unknown adjacency anyway because perpendicular distances will be
+ * larger than to the real legs.
+ */
+export function buildRouteWaypoints(exactPoints: unknown): RouteWaypoint[] {
+  const out: RouteWaypoint[] = []
+  const features = (exactPoints as { features?: unknown })?.features
+  if (!Array.isArray(features)) return out
+  for (const f of features) {
+    const role = (f as { properties?: { role?: unknown } })?.properties?.role
+    const name = (f as { properties?: { name?: unknown } })?.properties?.name
+    const coords = (f as { geometry?: { coordinates?: unknown } })?.geometry?.coordinates
+    if (role !== 'exact' || typeof name !== 'string' || !name) continue
+    if (!Array.isArray(coords) || coords.length < 2) continue
+    const lng = Number(coords[0])
+    const lat = Number(coords[1])
+    if (!Number.isFinite(lng) || !Number.isFinite(lat)) {
+      console.warn('[buildRouteWaypoints] dropping waypoint with non-finite coords:', name, coords)
+      continue
+    }
+    out.push({ name, coord: [lng, lat] })
+  }
+  const tpNum = (s: string) => {
+    const m = s.match(/(\d+)/)
+    return m ? parseInt(m[1], 10) : NaN
+  }
+  out.sort((a, b) => {
+    if (a.name === b.name) return 0
+    if (a.name === 'SP') return -1
+    if (b.name === 'SP') return 1
+    if (a.name === 'FP') return 1
+    if (b.name === 'FP') return -1
+    const an = tpNum(a.name)
+    const bn = tpNum(b.name)
+    if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
+    return a.name.localeCompare(b.name)
+  })
+  return out
+}

--- a/frontend/map-corridors/src/corridors/extractStartName.ts
+++ b/frontend/map-corridors/src/corridors/extractStartName.ts
@@ -32,3 +32,29 @@ export function extractStartName(corridorName: string): string {
   if (beforeArrow.includes('after-')) return beforeArrow.split('after-').pop() || 'SP';
   return 'SP';
 }
+
+/**
+ * Extract the "following TP" endName from a corridor segment name.
+ *
+ * Mirror of `extractStartName` for the post-arrow side. Used by the
+ * leg-projection fallback (feedback 2026-05-03 follow-up): photos
+ * outside any polygon must project onto the NEAREST scenic leg —
+ * meaning a leg whose corridor was dropped because it's a chain of
+ * dashed connectors. To skip legs that already have a corridor we need
+ * the (start → end) waypoint pair from each corridor name.
+ *
+ * Examples (real shapes from preciseCorridor.ts):
+ *   "5NM-after-SP→TP1"   → "TP1"
+ *   "1NM-after-TP1→TP2"  → "TP2"
+ *   "1NM-after-TP4→FP"   → "FP"
+ *
+ * Returns '' when the name has no arrow (alternate authoring tools, no
+ * recognised shape). The leg-projection fallback treats an empty
+ * endName as "no covered pair" — the corresponding leg won't be
+ * skipped, which is the safe direction to fail.
+ */
+export function extractEndName(corridorName: string): string {
+  const parts = String(corridorName).split('→');
+  if (parts.length < 2) return '';
+  return (parts[1] || '').trim();
+}

--- a/frontend/map-corridors/src/corridors/matchPoints.ts
+++ b/frontend/map-corridors/src/corridors/matchPoints.ts
@@ -1,4 +1,4 @@
-import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon } from '@turf/turf'
+import { booleanPointInPolygon, point as turfPoint, polygon as turfPolygon, lineString as turfLineString, pointToLineDistance } from '@turf/turf'
 import { calculateDistance } from './segments'
 
 export type CorridorPolygon = {
@@ -11,6 +11,18 @@ export type CorridorPolygon = {
 
 export type PointForMatching = { id: string; lng: number; lat: number }
 export type CorridorMatch = { startCoord?: [number, number]; startName: string }
+
+/**
+ * Ordered route waypoints (SP, TP1, TP2, …, TPn, FP). When supplied, the
+ * fallback path projects unmatched markers onto adjacent waypoint legs and
+ * attributes them to the leg's PRECEDING waypoint — fixing the dashed/scenic
+ * leg case (feedback 2026-05-03): when the corridor between TPn and TPn+1 is
+ * dropped because the leg is a chain of dashed connectors, photos in the gap
+ * fall back to "nearest startCoord" and get attributed to TPn+1 (the next
+ * leg's start), which the rules dictate must be TPn (the preceding TP of the
+ * leg the photo is actually on).
+ */
+export type RouteWaypoint = { name: string; coord: [number, number] }
 
 /**
  * Maximum haversine distance (metres) from a marker to the chosen
@@ -38,9 +50,32 @@ export const NEAREST_CORRIDOR_MAX_METERS = 50_000
  * swallow is the exact pattern the 2026-04-23 feedback round fixed at the
  * upload path; we apply the same discipline here.
  */
+/**
+ * Set of "{from}→{to}" leg keys that are already covered by a corridor.
+ * The leg-projection fallback skips these so a marker outside any
+ * polygon only attaches to a SCENIC leg (one whose corridor was dropped
+ * because the leg is a chain of dashed connectors). Without this
+ * filter, a marker that just barely overshoots a corridor's polygon
+ * would still snap back onto that corridor's leg via projection — but
+ * the user's rule (feedback 2026-05-03 follow-up) is "outside corridor
+ * → assigned to nearest leg WITHOUT a corridor". The set lets the
+ * matcher honour that rule without having to re-derive corridor
+ * geometry here.
+ *
+ * Build keys as `${from}→${to}` (no spaces, exactly as written in the
+ * corridor segment name template at preciseCorridor.ts:281,292,376).
+ */
+export type CoveredLegKey = `${string}→${string}`
+
+export function legKey(fromName: string, toName: string): CoveredLegKey {
+  return `${fromName}→${toName}` as CoveredLegKey
+}
+
 export function matchPointsToCorridors(
   pts: ReadonlyArray<PointForMatching>,
   corridorPolygons: ReadonlyArray<CorridorPolygon>,
+  waypoints?: ReadonlyArray<RouteWaypoint>,
+  coveredLegs?: ReadonlySet<string>,
 ): Record<string, CorridorMatch | null> {
   const out: Record<string, CorridorMatch | null> = {}
   for (const m of pts) {
@@ -56,7 +91,31 @@ export function matchPointsToCorridors(
         console.error('[matchPointsToCorridors] polygon eval failed for corridor', c.startName, err)
       }
     }
-    if (!match && corridorPolygons.length) {
+    if (match) {
+      out[m.id] = { startCoord: match.startCoord, startName: match.startName }
+      continue
+    }
+
+    // Leg-projection fallback (preferred when ordered waypoints are
+    // available). Project the marker onto each adjacent-waypoint leg,
+    // pick the leg with smallest perpendicular distance, attribute to
+    // its PRECEDING waypoint. Handles the dashed/scenic-leg gap case
+    // (feedback 2026-05-03): markers between TPn and TPn+1 on a leg
+    // whose corridor was dropped (chain of dashed connectors) used to
+    // fall through the legacy nearest-startCoord branch and lock onto
+    // TPn+1 (the start of the NEXT corridor) because that startCoord
+    // happened to be the closest. Projecting onto the leg geometry
+    // instead picks the actual leg the marker is on, regardless of
+    // which endpoint the marker is geographically nearer to.
+    if (waypoints && waypoints.length >= 2) {
+      const legMatch = matchByLegProjection(m, waypoints, coveredLegs)
+      if (legMatch) {
+        out[m.id] = legMatch
+        continue
+      }
+    }
+
+    if (corridorPolygons.length) {
       const cosLat = Math.cos((m.lat * Math.PI) / 180) || 1e-9
       let nearest: CorridorPolygon | null = null
       let bestD2 = Infinity
@@ -81,4 +140,51 @@ export function matchPointsToCorridors(
     out[m.id] = match ? { startCoord: match.startCoord, startName: match.startName } : null
   }
   return out
+}
+
+/**
+ * Project the marker onto each adjacent leg `waypoints[i] → waypoints[i+1]`
+ * that is NOT covered by an existing corridor, pick the leg with smallest
+ * perpendicular distance, return its preceding waypoint as the match.
+ * Honors `NEAREST_CORRIDOR_MAX_METERS` so a marker 60+ km from every
+ * scenic leg returns null instead of a spurious attribution.
+ *
+ * Filtering by `coveredLegs` enforces the user's "outside corridor →
+ * assigned to nearest leg WITHOUT a corridor" rule (feedback 2026-05-03
+ * follow-up). When `coveredLegs` is undefined or empty, every leg is
+ * considered — keeps the function usable without corridor context (e.g.
+ * unit tests that only exercise the projection geometry).
+ *
+ * `pointToLineDistance` measures perpendicular distance to the segment
+ * (clamped at endpoints), which is exactly the "which leg is the marker
+ * on" question we want to answer.
+ */
+function matchByLegProjection(
+  m: PointForMatching,
+  waypoints: ReadonlyArray<RouteWaypoint>,
+  coveredLegs?: ReadonlySet<string>,
+): CorridorMatch | null {
+  let bestIdx = -1
+  let bestKm = Infinity
+  const pt = turfPoint([m.lng, m.lat])
+  for (let i = 0; i < waypoints.length - 1; i++) {
+    const fromName = waypoints[i].name
+    const toName = waypoints[i + 1].name
+    if (coveredLegs && coveredLegs.has(legKey(fromName, toName))) continue
+    const a = waypoints[i].coord
+    const b = waypoints[i + 1].coord
+    let km: number
+    try {
+      const seg = turfLineString([[a[0], a[1]], [b[0], b[1]]])
+      km = pointToLineDistance(pt, seg, { units: 'kilometers' })
+    } catch (err) {
+      console.error('[matchPointsToCorridors] leg projection failed for', fromName, '→', toName, err)
+      continue
+    }
+    if (km < bestKm) { bestKm = km; bestIdx = i }
+  }
+  if (bestIdx < 0) return null
+  if (bestKm * 1000 > NEAREST_CORRIDOR_MAX_METERS) return null
+  const leading = waypoints[bestIdx]
+  return { startName: leading.name, startCoord: leading.coord }
 }

--- a/frontend/photo-helper/src/__tests__/distributeRallyDrop.test.ts
+++ b/frontend/photo-helper/src/__tests__/distributeRallyDrop.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { distributeRallyDrop } from '../utils/distributeRallyDrop';
+import {
+  distributeRallyDrop,
+  RALLY_TURNING_PER_SET,
+  RALLY_TURNING_MAX_TOTAL,
+} from '../utils/distributeRallyDrop';
 
 // Minimal File stand-in; distributeRallyDrop only uses `files.slice` and
 // `files.length`, never File's own API. Plain objects keep the test hermetic.
@@ -7,62 +11,77 @@ function fakeFiles(n: number): File[] {
   return Array.from({ length: n }, (_, i) => ({ name: `p${i}.jpg` } as unknown as File));
 }
 
-describe('distributeRallyDrop — landscape (9+9 = 18 cap)', () => {
-  it('splits 16 photos across the empty 9/9 grid as 9 + 7', () => {
+// Rally rules allow up to 18 turning points (= SP + 18 TP + FP = 20
+// photos) per feedback 2026-05-03. Per-set capacity is therefore 10 in
+// BOTH orientations — the landscape grid auto-expands from 3×3 to 5×2
+// once a set reaches 10 photos. `layoutMode` is retained on the input
+// type for backward compatibility but no longer affects capacity.
+describe('distributeRallyDrop — orientation-agnostic 10+10 = 20 cap', () => {
+  it('exposes the per-set and total caps', () => {
+    expect(RALLY_TURNING_PER_SET).toBe(10);
+    expect(RALLY_TURNING_MAX_TOTAL).toBe(20);
+  });
+
+  it('splits 16 photos across an empty 10/10 grid as 10 + 6 (landscape)', () => {
     const r = distributeRallyDrop({
       files: fakeFiles(16), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(9);
-    expect(r.toSet2).toHaveLength(7);
-    expect(r.maxTotal).toBe(18);
+    expect(r.toSet1).toHaveLength(10);
+    expect(r.toSet2).toHaveLength(6);
+    expect(r.maxTotal).toBe(20);
   });
 
-  it('splits 10 photos as 9 + 1', () => {
+  it('splits 10 photos as 10 + 0 (single page filled)', () => {
     const r = distributeRallyDrop({
       files: fakeFiles(10), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(9);
-    expect(r.toSet2).toHaveLength(1);
+    expect(r.toSet1).toHaveLength(10);
+    expect(r.toSet2).toHaveLength(0);
   });
 
-  it('accepts exactly 18 photos (capacity boundary)', () => {
+  it('accepts exactly 20 photos at the capacity boundary', () => {
     const r = distributeRallyDrop({
-      files: fakeFiles(18), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+      files: fakeFiles(20), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(9);
-    expect(r.toSet2).toHaveLength(9);
+    expect(r.toSet1).toHaveLength(10);
+    expect(r.toSet2).toHaveLength(10);
   });
 
-  it('rejects 19 photos in landscape (over cap)', () => {
-    const r = distributeRallyDrop({
-      files: fakeFiles(19), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
+  it('rejects 21 photos (over cap) regardless of layout', () => {
+    const land = distributeRallyDrop({
+      files: fakeFiles(21), layoutMode: 'landscape', set1Count: 0, set2Count: 0,
     });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.reason).toBe('overflow');
-    expect(r.maxTotal).toBe(18);
-    expect(r.totalIfAdded).toBe(19);
+    expect(land.ok).toBe(false);
+    if (land.ok) return;
+    expect(land.reason).toBe('overflow');
+    expect(land.maxTotal).toBe(20);
+    expect(land.totalIfAdded).toBe(21);
+
+    const port = distributeRallyDrop({
+      files: fakeFiles(21), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
+    });
+    expect(port.ok).toBe(false);
   });
 
-  it('respects partially-filled set1: set1Count=5 + drop 10 → 4 remaining to set1, 6 to set2', () => {
+  it('respects partially-filled set1: set1Count=5 + drop 10 → 5 remaining to set1, 5 to set2', () => {
     const r = distributeRallyDrop({
       files: fakeFiles(10), layoutMode: 'landscape', set1Count: 5, set2Count: 0,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(4);
-    expect(r.toSet2).toHaveLength(6);
+    expect(r.toSet1).toHaveLength(5);
+    expect(r.toSet2).toHaveLength(5);
   });
 
   it('set1 already full: drop 8 → 0 to set1, 8 to set2', () => {
     const r = distributeRallyDrop({
-      files: fakeFiles(8), layoutMode: 'landscape', set1Count: 9, set2Count: 0,
+      files: fakeFiles(8), layoutMode: 'landscape', set1Count: 10, set2Count: 0,
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
@@ -74,45 +93,12 @@ describe('distributeRallyDrop — landscape (9+9 = 18 cap)', () => {
     const r = distributeRallyDrop({
       files: fakeFiles(3), layoutMode: 'landscape', set1Count: 12, set2Count: 0,
     });
-    // set1Count (12) > maxTotal (18) – files(3) = 15, so overflow check passes.
-    // Math.max(0, 9 - 12) = 0 → everything to set2.
+    // set1Count (12) + files (3) = 15 ≤ maxTotal (20), so overflow check passes.
+    // Math.max(0, 10 - 12) = 0 → everything to set2.
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.toSet1).toHaveLength(0);
     expect(r.toSet2).toHaveLength(3);
-  });
-});
-
-describe('distributeRallyDrop — portrait (10+10 = 20 cap)', () => {
-  it('splits 16 photos across the empty 10/10 grid as 10 + 6', () => {
-    const r = distributeRallyDrop({
-      files: fakeFiles(16), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
-    });
-    expect(r.ok).toBe(true);
-    if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(10);
-    expect(r.toSet2).toHaveLength(6);
-  });
-
-  it('accepts exactly 20 photos (capacity boundary)', () => {
-    const r = distributeRallyDrop({
-      files: fakeFiles(20), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
-    });
-    expect(r.ok).toBe(true);
-    if (!r.ok) return;
-    expect(r.toSet1).toHaveLength(10);
-    expect(r.toSet2).toHaveLength(10);
-    expect(r.maxTotal).toBe(20);
-  });
-
-  it('rejects 21 photos in portrait (over cap)', () => {
-    const r = distributeRallyDrop({
-      files: fakeFiles(21), layoutMode: 'portrait', set1Count: 0, set2Count: 0,
-    });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.reason).toBe('overflow');
-    expect(r.maxTotal).toBe(20);
   });
 });
 

--- a/frontend/photo-helper/src/__tests__/getGridCapacity.test.ts
+++ b/frontend/photo-helper/src/__tests__/getGridCapacity.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getGridCapacity,
+  TURNING_POINT_PER_SET,
+  TRACK_LANDSCAPE_PER_SET,
+  TRACK_PORTRAIT_PER_SET,
+} from '../utils/getGridCapacity';
+
+// Single source of truth for grid capacity across five sites
+// (`addPhotosToSet`, `reorderPhotos`, `getSessionStats` x2,
+// `addPhotosToTurningPoint`). A cap bump must propagate uniformly — these
+// tests pin the rule so a future change can't drift any one site.
+describe('getGridCapacity', () => {
+  it('exposes the documented constants', () => {
+    expect(TURNING_POINT_PER_SET).toBe(10);
+    expect(TRACK_LANDSCAPE_PER_SET).toBe(9);
+    expect(TRACK_PORTRAIT_PER_SET).toBe(10);
+  });
+
+  it('returns track-landscape default for null/undefined session', () => {
+    expect(getGridCapacity(null)).toBe(9);
+    expect(getGridCapacity(undefined)).toBe(9);
+  });
+
+  describe('turning-point mode', () => {
+    it('caps at 10 in landscape', () => {
+      expect(getGridCapacity({ mode: 'turningpoint', layoutMode: 'landscape' })).toBe(10);
+    });
+
+    it('caps at 10 in portrait', () => {
+      expect(getGridCapacity({ mode: 'turningpoint', layoutMode: 'portrait' })).toBe(10);
+    });
+
+    it('caps at 10 even when layoutMode is missing', () => {
+      // Layout is irrelevant for turning-point mode — the auto-flipping
+      // 3×3 / 5×2 grid handles both orientations at 10/set.
+      expect(getGridCapacity({ mode: 'turningpoint' })).toBe(10);
+    });
+  });
+
+  describe('track mode', () => {
+    it('caps at 9 in landscape', () => {
+      expect(getGridCapacity({ mode: 'track', layoutMode: 'landscape' })).toBe(9);
+    });
+
+    it('caps at 10 in portrait', () => {
+      expect(getGridCapacity({ mode: 'track', layoutMode: 'portrait' })).toBe(10);
+    });
+
+    it('defaults to landscape (9) when layoutMode is missing', () => {
+      // The legacy default — track mode without an explicit layoutMode
+      // renders in landscape, so capacity follows.
+      expect(getGridCapacity({ mode: 'track' })).toBe(9);
+    });
+
+    it('treats unknown layoutMode strings as landscape (9)', () => {
+      // Defensive: anything other than 'portrait' falls into the
+      // landscape branch.
+      expect(getGridCapacity({ mode: 'track', layoutMode: 'square' as any })).toBe(9);
+    });
+  });
+
+  it('defaults to track when mode is missing', () => {
+    // A session loaded from an older build might not have `mode` set.
+    // Track is the legacy default.
+    expect(getGridCapacity({ layoutMode: 'portrait' })).toBe(10);
+    expect(getGridCapacity({ layoutMode: 'landscape' })).toBe(9);
+    expect(getGridCapacity({})).toBe(9);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/pdfLandscapeGrid.test.ts
+++ b/frontend/photo-helper/src/__tests__/pdfLandscapeGrid.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateLandscapeGrid,
+  A4_LANDSCAPE_WIDTH_PT,
+  A4_LANDSCAPE_HEIGHT_PT,
+  PDF_LANDSCAPE_GAP_PT,
+} from '../utils/pdfLandscapeGrid';
+
+// 3:2 photo aspect ratio (typical 35mm digital, what the rally answer
+// sheet usually carries). Tests don't depend on the exact value — they
+// pin RELATIONSHIPS (cols/rows transitions, centering invariants) so a
+// future tweak to aspect-ratio handling won't break them spuriously.
+const ASPECT_3_2 = 1.5;
+const HEADER_HEIGHT = 25;
+const HEADER_TOP_PAD = 2.83;
+
+describe('calculateLandscapeGrid', () => {
+  describe('grid selection (3×3 vs 5×2 boundary)', () => {
+    it('selects 3×3 when pageCount is below 10', () => {
+      // Round-4 rule: below 10 photos in landscape, render 3×3 so a
+      // partial drop doesn't leave 4 trailing empties.
+      for (const count of [0, 5, 8, 9]) {
+        const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, count);
+        expect(layout.cols).toBe(3);
+        expect(layout.rows).toBe(3);
+      }
+    });
+
+    it('selects 5×2 at the count === 10 boundary', () => {
+      // The exact boundary the round-4 fix targets.
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      expect(layout.cols).toBe(5);
+      expect(layout.rows).toBe(2);
+    });
+
+    it('keeps 5×2 when pageCount > 10 (defensive — cap is 10)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 11);
+      expect(layout.cols).toBe(5);
+      expect(layout.rows).toBe(2);
+    });
+  });
+
+  describe('layout invariants', () => {
+    it('produces strictly positive photo dimensions for both grids', () => {
+      // A regression that produced zero or negative widths (e.g. a sign
+      // flip on the gap calculation) would silently print empty pages.
+      const layout33 = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 9);
+      const layout52 = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      expect(layout33.photoWidth).toBeGreaterThan(0);
+      expect(layout33.photoHeight).toBeGreaterThan(0);
+      expect(layout52.photoWidth).toBeGreaterThan(0);
+      expect(layout52.photoHeight).toBeGreaterThan(0);
+    });
+
+    it('respects the photo aspect ratio (corrected width = corrected height × aspectRatio)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      // Within a small floating-point tolerance — `Math.floor` is applied
+      // to the pre-correction dimensions, then aspect-ratio is enforced.
+      expect(layout.photoWidth / layout.photoHeight).toBeCloseTo(ASPECT_3_2, 5);
+    });
+
+    it('horizontally centers the grid within the available width', () => {
+      // Centering guarantee: 2 * startX + totalGridWidth ≈ pageWidth.
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      const totalGridWidth = layout.photoWidth * layout.cols + layout.gap * (layout.cols - 1);
+      // Margin is 0 (edge-less), so startX === (pageWidth - totalGridWidth) / 2.
+      const expectedStartX = (A4_LANDSCAPE_WIDTH_PT - totalGridWidth) / 2;
+      expect(layout.startX).toBeCloseTo(expectedStartX, 5);
+    });
+
+    it('places the grid directly below the header (startY = headerTopPad + headerHeight)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      expect(layout.startY).toBeCloseTo(HEADER_TOP_PAD + HEADER_HEIGHT, 5);
+    });
+
+    it('echoes headerTopPad as headerY (where the title text lands)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 5);
+      expect(layout.headerY).toBe(HEADER_TOP_PAD);
+    });
+
+    it('returns the documented constant gap (1mm in PDF points)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 7);
+      expect(layout.gap).toBe(PDF_LANDSCAPE_GAP_PT);
+    });
+  });
+
+  describe('grid fits on the A4 page (sanity)', () => {
+    // The total grid bounding box should never overflow the page in either
+    // dimension. A regression that picked the wrong page constant or got
+    // the cols/rows transposed would show up here.
+    it('3×3 grid total height fits below the available height', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 9);
+      const totalHeight = layout.photoHeight * layout.rows + layout.gap * (layout.rows - 1);
+      const availableHeight = A4_LANDSCAPE_HEIGHT_PT - HEADER_TOP_PAD - HEADER_HEIGHT;
+      expect(totalHeight).toBeLessThanOrEqual(availableHeight + 1); // +1 for floor rounding
+    });
+
+    it('5×2 grid total height fits below the available height', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, HEADER_HEIGHT, HEADER_TOP_PAD, 10);
+      const totalHeight = layout.photoHeight * layout.rows + layout.gap * (layout.rows - 1);
+      const availableHeight = A4_LANDSCAPE_HEIGHT_PT - HEADER_TOP_PAD - HEADER_HEIGHT;
+      expect(totalHeight).toBeLessThanOrEqual(availableHeight + 1);
+    });
+  });
+
+  describe('header height edge cases', () => {
+    it('handles a zero-height header (no header rendered)', () => {
+      const layout = calculateLandscapeGrid(ASPECT_3_2, 0, HEADER_TOP_PAD, 10);
+      expect(layout.startY).toBeCloseTo(HEADER_TOP_PAD, 5);
+    });
+
+    it('clamps a negative header height to zero', () => {
+      // Defensive: a negative input shouldn't push the grid above the page.
+      const layout = calculateLandscapeGrid(ASPECT_3_2, -50, HEADER_TOP_PAD, 10);
+      expect(layout.startY).toBeCloseTo(HEADER_TOP_PAD, 5);
+    });
+  });
+});

--- a/frontend/photo-helper/src/__tests__/rallyGridFor.test.ts
+++ b/frontend/photo-helper/src/__tests__/rallyGridFor.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { rallyGridFor } from '../utils/rallyGridFor';
+
+// The boundary at count === 10 is load-bearing: a regression where
+// `count >= 10` becomes `count > 10` would resurrect the round-4 bug
+// (the 10th photo silently hidden behind a 3×3 landscape grid).
+// Pinning every adjacent point to the boundary surfaces that.
+describe('rallyGridFor', () => {
+  describe('precision discipline', () => {
+    it('returns undefined regardless of count or layout', () => {
+      expect(rallyGridFor(0, 'landscape', true)).toBeUndefined();
+      expect(rallyGridFor(5, 'portrait', true)).toBeUndefined();
+      expect(rallyGridFor(10, 'landscape', true)).toBeUndefined();
+      expect(rallyGridFor(10, 'portrait', true)).toBeUndefined();
+    });
+  });
+
+  describe('rally portrait', () => {
+    it('always returns 10 slots in 2 columns (2×5), regardless of count', () => {
+      // Portrait stays 2×5 = 10 unconditionally — the only orientation
+      // that ever rendered 10 cells in the legacy code.
+      expect(rallyGridFor(0, 'portrait', false)).toEqual({ slots: 10, columns: 2 });
+      expect(rallyGridFor(5, 'portrait', false)).toEqual({ slots: 10, columns: 2 });
+      expect(rallyGridFor(10, 'portrait', false)).toEqual({ slots: 10, columns: 2 });
+    });
+  });
+
+  describe('rally landscape', () => {
+    it('returns 9 slots in 3 columns (3×3) when count is below 10', () => {
+      expect(rallyGridFor(0, 'landscape', false)).toEqual({ slots: 9, columns: 3 });
+      expect(rallyGridFor(5, 'landscape', false)).toEqual({ slots: 9, columns: 3 });
+      expect(rallyGridFor(9, 'landscape', false)).toEqual({ slots: 9, columns: 3 });
+    });
+
+    it('returns 10 slots in 5 columns (5×2) at the count === 10 boundary', () => {
+      // The exact boundary the round-4 fix targets — flips from 3×3 to 5×2.
+      expect(rallyGridFor(10, 'landscape', false)).toEqual({ slots: 10, columns: 5 });
+    });
+
+    it('returns 10 slots in 5 columns when count > 10 (defensive — cap is 10)', () => {
+      // Cap is enforced upstream by distributeRallyDrop. If somehow a
+      // higher count slips through, the grid still shows 5×2 rather
+      // than truncating to 3×3.
+      expect(rallyGridFor(11, 'landscape', false)).toEqual({ slots: 10, columns: 5 });
+      expect(rallyGridFor(99, 'landscape', false)).toEqual({ slots: 10, columns: 5 });
+    });
+
+    it('shrinks back to 3×3 if the user removes a photo from a full 5×2 set', () => {
+      // 10 photos → 5×2; user removes one, count becomes 9 → 3×3.
+      // The remaining 9 photos still fit (3×3 holds 9 exactly), no loss.
+      const fullGrid = rallyGridFor(10, 'landscape', false);
+      const afterRemove = rallyGridFor(9, 'landscape', false);
+      expect(fullGrid).toEqual({ slots: 10, columns: 5 });
+      expect(afterRemove).toEqual({ slots: 9, columns: 3 });
+    });
+  });
+});

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -30,6 +30,14 @@ interface PhotoGridApiProps {
    * layouts so a 10th upload can still land and flip the layout to portrait.
    */
   maxPhotosOverride?: number;
+  /**
+   * Override the rendered grid slot count and column count. Used by rally
+   * turning-point mode (feedback 2026-05-03): per-set capacity is 10 in both
+   * orientations, so a landscape grid with 10 photos must render as 5×2
+   * instead of the default 3×3 (which silently hid the 10th photo).
+   */
+  slotsOverride?: number;
+  columnsOverride?: number;
 }
 
 interface GridSlot {
@@ -57,6 +65,8 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   labelOffset = 0,
   customLabels,
   maxPhotosOverride,
+  slotsOverride,
+  columnsOverride,
 }) => {
   const { currentRatio, isTransitioning } = useAspectRatio();
   const { generateLabel } = useLabeling();
@@ -80,9 +90,14 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   const { layoutConfig } = useLayoutMode();
   const effectiveMaxPhotos = maxPhotosOverride ?? layoutConfig.maxPhotosPerSet;
   const maxFilesRemaining = Math.max(0, effectiveMaxPhotos - photoSet.photos.length);
-  
+  // Effective grid: defaults to the layout config; rally turning-point in
+  // landscape passes overrides so a 10-photo set renders as 5×2 instead of
+  // the default 3×3 (feedback 2026-05-03).
+  const effectiveSlots = slotsOverride ?? layoutConfig.slots;
+  const effectiveColumns = columnsOverride ?? layoutConfig.columns;
+
   // Create grid slots based on layout mode (9 for landscape, 10 for portrait)
-  const gridSlots: GridSlot[] = Array.from({ length: layoutConfig.slots }, (_, index) => {
+  const gridSlots: GridSlot[] = Array.from({ length: effectiveSlots }, (_, index) => {
     const photo = photoSet.photos[index] || null;
     
     // Only show labels when there's a photo, or in track mode for empty slots
@@ -171,7 +186,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
         /* Dynamic Photo Grid (3x3 or 2x5 based on layout) */
         <Box sx={{
           display: 'grid',
-          gridTemplateColumns: `repeat(${layoutConfig.columns}, 1fr)`,
+          gridTemplateColumns: `repeat(${effectiveColumns}, 1fr)`,
           gap: 2,
           p: 2,
           bgcolor: 'background.paper',

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -35,7 +35,10 @@ interface TurningPointLayoutProps {
 // Precision turning-point mode caps at 9 photos per feedback 2026-04-18:
 // SP + up to 7 turning points + FP.
 const PRECISION_TURNING_MAX_PHOTOS = 9;
-const RALLY_TURNING_MAX_PHOTOS = 18;
+// Rally turning-point caps at 20 (= SP + 18 TP + FP) per feedback
+// 2026-05-03. Per-set capacity is 10 in BOTH orientations — landscape
+// grid auto-expands from 3×3 to 5×2 once a set reaches 10.
+const RALLY_TURNING_MAX_PHOTOS = 20;
 
 export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   set1,
@@ -62,6 +65,25 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   const effectiveSet2Count = isPrecision ? 0 : set2.photos.length;
   const turningPointLabels = generateTurningPointLabels(set1.photos.length, effectiveSet2Count, layoutMode);
   const initialDropMax = isPrecision ? PRECISION_TURNING_MAX_PHOTOS : RALLY_TURNING_MAX_PHOTOS;
+
+  // Rally turning-point: per-set cap is 10 in both orientations, so the
+  // landscape grid must render as 5×2 (10 cells) instead of the default
+  // 3×3 (9 cells) once a set reaches 10 photos. Below 10, keep 3×3 in
+  // landscape so partial drops (e.g. 6 photos) don't render with 4 empty
+  // tiles trailing — feedback 2026-05-03 ("default 5x2 if 10 photos,
+  // otherwise 3x3"). Portrait stays at 2×5 = 10 unconditionally.
+  const rallyGridFor = (count: number): { slots: number; columns: number } | undefined => {
+    if (isPrecision) return undefined;
+    if (layoutMode === 'portrait') {
+      return { slots: 10, columns: 2 };
+    }
+    return count >= 10
+      ? { slots: 10, columns: 5 }
+      : { slots: 9, columns: 3 };
+  };
+  const set1Grid = rallyGridFor(set1.photos.length);
+  const set2Grid = rallyGridFor(set2.photos.length);
+  const rallyMaxPerSet = isPrecision ? undefined : 10;
 
   return (
     <Box>
@@ -100,6 +122,9 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set1', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set1', files)}
                 customLabels={turningPointLabels.set1}
+                maxPhotosOverride={rallyMaxPerSet}
+                slotsOverride={set1Grid?.slots}
+                columnsOverride={set1Grid?.columns}
               />
             </Paper>
           );
@@ -120,6 +145,9 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set2', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set2', files)}
                 customLabels={turningPointLabels.set2}
+                maxPhotosOverride={rallyMaxPerSet}
+                slotsOverride={set2Grid?.slots}
+                columnsOverride={set2Grid?.columns}
               />
             </Paper>
           );

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '../contexts/I18nContext';
 import { generateTurningPointLabels } from '../utils/imageProcessing';
 import type { ApiPhoto, ApiPhotoSet } from '../types/api';
 import { useLayoutMode } from '../contexts/LayoutModeContext';
+import { rallyGridFor } from '../utils/rallyGridFor';
 
 interface TurningPointLayoutProps {
   set1: ApiPhotoSet;
@@ -66,23 +67,11 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   const turningPointLabels = generateTurningPointLabels(set1.photos.length, effectiveSet2Count, layoutMode);
   const initialDropMax = isPrecision ? PRECISION_TURNING_MAX_PHOTOS : RALLY_TURNING_MAX_PHOTOS;
 
-  // Rally turning-point: per-set cap is 10 in both orientations, so the
-  // landscape grid must render as 5×2 (10 cells) instead of the default
-  // 3×3 (9 cells) once a set reaches 10 photos. Below 10, keep 3×3 in
-  // landscape so partial drops (e.g. 6 photos) don't render with 4 empty
-  // tiles trailing — feedback 2026-05-03 ("default 5x2 if 10 photos,
-  // otherwise 3x3"). Portrait stays at 2×5 = 10 unconditionally.
-  const rallyGridFor = (count: number): { slots: number; columns: number } | undefined => {
-    if (isPrecision) return undefined;
-    if (layoutMode === 'portrait') {
-      return { slots: 10, columns: 2 };
-    }
-    return count >= 10
-      ? { slots: 10, columns: 5 }
-      : { slots: 9, columns: 3 };
-  };
-  const set1Grid = rallyGridFor(set1.photos.length);
-  const set2Grid = rallyGridFor(set2.photos.length);
+  // Rally turning-point: per-set cap is 10 in both orientations. Logic
+  // is in `utils/rallyGridFor.ts` so the boundary at count === 10 is
+  // unit-testable (round-5 follow-up to feedback 2026-05-03).
+  const set1Grid = rallyGridFor(set1.photos.length, layoutMode, isPrecision);
+  const set2Grid = rallyGridFor(set2.photos.length, layoutMode, isPrecision);
   const rallyMaxPerSet = isPrecision ? undefined : 10;
 
   return (

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -894,7 +894,12 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     const set1Count = session.sets.set1.photos.length;
     const set2Count = session.sets.set2.photos.length;
     const layoutMode = (session as any).layoutMode || 'landscape';
-    const gridCapacity = layoutMode === 'portrait' ? 10 : 9;
+    // Turning-point mode: 10 per set in both orientations (feedback
+    // 2026-05-03 — landscape grid auto-expands to 5×2 at 10). Track
+    // mode keeps the layout-driven 9/10 cap.
+    const gridCapacity = session.mode === 'turningpoint'
+      ? 10
+      : (layoutMode === 'portrait' ? 10 : 9);
     
     return {
       set1Photos: set1Count,
@@ -934,9 +939,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // Methods to align with AppApi expectations
     reorderPhotos,
     shufflePhotos,
-    // Rally turning-point initial drop: distribute files across set1 (first 9)
-    // and set2 (remainder). Without this, a 10+ photo drop overflows the
-    // 9-slot set1 grid and later photos become invisible (feedback 2026-04-23).
+    // Rally turning-point initial drop: distribute files across set1 (first
+    // 10) and set2 (remainder). Per-set capacity is 10 in BOTH orientations
+    // (feedback 2026-05-03 — landscape auto-expands from 3×3 to 5×2 at 10).
+    // Without this, a 10+ photo drop overflowed set1 invisibly.
     addPhotosToTurningPoint: (async (files: File[]) => {
       const session = currentCompetition?.session;
       if (!session) {

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -16,6 +16,7 @@ import { migrationService } from '../services/migrationService';
 import { useI18n } from '../contexts/I18nContext';
 import { applySettingToAllInSession, type CanvasSetting } from '../utils/canvasStatePatch';
 import { distributeRallyDrop } from '../utils/distributeRallyDrop';
+import { getGridCapacity } from '../utils/getGridCapacity';
 import { parseDiscipline } from '../utils/parseDiscipline';
 import {
   defaultTrackSetTitles,
@@ -893,13 +894,9 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     const session = currentCompetition.session;
     const set1Count = session.sets.set1.photos.length;
     const set2Count = session.sets.set2.photos.length;
-    const layoutMode = (session as any).layoutMode || 'landscape';
-    // Turning-point mode: 10 per set in both orientations (feedback
-    // 2026-05-03 — landscape grid auto-expands to 5×2 at 10). Track
-    // mode keeps the layout-driven 9/10 cap.
-    const gridCapacity = session.mode === 'turningpoint'
-      ? 10
-      : (layoutMode === 'portrait' ? 10 : 9);
+    // Same source-of-truth helper as usePhotoSessionOPFS so the four sites
+    // can't drift (round-5 follow-up to feedback 2026-05-03).
+    const gridCapacity = getGridCapacity(session as any);
     
     return {
       set1Photos: set1Count,

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -3,6 +3,7 @@ import type { Photo } from '../types';
 import type { ApiPhoto, ApiPhotoSession } from '../types/api';
 import { applySettingToAllInSession, type CanvasSetting } from '../utils/canvasStatePatch';
 import { deriveSet1FromSet2, deriveSet2FromSet1 } from '../utils/autoPrefillSetTitle';
+import { getGridCapacity, TURNING_POINT_PER_SET } from '../utils/getGridCapacity';
 import {
   isStorageAvailable,
   initStorage,
@@ -206,15 +207,22 @@ export function usePhotoSessionOPFS() {
     setLoading(true);
     setError(null);
     try {
-      // Turning-point mode (rally) allows up to 10 photos per set in
-      // both orientations — the landscape grid auto-expands from 3×3 to
-      // 5×2 once a set hits 10 (feedback 2026-05-03). Track mode keeps
-      // the layout-driven 9/10 cap because its grid is hard-pinned to
-      // 3×3 (landscape) / 2×5 (portrait).
-      const gridCapacity = session.mode === 'turningpoint'
-        ? 10
-        : ((session as any).layoutMode === 'portrait' ? 10 : 9);
+      // Single-source-of-truth helper (feedback 2026-05-03 follow-up):
+      // turning-point mode caps at 10 in both orientations, track mode
+      // follows the layout. Centralised in `getGridCapacity` so the four
+      // sites in this file plus `useCompetitionSystem.getSessionStats`
+      // can't drift.
+      const gridCapacity = getGridCapacity(session as any);
       const current = session.sets[setKey].photos.length;
+      // State-corruption guard (round-5 follow-up): a layout switch with
+      // photos already loaded (or a session imported from an older build
+      // with a higher cap) can leave `current > gridCapacity`. Without
+      // this branch the user saw "Can only add -3 more photos", which
+      // hid the underlying corruption. Surface it explicitly so support
+      // can identify the case and so the user has a clear next step.
+      if (current > gridCapacity) {
+        throw new Error(`This set already has ${current} photos but the cap is now ${gridCapacity}. Please reload the competition or remove photos before adding more.`);
+      }
       if (current + files.length > gridCapacity) throw new Error(`Can only add ${gridCapacity - current} more photos to this set`);
 
       const photosDir = handlesRef.current.photosDir;
@@ -400,9 +408,7 @@ export function usePhotoSessionOPFS() {
 
   const reorderPhotos = useCallback(async (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => {
     if (!session) return;
-    const gridCapacity = session.mode === 'turningpoint'
-      ? 10
-      : (((session as any).layoutMode === 'portrait') ? 10 : 9);
+    const gridCapacity = getGridCapacity(session as any);
     if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= gridCapacity || toIndex >= gridCapacity) return;
     const current = [...session.sets[setKey].photos];
     const slots: (ApiPhoto | null)[] = Array(gridCapacity).fill(null);
@@ -489,9 +495,7 @@ export function usePhotoSessionOPFS() {
 
   const getSessionStats = useCallback(() => {
     if (!session) return { set1Photos: 0, set2Photos: 0, totalPhotos: 0, set1Available: 9, set2Available: 9, isComplete: false };
-    const gridCapacity = session.mode === 'turningpoint'
-      ? 10
-      : (((session as any).layoutMode === 'portrait') ? 10 : 9);
+    const gridCapacity = getGridCapacity(session as any);
     const set1Count = session.sets.set1.photos.length;
     const set2Count = session.sets.set2.photos.length;
     return {
@@ -515,7 +519,8 @@ export function usePhotoSessionOPFS() {
       if (!session) return;
       // Rally turning-point: 10 per set, 20 total, regardless of orientation
       // (feedback 2026-05-03 — landscape grid auto-expands to 5×2 at 10).
-      const gridCapacity = 10;
+      // Sourced from the central helper so a future cap bump propagates.
+      const gridCapacity = TURNING_POINT_PER_SET;
       const maxTotal = gridCapacity * 2;
       const set1Count = session.sets.set1.photos.length;
       const set2Count = session.sets.set2.photos.length;

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -206,7 +206,14 @@ export function usePhotoSessionOPFS() {
     setLoading(true);
     setError(null);
     try {
-      const gridCapacity = (session as any).layoutMode === 'portrait' ? 10 : 9;
+      // Turning-point mode (rally) allows up to 10 photos per set in
+      // both orientations — the landscape grid auto-expands from 3×3 to
+      // 5×2 once a set hits 10 (feedback 2026-05-03). Track mode keeps
+      // the layout-driven 9/10 cap because its grid is hard-pinned to
+      // 3×3 (landscape) / 2×5 (portrait).
+      const gridCapacity = session.mode === 'turningpoint'
+        ? 10
+        : ((session as any).layoutMode === 'portrait' ? 10 : 9);
       const current = session.sets[setKey].photos.length;
       if (current + files.length > gridCapacity) throw new Error(`Can only add ${gridCapacity - current} more photos to this set`);
 
@@ -393,7 +400,9 @@ export function usePhotoSessionOPFS() {
 
   const reorderPhotos = useCallback(async (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => {
     if (!session) return;
-    const gridCapacity = ((session as any).layoutMode === 'portrait') ? 10 : 9;
+    const gridCapacity = session.mode === 'turningpoint'
+      ? 10
+      : (((session as any).layoutMode === 'portrait') ? 10 : 9);
     if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0 || fromIndex >= gridCapacity || toIndex >= gridCapacity) return;
     const current = [...session.sets[setKey].photos];
     const slots: (ApiPhoto | null)[] = Array(gridCapacity).fill(null);
@@ -480,7 +489,9 @@ export function usePhotoSessionOPFS() {
 
   const getSessionStats = useCallback(() => {
     if (!session) return { set1Photos: 0, set2Photos: 0, totalPhotos: 0, set1Available: 9, set2Available: 9, isComplete: false };
-    const gridCapacity = ((session as any).layoutMode === 'portrait') ? 10 : 9;
+    const gridCapacity = session.mode === 'turningpoint'
+      ? 10
+      : (((session as any).layoutMode === 'portrait') ? 10 : 9);
     const set1Count = session.sets.set1.photos.length;
     const set2Count = session.sets.set2.photos.length;
     return {
@@ -502,7 +513,9 @@ export function usePhotoSessionOPFS() {
     addPhotosToSet,
     addPhotosToTurningPoint: async (files: File[]) => {
       if (!session) return;
-      const gridCapacity = ((session as any).layoutMode === 'portrait') ? 10 : 9;
+      // Rally turning-point: 10 per set, 20 total, regardless of orientation
+      // (feedback 2026-05-03 — landscape grid auto-expands to 5×2 at 10).
+      const gridCapacity = 10;
       const maxTotal = gridCapacity * 2;
       const set1Count = session.sets.set1.photos.length;
       const set2Count = session.sets.set2.photos.length;

--- a/frontend/photo-helper/src/utils/distributeRallyDrop.ts
+++ b/frontend/photo-helper/src/utils/distributeRallyDrop.ts
@@ -13,22 +13,29 @@ export type DistributeRallyDropResult =
 
 /**
  * Distribute a Rally turning-point initial drop across set1 (first
- * `gridCapacity` files) and set2 (the remainder). Without this the 9-slot
- * set1 grid silently swallowed files 10+ on a 10–18-photo drop (feedback
- * 2026-04-23).
+ * `RALLY_TURNING_PER_SET` files) and set2 (the remainder). Without this
+ * the set1 grid silently swallowed files 10+ on a 10+ photo drop
+ * (feedback 2026-04-23).
  *
- * Grid capacity is 9 in landscape and 10 in portrait — `maxTotal` is
- * therefore 18 or 20. Exceeding the total returns `ok: false` so the
- * caller can surface a user-facing error instead of dropping files.
+ * Rally rules allow up to 18 turning points (= SP + 18 TP + FP = 20
+ * photos) per feedback 2026-05-03. Per-set capacity is therefore 10 in
+ * BOTH orientations — the landscape grid auto-expands from 3×3 to 5×2
+ * once a set reaches 10 photos. `layoutMode` is retained on the input
+ * type for backward compatibility but no longer affects capacity.
+ *
+ * Exceeding the total returns `ok: false` so the caller can surface a
+ * user-facing error instead of dropping files.
  */
+export const RALLY_TURNING_PER_SET = 10;
+export const RALLY_TURNING_MAX_TOTAL = RALLY_TURNING_PER_SET * 2;
+
 export function distributeRallyDrop({
   files,
-  layoutMode,
   set1Count,
   set2Count,
 }: DistributeRallyDropInput): DistributeRallyDropResult {
-  const gridCapacity = layoutMode === 'portrait' ? 10 : 9;
-  const maxTotal = gridCapacity * 2;
+  const gridCapacity = RALLY_TURNING_PER_SET;
+  const maxTotal = RALLY_TURNING_MAX_TOTAL;
   const totalIfAdded = set1Count + set2Count + files.length;
   if (totalIfAdded > maxTotal) {
     return { ok: false, reason: 'overflow', maxTotal, totalIfAdded };

--- a/frontend/photo-helper/src/utils/getGridCapacity.ts
+++ b/frontend/photo-helper/src/utils/getGridCapacity.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-set grid capacity for a photo session. Centralised to keep the four
+ * call sites in `usePhotoSessionOPFS` (`addPhotosToSet`, `reorderPhotos`,
+ * `getSessionStats`, `addPhotosToTurningPoint`) and the one in
+ * `useCompetitionSystem.getSessionStats` in lockstep — round-5 follow-up
+ * to feedback 2026-05-03: the duplicated branches were a known drift
+ * hazard (a future cap bump would have to be applied identically in five
+ * places, and the diff history shows we already missed sites once).
+ *
+ * Rules:
+ *   • Turning-point mode (rally + precision-hidden-set2): always 10 per set
+ *     in BOTH orientations. Landscape grid auto-expands from 3×3 to 5×2 at
+ *     10 photos; portrait stays 2×5 = 10.
+ *   • Track mode: layout-driven (10 portrait, 9 landscape). The grid is
+ *     hard-pinned in track mode so the cap follows orientation.
+ *
+ * Accepts `unknown` so callers don't have to import the photo-session type
+ * just to thread it through. Defensive: missing `mode` defaults to track
+ * (the legacy default) and missing `layoutMode` defaults to landscape.
+ */
+export type SessionShape = {
+  mode?: 'track' | 'turningpoint';
+  layoutMode?: 'portrait' | 'landscape' | string;
+};
+
+export const TURNING_POINT_PER_SET = 10;
+export const TRACK_LANDSCAPE_PER_SET = 9;
+export const TRACK_PORTRAIT_PER_SET = 10;
+
+export function getGridCapacity(session: SessionShape | null | undefined): number {
+  if (!session) return TRACK_LANDSCAPE_PER_SET;
+  if (session.mode === 'turningpoint') return TURNING_POINT_PER_SET;
+  return session.layoutMode === 'portrait' ? TRACK_PORTRAIT_PER_SET : TRACK_LANDSCAPE_PER_SET;
+}

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { Document, Page, Image, pdf, StyleSheet } from '@react-pdf/renderer';
 import type { ApiPhotoSet } from '../types/api';
 import { dirnameOf } from '@airq/shared-storage';
+import { calculateLandscapeGrid } from './pdfLandscapeGrid';
 
 // Polyfill Buffer for @react-pdf/renderer
 import { Buffer } from 'buffer';
@@ -255,47 +256,11 @@ export const generatePDF = async (
         textY: pageHeight / 2 // Center vertically
       };
     } else {
-      // A4 Landscape: 842 x 595 points
-      const pageWidth = 842;
-      const pageHeight = 595;
-      const margin = 0; // edge-less layout
-      const headerHeight = Math.max(0, landscapeHeaderHeight || 0);
-      const gap = 2.83; // 1mm in points
-
-      // Rally turning-point with 10 photos uses 5×2 instead of 3×3
-      // (feedback 2026-05-03). Trigger purely on `pageCount` so the
-      // selection is per-page — set1 with 10 photos can render 5×2 even
-      // when set2 has 7 (renders 3×3 with 2 empty trailing tiles).
-      const cols = pageCount >= 10 ? 5 : 3;
-      const rows = pageCount >= 10 ? 2 : 3;
-
-      // Available space for photos
-      const availableWidth = pageWidth - (2 * margin);
-      const availableHeight = pageHeight - headerTopPad - headerHeight; // start directly under header
-
-      // Calculate photo size for the chosen grid
-      const photoWidth = Math.floor((availableWidth - ((cols - 1) * gap)) / cols);
-      const photoHeight = Math.floor((availableHeight - ((rows - 1) * gap)) / rows);
-
-      // Ensure aspect ratio
-      const correctedHeight = Math.min(photoHeight, photoWidth / aspectRatio);
-      const correctedWidth = correctedHeight * aspectRatio;
-
-      // Center the grid
-      const totalWidth = (correctedWidth * cols) + (gap * (cols - 1));
-      const startX = margin + (availableWidth - totalWidth) / 2;
-      const startY = headerTopPad + headerHeight;
-
-      return {
-        photoWidth: correctedWidth,
-        photoHeight: correctedHeight,
-        startX,
-        startY,
-        gap,
-        cols,
-        rows,
-        headerY: headerTopPad // place text ~1mm from the top edge
-      };
+      // Landscape grid math (3×3 vs 5×2 selection) lives in
+      // `pdfLandscapeGrid.ts` so the boundary at pageCount >= 10 and the
+      // centering arithmetic are unit-testable. Returns the same shape
+      // the previous inline block produced.
+      return calculateLandscapeGrid(aspectRatio, landscapeHeaderHeight, headerTopPad, pageCount);
     }
   };
 

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -211,7 +211,11 @@ export const generatePDF = async (
   // portraitGutterWidth: measured width of rotated header gutter (portrait mode)
   // landscapeHeaderHeight: measured header height (landscape mode)
   // headerTopPad: top padding for header text (default ~1mm)
-  const calculateLayout = (portraitGutterWidth: number = 15, landscapeHeaderHeight: number = 25, headerTopPad: number = 2.83) => {
+  // pageCount: number of photos on this specific page — used to pick a
+  // landscape grid (3×3 vs 5×2) for rally turning-point pages with 10
+  // photos (feedback 2026-05-03). Defaults to a value that selects the
+  // legacy 3×3 to keep all existing call-sites unchanged.
+  const calculateLayout = (portraitGutterWidth: number = 15, landscapeHeaderHeight: number = 25, headerTopPad: number = 2.83, pageCount: number = 0) => {
     if (layoutMode === 'portrait') {
       // A4 Portrait: 595 x 842 points
       const pageWidth = 595;
@@ -251,38 +255,45 @@ export const generatePDF = async (
         textY: pageHeight / 2 // Center vertically
       };
     } else {
-      // A4 Landscape: 842 x 595 points  
+      // A4 Landscape: 842 x 595 points
       const pageWidth = 842;
       const pageHeight = 595;
       const margin = 0; // edge-less layout
       const headerHeight = Math.max(0, landscapeHeaderHeight || 0);
       const gap = 2.83; // 1mm in points
-      
+
+      // Rally turning-point with 10 photos uses 5×2 instead of 3×3
+      // (feedback 2026-05-03). Trigger purely on `pageCount` so the
+      // selection is per-page — set1 with 10 photos can render 5×2 even
+      // when set2 has 7 (renders 3×3 with 2 empty trailing tiles).
+      const cols = pageCount >= 10 ? 5 : 3;
+      const rows = pageCount >= 10 ? 2 : 3;
+
       // Available space for photos
       const availableWidth = pageWidth - (2 * margin);
       const availableHeight = pageHeight - headerTopPad - headerHeight; // start directly under header
-      
-      // Calculate photo size for 3x3 grid
-      const photoWidth = Math.floor((availableWidth - (2 * gap)) / 3);
-      const photoHeight = Math.floor((availableHeight - (2 * gap)) / 3);
-      
+
+      // Calculate photo size for the chosen grid
+      const photoWidth = Math.floor((availableWidth - ((cols - 1) * gap)) / cols);
+      const photoHeight = Math.floor((availableHeight - ((rows - 1) * gap)) / rows);
+
       // Ensure aspect ratio
       const correctedHeight = Math.min(photoHeight, photoWidth / aspectRatio);
       const correctedWidth = correctedHeight * aspectRatio;
-      
+
       // Center the grid
-      const totalWidth = (correctedWidth * 3) + (gap * 2);
+      const totalWidth = (correctedWidth * cols) + (gap * (cols - 1));
       const startX = margin + (availableWidth - totalWidth) / 2;
       const startY = headerTopPad + headerHeight;
-      
+
       return {
         photoWidth: correctedWidth,
         photoHeight: correctedHeight,
         startX,
         startY,
         gap,
-        cols: 3,
-        rows: 3,
+        cols,
+        rows,
         headerY: headerTopPad // place text ~1mm from the top edge
       };
     }
@@ -299,7 +310,10 @@ export const generatePDF = async (
   // Create a single page (compute a local layout per page)
   const createPage = (photoSet: ApiPhotoSet, setTitle: string, pageKey: string) => {
     const elements: any[] = [];
-    let localLayout = calculateLayout(15);
+    // Per-page count drives the landscape rally turning-point grid
+    // selection (3×3 vs 5×2). Other modes ignore it.
+    const pageCount = photoSet.photos.length;
+    let localLayout = calculateLayout(15, 25, 2.83, pageCount);
     
     // Add header/title
     const modeLabel = headerLabelFor(pageKey === 'set2' ? 'set2' : 'set1');
@@ -324,7 +338,7 @@ export const generatePDF = async (
       if (headerImage) {
         // Recalculate layout with actual measured gutter width
         const measuredGutter = Math.max(15, Math.ceil(headerImage.width));
-        localLayout = calculateLayout(measuredGutter);
+        localLayout = calculateLayout(measuredGutter, 25, 2.83, pageCount);
         // Calculate positioning to center along left edge
         const pageHeight = 842; // A4 portrait height
         const topPosition = (pageHeight - headerImage.height) / 2; // Center vertically
@@ -368,7 +382,7 @@ export const generatePDF = async (
         mergedTitleImage?.height || 0,
         promotionalImage?.height || 0
       );
-      localLayout = calculateLayout(15, measuredHeaderHeight, headerTopPad);
+      localLayout = calculateLayout(15, measuredHeaderHeight, headerTopPad, pageCount);
 
       if (mergedTitleImage) {
         // Place merged title at top-left

--- a/frontend/photo-helper/src/utils/pdfLandscapeGrid.ts
+++ b/frontend/photo-helper/src/utils/pdfLandscapeGrid.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure A4-landscape grid math for the rally turning-point PDF page
+ * (feedback 2026-05-03 — landscape page renders 5×2 when a set has >= 10
+ * photos, else 3×3). Extracted from `pdfGenerator.calculateLayout` so the
+ * grid-selection boundary, the per-photo dimensions, and the centering
+ * arithmetic can be unit-tested without spawning the React PDF renderer.
+ *
+ * Inputs:
+ *   • aspectRatio — photo aspect ratio (width / height)
+ *   • landscapeHeaderHeight — measured height of the rasterised header
+ *   • headerTopPad — top padding for header text in points (~1mm)
+ *   • pageCount — number of photos on this specific page; >= 10 triggers
+ *     5×2, else 3×3. Per-page so set1=10 / set2=7 mixes (5×2 page + 3×3
+ *     page with 2 trailing empties) work as expected.
+ */
+export const A4_LANDSCAPE_WIDTH_PT = 842;
+export const A4_LANDSCAPE_HEIGHT_PT = 595;
+export const PDF_LANDSCAPE_GAP_PT = 2.83; // ~1mm in points
+export const PDF_LANDSCAPE_MARGIN_PT = 0; // edge-less layout
+
+export type LandscapeGridLayout = {
+  photoWidth: number;
+  photoHeight: number;
+  startX: number;
+  startY: number;
+  gap: number;
+  cols: number;
+  rows: number;
+  headerY: number;
+};
+
+export function calculateLandscapeGrid(
+  aspectRatio: number,
+  landscapeHeaderHeight: number,
+  headerTopPad: number,
+  pageCount: number,
+): LandscapeGridLayout {
+  const pageWidth = A4_LANDSCAPE_WIDTH_PT;
+  const pageHeight = A4_LANDSCAPE_HEIGHT_PT;
+  const margin = PDF_LANDSCAPE_MARGIN_PT;
+  const headerHeight = Math.max(0, landscapeHeaderHeight || 0);
+  const gap = PDF_LANDSCAPE_GAP_PT;
+
+  // pageCount >= 10 → 5×2; else 3×3. Trigger purely on `pageCount` so the
+  // selection is per-page — set1 with 10 photos can render 5×2 even when
+  // set2 has 7 (renders 3×3 with 2 empty trailing tiles).
+  const cols = pageCount >= 10 ? 5 : 3;
+  const rows = pageCount >= 10 ? 2 : 3;
+
+  const availableWidth = pageWidth - 2 * margin;
+  const availableHeight = pageHeight - headerTopPad - headerHeight;
+
+  const photoWidth = Math.floor((availableWidth - (cols - 1) * gap) / cols);
+  const photoHeight = Math.floor((availableHeight - (rows - 1) * gap) / rows);
+
+  // Match aspect ratio: shrink the larger dimension to satisfy width/height.
+  const correctedHeight = Math.min(photoHeight, photoWidth / aspectRatio);
+  const correctedWidth = correctedHeight * aspectRatio;
+
+  const totalWidth = correctedWidth * cols + gap * (cols - 1);
+  const startX = margin + (availableWidth - totalWidth) / 2;
+  const startY = headerTopPad + headerHeight;
+
+  return {
+    photoWidth: correctedWidth,
+    photoHeight: correctedHeight,
+    startX,
+    startY,
+    gap,
+    cols,
+    rows,
+    headerY: headerTopPad,
+  };
+}

--- a/frontend/photo-helper/src/utils/rallyGridFor.ts
+++ b/frontend/photo-helper/src/utils/rallyGridFor.ts
@@ -1,0 +1,29 @@
+/**
+ * Per-set grid layout (slots and column count) for rally turning-point
+ * mode (feedback 2026-05-03). Extracted from `TurningPointLayout.tsx` so
+ * the boundary logic at `count === 10` is unit-testable — a regression
+ * where `count >= 10` becomes `count > 10` would resurrect the exact
+ * silent-photo-loss bug that motivated the round-4 fix (the 10th photo
+ * silently hidden behind a 3×3 grid).
+ *
+ * Rules:
+ *   • Precision discipline: returns `undefined` so the caller falls back
+ *     to its own layoutConfig (precision uses a single 9-slot 3×3).
+ *   • Portrait orientation: always 10 slots in 2 columns (2×5).
+ *   • Landscape, count >= 10: 10 slots in 5 columns (5×2). The cap is
+ *     reached only on a fully-filled rally page.
+ *   • Landscape, count < 10: 9 slots in 3 columns (3×3). Below 10,
+ *     keeping 3×3 avoids rendering 4 trailing empties on a partial drop.
+ */
+export type RallyGridLayout = { slots: number; columns: number };
+export type RallyLayoutMode = 'portrait' | 'landscape';
+
+export function rallyGridFor(
+  count: number,
+  layoutMode: RallyLayoutMode,
+  isPrecision: boolean,
+): RallyGridLayout | undefined {
+  if (isPrecision) return undefined;
+  if (layoutMode === 'portrait') return { slots: 10, columns: 2 };
+  return count >= 10 ? { slots: 10, columns: 5 } : { slots: 9, columns: 3 };
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       electron-builder:
         specifier: ^26.0.12
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      vitest:
+        specifier: 4.1.4
+        version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2)(vite@7.3.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
 
   map-corridors:
     dependencies:


### PR DESCRIPTION
## Summary
- **Rally turning-point cap 18 → 20**: per-set capacity is now 10 in both orientations; landscape grid auto-expands from 3×3 to 5×2 once a set reaches 10 photos. PDF generator follows the same rule per page.
- **Scenic-leg attribution fixed**: photos in dashed/scenic-leg gaps (TP6→TP7 and TP13→TP14 in the test KML) now project onto the actual leg they're on and report the **preceding** TP — not the geographically-closer next TP. Leg-projection fallback explicitly skips legs that already have a corridor (`coveredLegs` set built from `extractEndName` parser).
- **Launcher folder picker**: "+ Nová soutěž" now uses a 560 px centered card. Press Enter / click OK → folder dialog auto-opens with a competition-named title; cancel → button flips to "Vytvořit bez složky" so there are no stuck states. Selector bar widened 720 → 1040 px so Rally toggle and "Smazat" never clip.
- **Defensive new-competition scrub**: `competition-create` `rmSync`-recursively wipes any pre-existing `competitions/{newId}` directory before initializing, guaranteeing a brand-new competition starts with zero photos / corridors / markers.
- **Folder anchor revert**: removed the post-save promote-to-workingDir behaviour. Working dir is now anchored to either the launcher's folder pick OR the imported KML's folder, never to whatever directory the user last navigated to in a save dialog.

Version bumped to **2.8.2**. Portable .exe built and verified locally.

## Test plan
- [x] `pnpm -r test`: 175/175 map-corridors + 157/157 photo-helper (was 169 + 6 new regression tests for scenic-leg attribution and the `extractEndName` parser; rewrote `distributeRallyDrop` tests for the new 20-cap)
- [x] `pnpm exec tsc --noEmit` clean in both packages
- [x] `pnpm run build:apps` clean
- [x] `pnpm run package` produces signed portable `dist/photo-helper-v2.8.2.exe`
- [ ] Manual: drop 13+ TP photos in rally landscape — set1 fills to 10, grid flips to 5×2; set2 picks up the rest; PDF renders 5×2 in landscape
- [ ] Manual: load `RED (1).kml` in map-corridors, drop a marker between TP8 and TP9 (scenic leg) — answer sheet shows "Od TP: TP 8" not "TP 9"; same for TP6→TP7 and TP13→TP14
- [ ] Manual: "+ Nová soutěž" → type name → Enter → folder dialog auto-opens with title `Vyberte složku pro soutěž "<name>"`. Pick → competition created with workingDir set; cancel → button reads "Vytvořit bez složky", second click commits without folder
- [ ] Manual: create new competition → open Foto editor and Map corridors → both empty (zero photos, no KML, no corridors, no markers)
- [ ] Manual: load KML in map-corridors, save export to a *different* folder; reopen save dialog — defaults back to KML folder, not the saved folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)