### PR TITLE
fix(desktop): include lib/ in electron-builder files allowlist #patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.8.3] - 2026-05-06
+
+### Fixed
+- **Desktop launcher:** include `lib/**/*` in the electron-builder `files`
+  allowlist so `lib/pathValidation.js` (extracted from `main.js` in the
+  silently-tagged `desktop-v2.8.1` / `desktop-v2.8.2`) ships inside the
+  asar. Without it, the .exe crashes on launch with
+  `Error: Cannot find module './lib/pathValidation'`. The 2.8.1 / 2.8.2
+  desktop tags were never released to GitHub, so end users were
+  unaffected — 2.8.3 is the first release that would have actually
+  shipped the latent bug.
+
 ## [2.8.0] - 2026-04-25
 
 This release consolidates the silently-tagged `desktop-v2.7.0`–`v2.7.5`

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",
@@ -24,6 +24,7 @@
     "files": [
       "main.js",
       "preload.js",
+      "lib/**/*",
       "renderer/**/*"
     ],
     "extraResources": [


### PR DESCRIPTION
## Summary
- Add `lib/**/*` to the electron-builder `files` allowlist in `frontend/desktop/package.json`.
- Bump desktop version 2.8.2 → 2.8.3 (one above the latest `desktop-v` tag).
- Add CHANGELOG entry under `[2.8.3]`.

## Why
Commit `428502e` (silently-tagged `desktop-v2.8.1` / `v2.8.2`) extracted path-validation helpers into `lib/pathValidation.js` and changed `main.js` to `require('./lib/pathValidation')`, but didn't update the `files` allowlist. As a result, the asar shipped without `lib/`, and any local build from `main` past that commit crashes on launch:

```
Error: Cannot find module './lib/pathValidation'
Require stack: …\resources\…\main.js
```

The last public GitHub release is `desktop-v2.8.0` (pathValidation still inlined) — so end users were unaffected. The `v2.8.1` / `v2.8.2` tags exist but were never released. `v2.8.3` is the first release that would have actually shipped the latent bug, hence catching it here before tag-on-merge fires.

## Test plan
- [x] Local rebuild via `bash frontend/desktop/build.sh portable` after the fix
- [x] `node -e "require('@electron/asar').listPackage('dist/win-unpacked/resources/app.asar')"` confirms `\lib\pathValidation.js` is in the asar
- [x] `dist/photo-helper-v2.8.3.exe` launches without the require error
- [ ] CI build runs against the new tag (`desktop-v2.8.3`) and produces a working portable .exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)