### PR TITLE
fix(photo-helper): default precision discipline to numeric photo labels

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -66,6 +66,37 @@ surface in code review / release notes.
 - **Effort:** ~1 hour (usually painless, occasionally rule renames bite).
 - **Tags:** `deps`, `hygiene`
 
+### 6. Provider-level tests for `LabelingContext` lock behavior
+- **Why:** PR #56 added defense-in-depth to `LabelingProvider` — `setLabeling`
+  silently no-ops when `isPrecision && labeling.id !== 'numbers'` and the
+  context exposes `isLocked: true` for precision. The new test file only
+  covers the pure helper (`resolveDefaultLabeling`); the guard and `isLocked`
+  are untested. A future refactor that re-enables letter switching for
+  precision would pass CI even though the rules-compliance contract regresses.
+- **Action:** Add a small RTL test that mounts `LabelingProvider` with
+  `window.location.search = '?discipline=precision'` (jsdom), asserts
+  `isLocked === true`, calls `setLabeling(LETTERS_OPTION)`, and asserts
+  `currentLabeling.id === 'numbers'` (i.e. the call was ignored). Pairs well
+  with item #4 if the dev-deps are added there first.
+- **Effort:** ~30 min once `@testing-library/react` is in (see #4).
+- **Tags:** `tests`, `regression`, `precision`
+
+### 7. ID-based lookup in `LABELING_OPTIONS` constants
+- **Why:** PR #56 introduced
+  `const LETTERS_OPTION = LABELING_OPTIONS[0]` and
+  `NUMBERS_OPTION = LABELING_OPTIONS[1]` in
+  `frontend/photo-helper/src/contexts/LabelingContext.tsx`. If anyone reorders
+  `LABELING_OPTIONS` (e.g. for UI grouping or to default-show numbers first),
+  the named constants silently flip and `resolveDefaultLabeling` returns the
+  wrong option for both disciplines. Coupled with the missing Provider tests
+  (#6), this would not be caught by CI.
+- **Action:** Replace the index lookups with id-based lookups —
+  `LABELING_OPTIONS.find(o => o.id === 'letters')!` and `… 'numbers'` — or
+  add a module-scope `console.assert(LABELING_OPTIONS[0].id === 'letters')`
+  guard. The find approach is preferred (reorder-safe by construction).
+- **Effort:** ~5 min.
+- **Tags:** `correctness`, `hygiene`
+
 ---
 
 ## Deferred (documented but not scheduled)

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -486,13 +486,16 @@ function AppApi() {
                   <AspectRatioSelector compact />
                 </Box>
 
-                {/* Photo Labels */}
-                <Box sx={{ display: 'flex', alignItems: { xs: 'center', xl: 'center' }, gap: 0.5, flexDirection: { xs: 'column', xl: 'row' } }}>
-                  <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500, fontSize: '0.8rem', display: 'block', textAlign: { xs: 'center', xl: 'inherit' }, width: { xs: '100%', xl: 'auto' }, whiteSpace: { xl: 'nowrap' } }}>
-                    {t('photoLabels.title')}
-                  </Typography>
-                  <LabelingSelector compact />
-                </Box>
+                {/* Photo Labels — hidden for precision: rules mandate
+                    numbers, so there is no valid alternative to expose. */}
+                {!isPrecision && (
+                  <Box sx={{ display: 'flex', alignItems: { xs: 'center', xl: 'center' }, gap: 0.5, flexDirection: { xs: 'column', xl: 'row' } }}>
+                    <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500, fontSize: '0.8rem', display: 'block', textAlign: { xs: 'center', xl: 'inherit' }, width: { xs: '100%', xl: 'auto' }, whiteSpace: { xl: 'nowrap' } }}>
+                      {t('photoLabels.title')}
+                    </Typography>
+                    <LabelingSelector compact />
+                  </Box>
+                )}
 
                 {/* Shuffle Photos - Only show in track mode */}
                 {session?.mode === 'track' && (

--- a/frontend/photo-helper/src/__tests__/resolveDefaultLabeling.test.ts
+++ b/frontend/photo-helper/src/__tests__/resolveDefaultLabeling.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveDefaultLabeling } from '../contexts/LabelingContext';
+
+// Precision flying competition rules require photos to be labeled with
+// numbers, not letters. The default labeling MUST follow the discipline
+// emitted by the desktop launcher; a silent letter default for precision
+// produces a non-compliant printed photo set.
+
+describe('resolveDefaultLabeling', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // parseDiscipline logs invalid values; silence to keep test output clean.
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('defaults to numbers for precision discipline', () => {
+    expect(resolveDefaultLabeling('?discipline=precision').id).toBe('numbers');
+  });
+
+  it('defaults to letters for rally discipline', () => {
+    expect(resolveDefaultLabeling('?discipline=rally').id).toBe('letters');
+  });
+
+  it('defaults to letters when discipline is absent (web / legacy)', () => {
+    expect(resolveDefaultLabeling('').id).toBe('letters');
+  });
+
+  it('defaults to letters when an unknown discipline is supplied', () => {
+    // Falls through parseDiscipline allowlist → rally → letters.
+    expect(resolveDefaultLabeling('?discipline=Precision').id).toBe('letters');
+  });
+
+  it('extracts discipline among multiple URL params', () => {
+    expect(
+      resolveDefaultLabeling('?competitionId=abc&discipline=precision').id,
+    ).toBe('numbers');
+  });
+});

--- a/frontend/photo-helper/src/contexts/LabelingContext.tsx
+++ b/frontend/photo-helper/src/contexts/LabelingContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { parseDiscipline } from '../utils/parseDiscipline';
 
 export interface LabelingOption {
   id: 'letters' | 'numbers';
@@ -13,24 +14,50 @@ export const LABELING_OPTIONS: LabelingOption[] = [
     description: 'A, B, C...'
   },
   {
-    id: 'numbers', 
+    id: 'numbers',
     name: 'Numbers',
     description: '1, 2, 3...'
   }
 ];
 
+const LETTERS_OPTION = LABELING_OPTIONS[0];
+const NUMBERS_OPTION = LABELING_OPTIONS[1];
+
+/**
+ * Precision flying competition rules require photos to be labeled with
+ * NUMBERS (1, 2, 3...) — letters are not permitted. Rally has no such
+ * constraint and keeps the historical letter default. Pure function so
+ * the URL → default mapping is unit-tested without React.
+ */
+export const resolveDefaultLabeling = (search: string): LabelingOption => {
+  return parseDiscipline(search) === 'precision' ? NUMBERS_OPTION : LETTERS_OPTION;
+};
+
 interface LabelingContextType {
   currentLabeling: LabelingOption;
   setLabeling: (labeling: LabelingOption) => void;
   generateLabel: (index: number, offset?: number) => string;
+  /**
+   * True when the discipline mandates a fixed labeling scheme
+   * (precision → numbers). Consumers should hide the labeling
+   * selector to prevent the user from picking an invalid option
+   * for the active competition.
+   */
+  isLocked: boolean;
 }
 
 const LabelingContext = createContext<LabelingContextType | null>(null);
 
 export const LabelingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [currentLabeling, setCurrentLabeling] = useState<LabelingOption>(LABELING_OPTIONS[0]); // Default to letters
+  const search = typeof window !== 'undefined' ? window.location.search : '';
+  const isPrecision = parseDiscipline(search) === 'precision';
+  const [currentLabeling, setCurrentLabeling] = useState<LabelingOption>(() => resolveDefaultLabeling(search));
 
   const setLabeling = (labeling: LabelingOption) => {
+    // Precision discipline locks labeling to numbers — silently ignore any
+    // attempt to switch it (defense in depth: the selector is hidden in
+    // the UI, but a stale render or test could still call this).
+    if (isPrecision && labeling.id !== 'numbers') return;
     setCurrentLabeling(labeling);
   };
 
@@ -48,7 +75,8 @@ export const LabelingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     <LabelingContext.Provider value={{
       currentLabeling,
       setLabeling,
-      generateLabel
+      generateLabel,
+      isLocked: isPrecision
     }}>
       {children}
     </LabelingContext.Provider>


### PR DESCRIPTION
## Summary
- Precision flying competition rules require photos to be labeled with **numbers** (1, 2, 3...), not letters. The default seeded every session with letters regardless of discipline, forcing the user to switch manually — and producing non-compliant PDFs whenever the switch was missed or didn't stick (turning-point mode, page reload).
- `LabelingProvider` now reads `?discipline=` on init and seeds state via a new pure `resolveDefaultLabeling` helper: `precision → numbers`, otherwise `letters` (rally / web / legacy). Context exposes `isLocked`; `setLabeling` silently no-ops on precision for any non-numbers option (defense in depth).
- `AppApi` hides the `LabelingSelector` block when `isPrecision` so the UI cannot expose a non-compliant choice — also eliminates the user-reported "I clicked numbers but it stayed as letters" symptom for precision sessions.

## Test plan
- [x] `pnpm test` in `frontend/photo-helper` — 191/191 passing (15 files), including 5 new `resolveDefaultLabeling` cases
- [x] `tsc --noEmit` clean
- [ ] Manual: open precision competition from desktop launcher → photo grid renders numeric labels (1., 2., 3., …) with no labels-selector visible in the toolbar
- [ ] Manual: open rally competition → letters default, selector visible, switching to numbers still works
- [ ] Manual: precision turning-point mode still shows SP / TP1…TPx / FP labels (unaffected by labeling context)
- [ ] Manual: PDF export from a precision track session prints numbers, not letters

🤖 Generated with [Claude Code](https://claude.com/claude-code)