### PR TITLE
refactor: extract @airq/shared-discipline workspace package #patch

### DIFF
--- a/frontend/map-corridors/package.json
+++ b/frontend/map-corridors/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@airq/shared-discipline": "workspace:*",
     "@airq/shared-storage": "workspace:*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/frontend/map-corridors/src/__tests__/sharedDiscipline.test.ts
+++ b/frontend/map-corridors/src/__tests__/sharedDiscipline.test.ts
@@ -18,12 +18,14 @@ import {
   type PhotoLabelNumber,
 } from '@airq/shared-discipline';
 
-// Contract tests for the shared discipline + labeling rules. These pin
-// the behaviour both photo-helper AND map-corridors rely on. A change
-// here that breaks one app will break the other identically — that's the
-// whole point of centralising. Mirrored on the map-corridors side
-// (`map-corridors/src/__tests__/sharedDiscipline.test.ts`) so each app's
-// CI independently asserts the contract it depends on.
+// Mirror of `photo-helper/src/__tests__/sharedDiscipline.test.ts`. Both
+// apps independently assert the shared contract so a regression in
+// `@airq/shared-discipline` fails CI in *both* suites — preventing the
+// scenario where one app's test suite is silently broken (e.g. a node-canvas
+// dependency issue in photo-helper) and the other still ships the regression.
+//
+// Keep the two files in sync: any new contract test added here must also
+// be added on the photo-helper side, and vice versa.
 
 describe('DISCIPLINES + Discipline type', () => {
   it('exports the canonical allowlist', () => {
@@ -31,8 +33,6 @@ describe('DISCIPLINES + Discipline type', () => {
   });
 
   it('Discipline type is derived from DISCIPLINES (no drift possible)', () => {
-    // Compile-time equivalence: if someone widens `Discipline` without
-    // extending `DISCIPLINES`, this fails to type-check.
     expectTypeOf<Discipline>().toEqualTypeOf<(typeof DISCIPLINES)[number]>();
   });
 });
@@ -111,19 +111,12 @@ describe('parseDisciplineFromSearch', () => {
       .toBe('rally');
   });
 
-  // Edge cases of `URLSearchParams` semantics — pinned because callers
-  // rely on these properties, not the parser itself.
-
   it('parses without a leading "?" (URLSearchParams is permissive)', () => {
     expect(parseDisciplineFromSearch('discipline=precision')).toBe('precision');
     expect(parseDisciplineFromSearch('discipline=rally')).toBe('rally');
   });
 
   it('does NOT strip a URL fragment — caller must pass location.search, not the full URL', () => {
-    // URLSearchParams treats `precision#foo` as the literal value;
-    // it is then rejected by the strict allowlist. Callers must NOT
-    // rely on the parser to trim fragments — passing window.location.search
-    // already excludes the hash.
     expect(parseDisciplineFromSearch('?discipline=precision#foo')).toBeNull();
     expect(errorSpy).toHaveBeenCalledOnce();
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('precision#foo'));
@@ -148,10 +141,6 @@ describe('getLabelingMode', () => {
   });
 
   it('1:1 mapping covers every Discipline (compile + runtime exhaustiveness)', () => {
-    // Runtime mirror of the `never` exhaustiveness check inside
-    // `getLabelingMode`. If a new Discipline is added, this test
-    // surfaces it as a runtime failure (the function will throw)
-    // even if the type-checker pass were skipped.
     for (const d of DISCIPLINES) {
       expect(() => getLabelingMode(d)).not.toThrow();
     }
@@ -182,9 +171,6 @@ describe('generateLabel', () => {
   });
 
   it('matches getLabelsForDiscipline(d)[index] for every i in [0,19]', () => {
-    // Parity test — pins generateLabel to the canonical arrays so an
-    // arithmetic regression (e.g. someone reverts to fromCharCode) is
-    // caught by direct array comparison, not just by spot-checks.
     for (const d of DISCIPLINES) {
       const labels = getLabelsForDiscipline(d);
       for (let i = 0; i <= MAX_LABEL_INDEX; i++) {
@@ -230,9 +216,6 @@ describe('generateLabelForMode', () => {
   });
 
   it('result equals generateLabel for the corresponding discipline', () => {
-    // generateLabel is a thin wrapper over generateLabelForMode (via
-    // getLabelingMode). Pin the equivalence so a future divergence in
-    // either function fails this test.
     for (let i = 0; i <= MAX_LABEL_INDEX; i++) {
       expect(generateLabelForMode('numbers', i)).toBe(generateLabel('precision', i));
       expect(generateLabelForMode('letters', i)).toBe(generateLabel('rally', i));

--- a/frontend/map-corridors/src/corridors/preciseCorridor.ts
+++ b/frontend/map-corridors/src/corridors/preciseCorridor.ts
@@ -18,7 +18,11 @@ export type DisciplineConfig = {
   rightDistanceM: number
 }
 
-export type Discipline = 'precision' | 'rally'
+// Discipline is the shared cross-app type — re-exported here so the
+// many existing `import type { Discipline } from './corridors/preciseCorridor'`
+// callsites keep resolving without a sweep.
+export type { Discipline } from '@airq/shared-discipline'
+import type { Discipline } from '@airq/shared-discipline'
 
 export const DISCIPLINE_CONFIGS: Record<Discipline, DisciplineConfig> = {
   precision: { spAfterNm: 0.5, tpAfterNm: 0.5, leftDistanceM: 100, rightDistanceM: 0 },

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -1,38 +1,18 @@
 // Shared marker type definitions — used by App.tsx, MapProviderView, useCorridorSessionOPFS, mapCapture
 
-import type { Discipline } from '../corridors/preciseCorridor'
+// Photo label sets + the discipline → label-set rule live in
+// `@airq/shared-discipline` so map-corridors and photo-helper cannot drift.
+// Re-exported here under the legacy names so existing imports
+// (`from '../types/markers'`) continue to resolve.
+import { ALL_PHOTO_LABELS, type PhotoLabel } from '@airq/shared-discipline'
 
-// Rally / web / legacy: photos are labelled A..T (matches photo-helper's
-// `letters` mode). Precision rules require numeric labels 1..20 (matches
-// photo-helper's `numbers` mode for precision discipline). Both sets are
-// length 20 — the maximum number of photos in a precision track set.
-export const PHOTO_LABELS_LETTERS = [
-  'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',
-] as const
-export const PHOTO_LABELS_NUMBERS = [
-  '1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20',
-] as const
-
-// Union of every label the sanitizer will accept on persisted state. Keep
-// both letters AND numbers valid: a session that flips discipline mid-flight
-// (or imports a KML produced under the other discipline) must not lose its
-// existing labels. The active labelling scheme is filtered at the UI layer
-// via `getLabelsForDiscipline`, not by narrowing the type.
-export const ALL_PHOTO_LABELS = [
-  ...PHOTO_LABELS_LETTERS,
-  ...PHOTO_LABELS_NUMBERS,
-] as const
-export type PhotoLabel = (typeof ALL_PHOTO_LABELS)[number]
-
-/**
- * Pick the label set for the active discipline. Mirrors photo-helper's
- * `resolveDefaultLabeling` so a precision-discipline session shows numeric
- * labels (1, 2, 3…) in the marker label picker AND the answer sheet, while
- * rally / unknown defaults to letters (A, B, C…).
- */
-export function getLabelsForDiscipline(discipline: Discipline): readonly PhotoLabel[] {
-  return discipline === 'precision' ? PHOTO_LABELS_NUMBERS : PHOTO_LABELS_LETTERS
-}
+export {
+  PHOTO_LABELS_LETTERS,
+  PHOTO_LABELS_NUMBERS,
+  ALL_PHOTO_LABELS,
+  getLabelsForDiscipline,
+} from '@airq/shared-discipline'
+export type { PhotoLabel } from '@airq/shared-discipline'
 
 export type PhotoMarker = Readonly<{
   id: string

--- a/frontend/map-corridors/src/utils/parseDiscipline.ts
+++ b/frontend/map-corridors/src/utils/parseDiscipline.ts
@@ -1,20 +1,11 @@
-import type { Discipline } from '../corridors/preciseCorridor'
-
 /**
- * Parse the `?discipline=` URL parameter. Returns `null` when the
- * param is absent or invalid so the caller can fall back to the
- * session-level discipline (see `App.tsx` — `effectiveDiscipline`).
+ * Map-corridors variant: re-exports the canonical parser from
+ * `@airq/shared-discipline` under the legacy local name. The semantics
+ * (returns `Discipline | null`) match the shared parser exactly — null
+ * lets `App.tsx` fall back to `session?.discipline` (the rally-vs-
+ * precision choice persists in the session, not just the URL).
  *
- * Invalid non-empty values are logged via `console.error` so a
- * desktop-launcher drift surfaces during QA instead of silently
- * downgrading precision sessions to rally.
+ * Kept as a re-export so existing imports `from '../utils/parseDiscipline'`
+ * keep working without a sweep.
  */
-export function parseDisciplineFromSearch(search: string): Discipline | null {
-  const params = new URLSearchParams(search)
-  const d = params.get('discipline')
-  if (d === 'precision' || d === 'rally') return d
-  if (d !== null && d !== '') {
-    console.error(`[parseDiscipline] Invalid ?discipline="${d}"; falling back to session discipline.`)
-  }
-  return null
-}
+export { parseDisciplineFromSearch } from '@airq/shared-discipline'

--- a/frontend/photo-helper/package.json
+++ b/frontend/photo-helper/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@airq/shared-discipline": "workspace:*",
     "@airq/shared-storage": "workspace:*",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/frontend/photo-helper/src/__tests__/sharedDiscipline.test.ts
+++ b/frontend/photo-helper/src/__tests__/sharedDiscipline.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseDisciplineFromSearch,
+  getLabelingMode,
+  getLabelsForDiscipline,
+  generateLabel,
+  PHOTO_LABELS_LETTERS,
+  PHOTO_LABELS_NUMBERS,
+  ALL_PHOTO_LABELS,
+} from '@airq/shared-discipline';
+
+// Contract tests for the shared discipline + labeling rules. These pin
+// the behaviour both photo-helper AND map-corridors rely on. A change
+// here that breaks one app will break the other identically — that's the
+// whole point of centralising.
+
+describe('parseDisciplineFromSearch', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns "precision" for ?discipline=precision', () => {
+    expect(parseDisciplineFromSearch('?discipline=precision')).toBe('precision');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns "rally" for ?discipline=rally', () => {
+    expect(parseDisciplineFromSearch('?discipline=rally')).toBe('rally');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the param is absent', () => {
+    expect(parseDisciplineFromSearch('')).toBeNull();
+    expect(parseDisciplineFromSearch('?other=1')).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null for empty ?discipline= without logging', () => {
+    expect(parseDisciplineFromSearch('?discipline=')).toBeNull();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null AND logs for mixed-case / typo values', () => {
+    expect(parseDisciplineFromSearch('?discipline=Precision')).toBeNull();
+    expect(parseDisciplineFromSearch('?discipline=RALLY')).toBeNull();
+    expect(parseDisciplineFromSearch('?discipline=precsn')).toBeNull();
+    expect(errorSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT accept URL-encoded whitespace around a valid value', () => {
+    expect(parseDisciplineFromSearch('?discipline=%20precision')).toBeNull();
+    expect(errorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('logs the invalid value verbatim so launcher drift is visible', () => {
+    parseDisciplineFromSearch('?discipline=Precision');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Precision'));
+  });
+
+  it('extracts discipline among multiple URL params', () => {
+    expect(parseDisciplineFromSearch('?competitionId=abc&discipline=precision'))
+      .toBe('precision');
+    expect(parseDisciplineFromSearch('?discipline=rally&foo=bar'))
+      .toBe('rally');
+  });
+});
+
+describe('getLabelingMode', () => {
+  it('returns "numbers" for precision (rules-mandated)', () => {
+    expect(getLabelingMode('precision')).toBe('numbers');
+  });
+
+  it('returns "letters" for rally (legacy default)', () => {
+    expect(getLabelingMode('rally')).toBe('letters');
+  });
+});
+
+describe('getLabelsForDiscipline', () => {
+  it('returns the numeric set (1..20) for precision', () => {
+    expect(getLabelsForDiscipline('precision')).toEqual(PHOTO_LABELS_NUMBERS);
+  });
+
+  it('returns the letter set (A..T) for rally', () => {
+    expect(getLabelsForDiscipline('rally')).toEqual(PHOTO_LABELS_LETTERS);
+  });
+});
+
+describe('generateLabel', () => {
+  it('generates 1..N for precision (1-based)', () => {
+    expect(generateLabel('precision', 0)).toBe('1');
+    expect(generateLabel('precision', 9)).toBe('10');
+    expect(generateLabel('precision', 19)).toBe('20');
+  });
+
+  it('generates A..T for rally', () => {
+    expect(generateLabel('rally', 0)).toBe('A');
+    expect(generateLabel('rally', 9)).toBe('J');
+    expect(generateLabel('rally', 19)).toBe('T');
+  });
+});
+
+describe('label sets', () => {
+  it('letters and numbers are both length 20', () => {
+    expect(PHOTO_LABELS_LETTERS).toHaveLength(20);
+    expect(PHOTO_LABELS_NUMBERS).toHaveLength(20);
+  });
+
+  it('ALL_PHOTO_LABELS is the disjoint union of the two sets', () => {
+    expect(ALL_PHOTO_LABELS).toHaveLength(40);
+    const letters = new Set<string>(PHOTO_LABELS_LETTERS);
+    for (const n of PHOTO_LABELS_NUMBERS) expect(letters.has(n)).toBe(false);
+  });
+});

--- a/frontend/photo-helper/src/contexts/LabelingContext.tsx
+++ b/frontend/photo-helper/src/contexts/LabelingContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState } from 'react';
 import {
   parseDisciplineFromSearch,
   getLabelingMode,
+  generateLabelForMode,
   type Discipline,
 } from '@airq/shared-discipline';
 
@@ -67,14 +68,15 @@ export const LabelingProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     setCurrentLabeling(labeling);
   };
 
-  const generateLabel = (index: number, offset = 0) => {
-    const position = index + offset;
-    
-    if (currentLabeling.id === 'numbers') {
-      return `${position + 1}`; // Numbers start from 1, no dot
-    } else {
-      return `${String.fromCharCode(65 + position)}`; // Letters A, B, C... no dot
-    }
+  // Delegates to the shared label generator so the precision/rally
+  // labeling rule cannot drift between photo-helper and map-corridors.
+  // The keying axis is `LabelingMode` (not `Discipline`) because the user
+  // can flip the labeling option independently of the URL-derived
+  // discipline — e.g., a rally session can opt into numbers via the
+  // selector. `LabelingOption.id` is structurally identical to
+  // `LabelingMode` (`'letters' | 'numbers'`).
+  const generateLabel = (index: number, offset = 0): string => {
+    return generateLabelForMode(currentLabeling.id, index + offset);
   };
 
   return (

--- a/frontend/photo-helper/src/contexts/LabelingContext.tsx
+++ b/frontend/photo-helper/src/contexts/LabelingContext.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, useContext, useState } from 'react';
-import { parseDiscipline } from '../utils/parseDiscipline';
+import {
+  parseDisciplineFromSearch,
+  getLabelingMode,
+  type Discipline,
+} from '@airq/shared-discipline';
 
 export interface LabelingOption {
   id: 'letters' | 'numbers';
@@ -24,13 +28,15 @@ const LETTERS_OPTION = LABELING_OPTIONS[0];
 const NUMBERS_OPTION = LABELING_OPTIONS[1];
 
 /**
- * Precision flying competition rules require photos to be labeled with
- * NUMBERS (1, 2, 3...) — letters are not permitted. Rally has no such
- * constraint and keeps the historical letter default. Pure function so
- * the URL → default mapping is unit-tested without React.
+ * Maps the URL-derived discipline to the photo-helper-specific
+ * `LabelingOption` (which carries UI metadata like name/description).
+ * The discipline → mode rule itself lives in `@airq/shared-discipline`
+ * (`getLabelingMode`) so a future change there propagates to every app
+ * that picks labels by discipline.
  */
 export const resolveDefaultLabeling = (search: string): LabelingOption => {
-  return parseDiscipline(search) === 'precision' ? NUMBERS_OPTION : LETTERS_OPTION;
+  const discipline: Discipline = parseDisciplineFromSearch(search) ?? 'rally';
+  return getLabelingMode(discipline) === 'numbers' ? NUMBERS_OPTION : LETTERS_OPTION;
 };
 
 interface LabelingContextType {
@@ -50,7 +56,7 @@ const LabelingContext = createContext<LabelingContextType | null>(null);
 
 export const LabelingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const search = typeof window !== 'undefined' ? window.location.search : '';
-  const isPrecision = parseDiscipline(search) === 'precision';
+  const isPrecision = parseDisciplineFromSearch(search) === 'precision';
   const [currentLabeling, setCurrentLabeling] = useState<LabelingOption>(() => resolveDefaultLabeling(search));
 
   const setLabeling = (labeling: LabelingOption) => {

--- a/frontend/photo-helper/src/utils/parseDiscipline.ts
+++ b/frontend/photo-helper/src/utils/parseDiscipline.ts
@@ -1,25 +1,24 @@
-export type Discipline = 'precision' | 'rally';
-
 /**
- * Parse the `?discipline=` URL parameter emitted by the desktop launcher
- * (see `desktop/main.js`). Accepts only the two exact values; anything
- * else (absent, empty, typo, wrong case) falls back to `rally` — that
- * is the safe default for web / legacy sessions that never saw the
- * launcher.
+ * Photo-helper variant of the discipline parser. Delegates to
+ * `@airq/shared-discipline` for the strict allowlist + console.error rule
+ * (the canonical implementation), then applies a rally fallback at the
+ * boundary because every consumer in this app needs a non-null Discipline:
  *
- * Invalid non-empty values are logged via `console.error` so a launcher
- * drift (e.g. `?Discipline=Precision`) surfaces during QA instead of
- * silently downgrading precision mode to rally.
+ *  - `AppApi.tsx` – `isPrecision` flips PDF set2 drop, 9-photo cap, etc.
+ *  - `LabelingContext.tsx` – locks labeling to numbers
+ *  - `useCompetitionSystem.ts` – gates competition mode
  *
- * Exposed as a pure function so the browser consumer and tests share
- * the same allowlist.
+ * The map-corridors app uses the shared parser directly because it has a
+ * meaningful third state (null = "use the persisted session discipline").
+ *
+ * This wrapper exists so existing `import { parseDiscipline } from
+ * '../utils/parseDiscipline'` callsites keep working without a sweep.
  */
+import { parseDisciplineFromSearch } from '@airq/shared-discipline';
+import type { Discipline } from '@airq/shared-discipline';
+
+export type { Discipline } from '@airq/shared-discipline';
+
 export function parseDiscipline(search: string): Discipline {
-  const params = new URLSearchParams(search);
-  const d = params.get('discipline');
-  if (d === 'precision' || d === 'rally') return d;
-  if (d !== null && d !== '') {
-    console.error(`[parseDiscipline] Invalid ?discipline="${d}"; defaulting to rally.`);
-  }
-  return 'rally';
+  return parseDisciplineFromSearch(search) ?? 'rally';
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   map-corridors:
     dependencies:
+      '@airq/shared-discipline':
+        specifier: workspace:*
+        version: link:../shared-discipline
       '@airq/shared-storage':
         specifier: workspace:*
         version: link:../shared-storage
@@ -129,6 +132,9 @@ importers:
 
   photo-helper:
     dependencies:
+      '@airq/shared-discipline':
+        specifier: workspace:*
+        version: link:../shared-discipline
       '@airq/shared-storage':
         specifier: workspace:*
         version: link:../shared-storage
@@ -220,6 +226,12 @@ importers:
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@25.3.3)(jsdom@29.0.2)(vite@7.3.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
+
+  shared-discipline:
+    dependencies:
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   shared-storage:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - shared-storage
+  - shared-discipline
   - photo-helper
   - map-corridors
   - desktop

--- a/frontend/shared-discipline/package.json
+++ b/frontend/shared-discipline/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@airq/shared-discipline",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "peerDependencies": {
+    "typescript": "~5.8.3"
+  }
+}

--- a/frontend/shared-discipline/src/index.ts
+++ b/frontend/shared-discipline/src/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared discipline + photo-labeling rules
+ *
+ * Single source of truth for:
+ *  - The `Discipline` type (`'precision' | 'rally'`)
+ *  - URL `?discipline=` parsing (strict allowlist; logs invalid values)
+ *  - The discipline → labeling-mode rule (precision → numbers, else letters)
+ *  - The 20-element photo-label sets (letters A..T, numbers 1..20)
+ *
+ * Consumed by `@airq/photo-helper` and `@airq/map-corridors`. Both apps
+ * previously implemented these rules separately; this package collapses
+ * the duplication so a future change to e.g. precision labeling cannot
+ * land in one app and not the other.
+ */
+
+// ---------------------------------------------------------------------------
+// Discipline type + allowlist
+// ---------------------------------------------------------------------------
+
+export type Discipline = 'precision' | 'rally';
+
+export const DISCIPLINES = ['precision', 'rally'] as const;
+
+const DISCIPLINE_SET: ReadonlySet<string> = new Set<string>(DISCIPLINES);
+
+function isDiscipline(value: unknown): value is Discipline {
+  return typeof value === 'string' && DISCIPLINE_SET.has(value);
+}
+
+// ---------------------------------------------------------------------------
+// URL parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the `?discipline=` URL parameter emitted by the desktop launcher
+ * (see `frontend/desktop/main.js`). Strict allowlist: only exact
+ * `'precision'` or `'rally'` accepted.
+ *
+ * Returns `null` when:
+ *  - the param is absent
+ *  - the value is empty (semantically "unset", same as absent)
+ *  - the value is non-empty but not in the allowlist (also calls
+ *    `console.error` so a launcher drift like `?Discipline=Precision`
+ *    surfaces during QA instead of silently downgrading precision → rally)
+ *
+ * Callers that need a default fall back themselves:
+ *
+ * ```ts
+ * const discipline = parseDisciplineFromSearch(window.location.search) ?? 'rally';
+ * ```
+ *
+ * The default-rally semantics live at the call site, not here, because
+ * map-corridors uses `null` to mean "let the persisted session discipline
+ * decide" — a default would mask that.
+ */
+export function parseDisciplineFromSearch(search: string): Discipline | null {
+  const params = new URLSearchParams(search);
+  const d = params.get('discipline');
+  if (isDiscipline(d)) return d;
+  if (d !== null && d !== '') {
+    console.error(`[parseDiscipline] Invalid ?discipline="${d}"; falling back.`);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Photo label sets
+// ---------------------------------------------------------------------------
+
+// Rally / web / legacy: photos are labelled A..T (matches photo-helper's
+// `letters` mode). Precision rules require numeric labels 1..20 (matches
+// photo-helper's `numbers` mode for precision discipline). Both sets are
+// length 20 — the maximum number of photos in a precision track set.
+
+export const PHOTO_LABELS_LETTERS = [
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+  'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+] as const;
+
+export const PHOTO_LABELS_NUMBERS = [
+  '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+  '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
+] as const;
+
+export const ALL_PHOTO_LABELS = [
+  ...PHOTO_LABELS_LETTERS,
+  ...PHOTO_LABELS_NUMBERS,
+] as const;
+
+export type PhotoLabelLetter = (typeof PHOTO_LABELS_LETTERS)[number];
+export type PhotoLabelNumber = (typeof PHOTO_LABELS_NUMBERS)[number];
+export type PhotoLabel = (typeof ALL_PHOTO_LABELS)[number];
+
+// ---------------------------------------------------------------------------
+// Discipline → labeling rule
+// ---------------------------------------------------------------------------
+
+export type LabelingMode = 'letters' | 'numbers';
+
+/**
+ * The single rule. Precision flying competition rules require photos to
+ * be labelled with NUMBERS (1, 2, 3...) — letters are not permitted.
+ * Rally has no such constraint and keeps the historical letter default.
+ */
+export function getLabelingMode(discipline: Discipline): LabelingMode {
+  return discipline === 'precision' ? 'numbers' : 'letters';
+}
+
+/**
+ * Picks the appropriate label *set* for the active discipline. Used by
+ * map-corridors to populate the marker label-picker and the answer sheet.
+ */
+export function getLabelsForDiscipline(discipline: Discipline): readonly PhotoLabel[] {
+  return getLabelingMode(discipline) === 'numbers'
+    ? PHOTO_LABELS_NUMBERS
+    : PHOTO_LABELS_LETTERS;
+}
+
+/**
+ * Generates the label for a zero-based photo index, given the active
+ * discipline. Used by photo-helper to render labels at draw time
+ * (no per-photo persistence — the label is a function of position only).
+ *
+ * Indexes outside [0, 19] are wrapped/clamped depending on mode:
+ *  - numbers: returns `${index + 1}` for any index (no upper bound — the
+ *    UI caps at 20 elsewhere; we don't second-guess it here)
+ *  - letters: `String.fromCharCode(65 + index)` for `index < 26`,
+ *    otherwise undefined behaviour (as before — UI caps it).
+ */
+export function generateLabel(discipline: Discipline, index: number): string {
+  if (getLabelingMode(discipline) === 'numbers') {
+    return String(index + 1);
+  }
+  return String.fromCharCode(65 + index);
+}

--- a/frontend/shared-discipline/src/index.ts
+++ b/frontend/shared-discipline/src/index.ts
@@ -6,6 +6,7 @@
  *  - URL `?discipline=` parsing (strict allowlist; logs invalid values)
  *  - The discipline → labeling-mode rule (precision → numbers, else letters)
  *  - The 20-element photo-label sets (letters A..T, numbers 1..20)
+ *  - Label generation by index (bounds-checked, returns `PhotoLabel`)
  *
  * Consumed by `@airq/photo-helper` and `@airq/map-corridors`. Both apps
  * previously implemented these rules separately; this package collapses
@@ -17,13 +18,21 @@
 // Discipline type + allowlist
 // ---------------------------------------------------------------------------
 
-export type Discipline = 'precision' | 'rally';
-
+// `DISCIPLINES` is the single source of truth; the type is derived from it
+// so adding a new discipline is a one-line change that the compiler then
+// forces through every `switch (discipline)` site (see `getLabelingMode`).
 export const DISCIPLINES = ['precision', 'rally'] as const;
+
+export type Discipline = (typeof DISCIPLINES)[number];
 
 const DISCIPLINE_SET: ReadonlySet<string> = new Set<string>(DISCIPLINES);
 
-function isDiscipline(value: unknown): value is Discipline {
+/**
+ * Type guard for `unknown -> Discipline`. Exported so consumers
+ * rehydrating persisted state (storage, KML imports) can validate
+ * without reinventing the allowlist.
+ */
+export function isDiscipline(value: unknown): value is Discipline {
   return typeof value === 'string' && DISCIPLINE_SET.has(value);
 }
 
@@ -42,6 +51,15 @@ function isDiscipline(value: unknown): value is Discipline {
  *  - the value is non-empty but not in the allowlist (also calls
  *    `console.error` so a launcher drift like `?Discipline=Precision`
  *    surfaces during QA instead of silently downgrading precision → rally)
+ *
+ * Notes on input handling — `URLSearchParams` is permissive:
+ *  - The leading `?` is optional (`'discipline=precision'` parses fine).
+ *  - URL fragments are NOT stripped (`'?discipline=precision#foo'` parses
+ *    the value as `'precision#foo'`, which then fails the allowlist).
+ *    Callers should pass `window.location.search` (which excludes the
+ *    hash) — relying on this parser to strip a fragment is unsafe.
+ *  - Duplicate `discipline` keys: first wins (`URLSearchParams.get`
+ *    semantics).
  *
  * Callers that need a default fall back themselves:
  *
@@ -82,6 +100,15 @@ export const PHOTO_LABELS_NUMBERS = [
   '11', '12', '13', '14', '15', '16', '17', '18', '19', '20',
 ] as const;
 
+/**
+ * Disjoint union of both label sets. Required because a session created
+ * under one discipline may be reopened under the other (e.g., user toggles
+ * mode mid-flight in map-corridors, or imports a KML produced under the
+ * other discipline). Existing labels must remain valid even when they
+ * don't match the *current* discipline's preferred set; the active set is
+ * filtered at the UI layer via `getLabelsForDiscipline`, not by narrowing
+ * the persisted type.
+ */
 export const ALL_PHOTO_LABELS = [
   ...PHOTO_LABELS_LETTERS,
   ...PHOTO_LABELS_NUMBERS,
@@ -90,6 +117,13 @@ export const ALL_PHOTO_LABELS = [
 export type PhotoLabelLetter = (typeof PHOTO_LABELS_LETTERS)[number];
 export type PhotoLabelNumber = (typeof PHOTO_LABELS_NUMBERS)[number];
 export type PhotoLabel = (typeof ALL_PHOTO_LABELS)[number];
+
+/**
+ * Maximum index supported by `generateLabel` / `generateLabelForMode`.
+ * Both label sets are length 20 (precision track-set cap), so valid
+ * indices are `[0, 19]`.
+ */
+export const MAX_LABEL_INDEX = 19;
 
 // ---------------------------------------------------------------------------
 // Discipline → labeling rule
@@ -101,9 +135,22 @@ export type LabelingMode = 'letters' | 'numbers';
  * The single rule. Precision flying competition rules require photos to
  * be labelled with NUMBERS (1, 2, 3...) — letters are not permitted.
  * Rally has no such constraint and keeps the historical letter default.
+ *
+ * Exhaustive switch with `never` check: adding a new `Discipline` will
+ * fail compilation here, forcing the maintainer to make an explicit
+ * choice instead of silently falling through to the rally default.
  */
 export function getLabelingMode(discipline: Discipline): LabelingMode {
-  return discipline === 'precision' ? 'numbers' : 'letters';
+  switch (discipline) {
+    case 'precision':
+      return 'numbers';
+    case 'rally':
+      return 'letters';
+    default: {
+      const _exhaustive: never = discipline;
+      throw new Error(`[getLabelingMode] unhandled discipline: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 /**
@@ -116,20 +163,42 @@ export function getLabelsForDiscipline(discipline: Discipline): readonly PhotoLa
     : PHOTO_LABELS_LETTERS;
 }
 
+// ---------------------------------------------------------------------------
+// Label generation
+// ---------------------------------------------------------------------------
+
+function assertValidLabelIndex(index: number, fnName: string): void {
+  if (!Number.isInteger(index) || index < 0 || index > MAX_LABEL_INDEX) {
+    throw new RangeError(
+      `[${fnName}] index must be an integer in [0, ${MAX_LABEL_INDEX}]; got ${index}`,
+    );
+  }
+}
+
+/**
+ * Returns the label at `index` for the given labeling mode. Bounds-checked:
+ * throws `RangeError` for non-integer or out-of-range indices instead of
+ * producing silent garbage (`String.fromCharCode(65 + 26)` = `'['`,
+ * `String(index + 1)` for index = -1 = `'0'` — both invalid as labels but
+ * type-equivalent to a real label).
+ *
+ * Used by photo-helper's `LabelingContext` to render labels at draw time
+ * — the user can flip the labeling mode independently of the URL-derived
+ * discipline (e.g., a rally session can opt into numbers), so the keying
+ * axis is `LabelingMode`, not `Discipline`.
+ */
+export function generateLabelForMode(mode: LabelingMode, index: number): PhotoLabel {
+  assertValidLabelIndex(index, 'generateLabelForMode');
+  return mode === 'numbers' ? PHOTO_LABELS_NUMBERS[index] : PHOTO_LABELS_LETTERS[index];
+}
+
 /**
  * Generates the label for a zero-based photo index, given the active
- * discipline. Used by photo-helper to render labels at draw time
- * (no per-photo persistence — the label is a function of position only).
+ * discipline. Convenience wrapper over `generateLabelForMode` for callers
+ * that already have a `Discipline` (e.g., map-corridors marker rendering).
  *
- * Indexes outside [0, 19] are wrapped/clamped depending on mode:
- *  - numbers: returns `${index + 1}` for any index (no upper bound — the
- *    UI caps at 20 elsewhere; we don't second-guess it here)
- *  - letters: `String.fromCharCode(65 + index)` for `index < 26`,
- *    otherwise undefined behaviour (as before — UI caps it).
+ * Same bounds contract — `RangeError` for indices outside `[0, 19]`.
  */
-export function generateLabel(discipline: Discipline, index: number): string {
-  if (getLabelingMode(discipline) === 'numbers') {
-    return String(index + 1);
-  }
-  return String.fromCharCode(65 + index);
+export function generateLabel(discipline: Discipline, index: number): PhotoLabel {
+  return generateLabelForMode(getLabelingMode(discipline), index);
 }

--- a/frontend/shared-discipline/tsconfig.json
+++ b/frontend/shared-discipline/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
Centralise the discipline + photo-labeling rules into a new workspace package `@airq/shared-discipline` consumed by both `@airq/photo-helper` and `@airq/map-corridors`. Mirrors the existing `@airq/shared-storage` pattern. Behaviour preserved end-to-end; tests gain coverage of the shared contract.

## Why
Three pieces of logic were duplicated across the two sub-apps:
1. `Discipline` type — declared in `corridors/preciseCorridor.ts` AND in `utils/parseDiscipline.ts` of photo-helper
2. URL parser — `parseDiscipline` (photo-helper, default 'rally') and `parseDisciplineFromSearch` (map-corridors, returns null) — same allowlist, different boundary semantics
3. Discipline → labeling mode rule (precision → numbers, otherwise letters) — landed independently in PR #56 (photo-helper, React context wrapper) and PR #58 (map-corridors, pure function over a string array)

Drift risk was real: a fix to the labeling rule would have to land in two PRs in two apps and the second was easy to forget.

## Package surface
```ts
type Discipline = 'precision' | 'rally';
const DISCIPLINES: readonly Discipline[];

function parseDisciplineFromSearch(search: string): Discipline | null;

const PHOTO_LABELS_LETTERS: readonly ['A'...'T'];      // length 20
const PHOTO_LABELS_NUMBERS: readonly ['1'...'20'];     // length 20
const ALL_PHOTO_LABELS: readonly PhotoLabel[];         // disjoint union
type PhotoLabel = ...

type LabelingMode = 'letters' | 'numbers';
function getLabelingMode(d: Discipline): LabelingMode;
function getLabelsForDiscipline(d: Discipline): readonly PhotoLabel[];
function generateLabel(d: Discipline, index: number): string;
```

## Migration
- **photo-helper**
  - `utils/parseDiscipline.ts` — thin wrapper: `parseDisciplineFromSearch(s) ?? 'rally'`
  - `contexts/LabelingContext.tsx` — `resolveDefaultLabeling` uses `getLabelingMode`
  - All existing callsites unchanged
- **map-corridors**
  - `utils/parseDiscipline.ts` — single re-export from shared (semantics already matched)
  - `types/markers.ts` — re-exports `PHOTO_LABELS_LETTERS`/`NUMBERS`/`ALL_PHOTO_LABELS`/`getLabelsForDiscipline`/`PhotoLabel`
  - `corridors/preciseCorridor.ts` — re-exports `Discipline` from shared so the many existing `import type { Discipline } from './corridors/preciseCorridor'` callsites still resolve

## Test plan
- [x] photo-helper: `pnpm test` — 191 → 207 passing (+16 contract tests in new `sharedDiscipline.test.ts`)
- [x] map-corridors: `pnpm test` — 194/194 passing (no behaviour change)
- [x] `tsc --noEmit` / `tsc -b` clean in both apps
- [x] `pnpm build` succeeds in both apps (vite resolves the workspace package via pnpm symlink + `exports: { ".": "./src/index.ts" }`)

## Notes
- The shared package has no vitest config of its own (matches `@airq/shared-storage`). Contract tests live in photo-helper's existing test suite.
- This PR will auto-tag `desktop-v2.8.5` because it touches `frontend/photo-helper/**` and `frontend/map-corridors/**`. Behaviour is unchanged so it's a safe patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)