### PR TITLE
feat: marker sizes, KML slugified filenames, PDF format defaults #minor

### DIFF
--- a/frontend/desktop/__tests__/pathValidation.test.js
+++ b/frontend/desktop/__tests__/pathValidation.test.js
@@ -23,6 +23,7 @@ const {
   isSafeStartDir,
   validateUserDir,
   validateStoragePath,
+  coerceExportFileName,
 } = require('../lib/pathValidation');
 
 describe('sanitizeFileName', () => {
@@ -244,5 +245,97 @@ describe('validateStoragePath', () => {
     expect(validateStoragePath(stillInside, storageRoot)).toBe(
       path.resolve(path.join(storageRoot, 'leaf'))
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coerceExportFileName — renderer-supplied export filename → sanitised name
+// with forced extension. Shared by save-map-image / save-pdf / save-kml so
+// the empty-body fallback is enforced at one place (otherwise a renderer
+// supplying just `".png"` could produce a hidden dot-file on Linux/macOS).
+// ---------------------------------------------------------------------------
+describe('coerceExportFileName', () => {
+  const FALLBACK = 'fallback-2026-05-12.png';
+
+  it('passes a clean slug-based name through with the forced extension', () => {
+    expect(coerceExportFileName('map-print-plzen-2026.png', 'png', FALLBACK))
+      .toBe('map-print-plzen-2026.png');
+    expect(coerceExportFileName('photo-sheet-brno-2026.pdf', 'pdf', FALLBACK))
+      .toBe('photo-sheet-brno-2026.pdf');
+  });
+
+  it('forces the extension when the renderer omits it', () => {
+    expect(coerceExportFileName('map-print-plzen-2026', 'png', FALLBACK))
+      .toBe('map-print-plzen-2026.png');
+  });
+
+  it('strips a single trailing extension match (case-insensitive)', () => {
+    expect(coerceExportFileName('photo-sheet.PDF', 'pdf', FALLBACK))
+      .toBe('photo-sheet.pdf');
+    expect(coerceExportFileName('photo-sheet.Pdf', 'pdf', FALLBACK))
+      .toBe('photo-sheet.pdf');
+  });
+
+  it('does not double-extension when the existing ext already matches', () => {
+    // Regression guard against `name.png` → `name.png.png`.
+    expect(coerceExportFileName('corridors.kml', 'kml', FALLBACK))
+      .toBe('corridors.kml');
+  });
+
+  it('falls back when renderer name is missing / empty / whitespace', () => {
+    expect(coerceExportFileName(undefined, 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName(null, 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName('', 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName('   ', 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName('\t\n', 'png', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back when renderer name is the wrong type', () => {
+    expect(coerceExportFileName(42, 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName({}, 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName([], 'png', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back when sanitisation reduces the body to empty (the dot-file guard)', () => {
+    // Round-1 fix for the silent failure: ".png" alone has a truthy
+    // .trim(), passes the first guard, but after stripping the extension
+    // there's nothing left. Without this guard the call would return
+    // ".png" — a hidden dot-file on Linux/macOS, confusing on Windows.
+    expect(coerceExportFileName('.png', 'png', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName('.pdf', 'pdf', FALLBACK)).toBe(FALLBACK);
+    expect(coerceExportFileName('.kml', 'kml', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('falls back when sanitisation strips everything (only control chars)', () => {
+    // Control chars are stripped by sanitizeFileName → empty body → fallback.
+    expect(coerceExportFileName('.png', 'png', FALLBACK))
+      .toBe(FALLBACK);
+  });
+
+  it('does not perform path traversal even with adversarial input', () => {
+    // sanitizeFileName replaces separators with `-` first, so traversal
+    // attempts collapse to a flat filename. The result here is whatever
+    // sanitisation produces — what matters is that there are no path
+    // separators in the output.
+    const result = coerceExportFileName('../../etc/passwd.png', 'png', FALLBACK);
+    expect(result).not.toMatch(/[\\/]/);
+    expect(result.endsWith('.png')).toBe(true);
+  });
+
+  it('rejects a non-alphanumeric ext (defensive — no metachars in the regex)', () => {
+    // The regex is built from `ext`; locking down the chars allowed in
+    // `ext` itself prevents a future caller from accidentally smuggling
+    // a metacharacter that turns the body-strip into something broader.
+    expect(() => coerceExportFileName('name', '.png', FALLBACK)).toThrow();
+    expect(() => coerceExportFileName('name', 'png|exe', FALLBACK)).toThrow();
+    expect(() => coerceExportFileName('name', '', FALLBACK)).toThrow();
+  });
+
+  it('accepts mixed-case alphanumeric extensions', () => {
+    // The ext is normalised into the filename in lowercase by callers;
+    // helper itself just needs to allow alnum so existing uppercase
+    // extension matchers (e.g. `.PDF`) still work.
+    expect(coerceExportFileName('name', 'png', FALLBACK)).toBe('name.png');
+    expect(coerceExportFileName('name', 'jpeg', FALLBACK)).toBe('name.jpeg');
   });
 });

--- a/frontend/desktop/lib/pathValidation.js
+++ b/frontend/desktop/lib/pathValidation.js
@@ -70,10 +70,34 @@ function validateStoragePath(inputPath, rootPath) {
   return resolved;
 }
 
+// Sanitise a renderer-supplied export filename and force a known extension,
+// falling back to `fallback` when the renderer didn't supply a usable name
+// OR when sanitisation reduced the body to empty.
+//
+// The empty-body guard is the part that's easy to miss when copy-pasting
+// this pattern across IPC handlers: without it, a renderer that sends just
+// `".png"` would slip through trim() (truthy + non-whitespace), strip the
+// extension, and produce a hidden `.png` dot-file in ~/Documents on
+// Linux/macOS. Shared between save-map-image / save-pdf / save-kml so any
+// future extension-suffixed export handler gets the guard for free.
+function coerceExportFileName(rendererName, ext, fallback) {
+  if (typeof rendererName !== 'string' || !rendererName.trim()) return fallback;
+  // Build the strip-regex from the extension argument (lowercase a-z0-9 only,
+  // hardcoded here so a future caller can't slip a metacharacter into the
+  // pattern). Each call site uses a 3-letter ext.
+  if (!/^[a-z0-9]+$/i.test(ext)) {
+    throw new Error('coerceExportFileName: ext must be alphanumeric');
+  }
+  const extRe = new RegExp('\\.' + ext + '$', 'i');
+  const body = sanitizeFileName(rendererName).replace(extRe, '');
+  return body.length > 0 ? body + '.' + ext : fallback;
+}
+
 module.exports = {
   MAX_USER_PATH_LEN,
   sanitizeFileName,
   isSafeStartDir,
   validateUserDir,
   validateStoragePath,
+  coerceExportFileName,
 };

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -887,7 +887,7 @@ safeHandle('competition-delete', async (event, id) => {
 // Save map print image via native save dialog. Prefers the directory the
 // source KML was imported from (feedback 2026-04-23: every export dialog
 // should land in the user's race folder, not our internal storage).
-safeHandle('save-map-image', async (event, base64Data, defaultDir) => {
+safeHandle('save-map-image', async (event, base64Data, defaultDir, fileNameArg) => {
   if (typeof base64Data !== 'string' || base64Data.length === 0) {
     throw new Error('Invalid image data');
   }
@@ -899,7 +899,13 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir) => {
   // at an attacker-controlled SMB share (NTLMv2 hash leak on Windows).
   let startDir = validateUserDir(defaultDir);
   if (!startDir) startDir = app.getPath('documents');
-  const fileName = `map-print-${new Date().toISOString().slice(0, 10)}.png`;
+  // Renderer-supplied filename carries the slugified competition name when
+  // available (feedback 2026-05-10 — every export should be self-identifying).
+  // Sanitise + force the .png extension; fall back to the legacy date-only
+  // default when the renderer didn't (or couldn't) supply a name.
+  const fileName = (typeof fileNameArg === 'string' && fileNameArg.trim())
+    ? sanitizeFileName(fileNameArg).replace(/\.png$/i, '') + '.png'
+    : `map-print-${new Date().toISOString().slice(0, 10)}.png`;
   const { filePath } = await dialog.showSaveDialog(mainWindow, {
     defaultPath: path.join(startDir, fileName),
     filters: [{ name: 'PNG Images', extensions: ['png'] }]

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -318,6 +318,7 @@ const {
   isSafeStartDir,
   validateUserDir,
   validateStoragePath: validateStoragePathPure,
+  coerceExportFileName,
 } = require('./lib/pathValidation');
 
 // Convenience wrapper that pins the storage root to the photo-sessions
@@ -901,11 +902,14 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir, fileNameArg) 
   if (!startDir) startDir = app.getPath('documents');
   // Renderer-supplied filename carries the slugified competition name when
   // available (feedback 2026-05-10 — every export should be self-identifying).
-  // Sanitise + force the .png extension; fall back to the legacy date-only
-  // default when the renderer didn't (or couldn't) supply a name.
-  const fileName = (typeof fileNameArg === 'string' && fileNameArg.trim())
-    ? sanitizeFileName(fileNameArg).replace(/\.png$/i, '') + '.png'
-    : `map-print-${new Date().toISOString().slice(0, 10)}.png`;
+  // `coerceExportFileName` sanitises + forces the .png extension AND falls
+  // back when the post-sanitisation body is empty, so a renderer-supplied
+  // `".png"` can't slip through as a hidden dot-file.
+  const fileName = coerceExportFileName(
+    fileNameArg,
+    'png',
+    `map-print-${new Date().toISOString().slice(0, 10)}.png`,
+  );
   const { filePath } = await dialog.showSaveDialog(mainWindow, {
     defaultPath: path.join(startDir, fileName),
     filters: [{ name: 'PNG Images', extensions: ['png'] }]
@@ -1014,9 +1018,11 @@ safeHandle('save-pdf', async (event, base64Data, fileName, defaultDir) => {
   if (base64Data.length > 200 * 1024 * 1024) {
     throw new Error('PDF data too large');
   }
-  const safeName = (typeof fileName === 'string' && fileName.trim())
-    ? sanitizeFileName(fileName).replace(/\.pdf$/i, '') + '.pdf'
-    : `photo-sheet-${new Date().toISOString().slice(0, 10)}.pdf`;
+  const safeName = coerceExportFileName(
+    fileName,
+    'pdf',
+    `photo-sheet-${new Date().toISOString().slice(0, 10)}.pdf`,
+  );
   // Same UNC + length validation as save-kml / save-map-image.
   let startDir = validateUserDir(defaultDir);
   if (!startDir) startDir = app.getPath('documents');
@@ -1041,9 +1047,11 @@ safeHandle('save-kml', async (event, kmlText, fileName, defaultDir, competitionI
   if (kmlText.length > 50 * 1024 * 1024) {
     throw new Error('KML content too large');
   }
-  const safeName = (typeof fileName === 'string' && fileName.trim())
-    ? sanitizeFileName(fileName).replace(/\.kml$/i, '') + '.kml'
-    : `corridors_export_${new Date().toISOString().slice(0, 10)}.kml`;
+  const safeName = coerceExportFileName(
+    fileName,
+    'kml',
+    `corridors_export_${new Date().toISOString().slice(0, 10)}.kml`,
+  );
 
   // 1) User-supplied directory (the folder they imported the KML from) —
   //    `validateUserDir` enforces type, length cap, UNC/device rejection,

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.8.3",
+  "version": "2.8.13",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -50,8 +50,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   //   • { canceled: false, path: '<abs>' }                  — picked and validated
   pickDirectory: (defaultDir, title) => ipcRenderer.invoke('pick-directory', defaultDir, title),
 
-  // Save map print image via native save dialog
-  saveMapImage: (base64Data, defaultDir) => ipcRenderer.invoke('save-map-image', base64Data, defaultDir),
+  // Save map print image via native save dialog. `fileName` is optional —
+  // when provided the renderer's slug-based name (e.g. map-print-plzen-2026-…)
+  // is used; otherwise the main-process handler falls back to the legacy
+  // date-only default.
+  saveMapImage: (base64Data, defaultDir, fileName) => ipcRenderer.invoke('save-map-image', base64Data, defaultDir, fileName),
 
   // Save a photo-sheet PDF via native save dialog. defaultDir is the
   // competition's working folder (set when the user imports a KML).

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -15,6 +15,7 @@ import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
 import { rasterizeGroundMarkerSet } from './utils/groundMarkerPng'
 import { parseDisciplineFromSearch } from './utils/parseDiscipline'
+import { slugifyForFilename } from '@airq/shared-storage'
 import { MapStyleSelector } from './components/MapStyleSelector'
 import { GROUND_MARKER_ICON } from './components/GroundMarkerIcons'
 import { useMapStyle } from './hooks/useMapStyle'
@@ -554,7 +555,16 @@ function App() {
         alert(t('errors.someGroundMarkersFailed', { types: failed.join(', ') }))
       }
     }
-    const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, 'corridors_export', { groundMarkerIcons })
+    // Filename uses a slug of the competition name so a folder of exports
+    // stays sortable and self-identifying (e.g. corridors-plzen-2026.kml).
+    // The inner KML <Document><name> keeps the human-readable name so
+    // Google Earth's tree view shows "Plzeň 2026" rather than the slug.
+    // Both fall back to the legacy 'corridors_export' when no competition
+    // is loaded (web build, or no competitionId in the URL).
+    const slug = competitionName ? slugifyForFilename(competitionName) : ''
+    const kmlFilename = slug ? `corridors-${slug}.kml` : 'corridors_export.kml'
+    const kmlDocName = competitionName || 'corridors_export'
+    const mergedKml = appendFeaturesToKML(originalKmlText, combinedGeoJSON, kmlDocName, { groundMarkerIcons })
     // Prefer the Electron save dialog when running in the desktop app so the
     // dialog defaults to the folder the source KML was imported from
     // (feedback 2026-04-23 — users don't care about our internal storage).
@@ -570,21 +580,29 @@ function App() {
         // competition's working dir (see comment near top of this file).
         // The return value is intentionally unused here; null vs path
         // only matters for diagnostics.
-        await api.saveKml(mergedKml, 'corridors_export.kml', importedKmlDir || undefined, competitionId || undefined)
+        await api.saveKml(mergedKml, kmlFilename, importedKmlDir || undefined, competitionId || undefined)
       } catch (err) {
         console.error('electronAPI.saveKml failed:', err)
         alert(err instanceof Error ? err.message : t('errors.exportFailed'))
       }
       return
     }
-    downloadKML(mergedKml, 'corridors_export.kml')
-  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, importedKmlDir])
+    downloadKML(mergedKml, kmlFilename)
+  }, [markers, groundMarkers, loadOriginalKmlText, t, competitionId, competitionName, importedKmlDir])
 
   const handlePrintMap = useCallback(async () => {
     if (!mapRef.current) return
     try {
       const { blob, warnings } = await mapRef.current.captureForPrint()
       const electronAPI = window.electronAPI
+
+      // Filename mirrors the KML / PDF exports — slug of the competition
+      // name when available, falling back to the legacy date-only form.
+      const printSlug = competitionName ? slugifyForFilename(competitionName) : ''
+      const printDate = new Date().toISOString().slice(0, 10)
+      const printFileName = printSlug
+        ? `map-print-${printSlug}-${printDate}.png`
+        : `map-print-${printDate}.png`
 
       if (electronAPI?.saveMapImage) {
         // Electron: save via native dialog
@@ -598,13 +616,13 @@ function App() {
           reader.readAsDataURL(blob)
         })
         // Round-5: chosen folder is no longer auto-promoted to workingDir.
-        await electronAPI.saveMapImage(base64, importedKmlDir || undefined)
+        await electronAPI.saveMapImage(base64, importedKmlDir || undefined, printFileName)
       } else {
         // Browser: download via anchor
         const url = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = url
-        link.download = `map-print-${new Date().toISOString().slice(0, 10)}.png`
+        link.download = printFileName
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)
@@ -620,7 +638,7 @@ function App() {
       console.error('Map print failed:', err)
       alert(err instanceof Error ? err.message : t('errors.printFailed'))
     }
-  }, [t, importedKmlDir])
+  }, [t, importedKmlDir, competitionName])
 
   // Drag source for placing photo markers
   const onDragStartMarker = useCallback((e: React.DragEvent) => {

--- a/frontend/map-corridors/src/__tests__/fixtures/RF_2_RED.kml
+++ b/frontend/map-corridors/src/__tests__/fixtures/RF_2_RED.kml
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<Style id="myStyleLine">
+		<LineStyle>
+			<color>ff00ffff</color>
+			<width>2.0</width>
+		</LineStyle>
+	</Style>
+	<StyleMap id="msn_target">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_target</styleUrl>
+		</Pair>
+			<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_target</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sh_target">
+		<IconStyle>
+			<color>ff00ffff</color>
+			<scale>0.8</scale>
+		<Icon>
+			<href>http://maps.google.com/mapfiles/kml/shapes/target.png</href>
+			</Icon>
+		</IconStyle>
+	<BalloonStyle>
+	</BalloonStyle>
+	<ListStyle>
+	</ListStyle>
+	</Style>
+	<Style id="sn_target">
+		<IconStyle>
+			<color>ff00ffff</color>
+			<scale>0.8</scale>
+		<Icon>
+			<href>http://maps.google.com/mapfiles/kml/shapes/target.png</href>
+			</Icon>
+		</IconStyle>
+	<BalloonStyle>
+	</BalloonStyle>
+	<ListStyle>
+	</ListStyle>
+	</Style>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>14.031119,50.131315,0 13.757056,50.051162,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.757056,50.051162,0 13.47584,50.080134,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.47584,50.080134,0 13.512147,50.179968,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.512147,50.179968,0 13.794744,50.228576,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.794744,50.228576,0 13.768655,50.124809,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.768655,50.124809,0 14.036817,50.161759,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>14.0257080608168,50.1388857847816,0 14.031119,50.131315,0 14.0365282249615,50.123743963191,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.751654105946,50.0587327851385,0 13.757056,50.051162,0 13.7624561875483,50.0435909635476,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.4778726425713,50.0883586448703,0 13.47584,50.080134,0 13.4738080521862,50.0719093199128,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.5248100829406,50.1780746511764,0 13.512147,50.179968,0 13.4994829142014,50.1818599737997,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.7980979075768,50.2205297841095,0 13.794744,50.228576,0 13.7913889629859,50.2366221197541,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>13.7558305386757,50.1261306390705,0 13.768655,50.124809,0 13.781478752333,50.1234859470233,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>14.0395260885177,50.1536144673472,0 14.036817,50.161759,0 14.0341069907167,50.1699034699691,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>14.0813721011083,50.1156636017108,0 14.083107924722,50.117076391709,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>14.0971822458341,50.1076776017117,0 14.0989177799847,50.1090903917099,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<color>00ffffff</color>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<color>00ffffff</color>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Placemark>
+		<name>SP</name>
+		<LookAt>
+			<longitude>14.031119</longitude>
+			<latitude>50.131315</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>14.032119,50.131315,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>TP 1</name>
+		<LookAt>
+			<longitude>13.757056</longitude>
+			<latitude>50.051162</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>13.758056,50.051162,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>TP 2</name>
+		<LookAt>
+			<longitude>13.47584</longitude>
+			<latitude>50.080134</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>13.47684,50.080134,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>TP 3</name>
+		<LookAt>
+			<longitude>13.512147</longitude>
+			<latitude>50.179968</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>13.513147,50.179968,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>TP 4</name>
+		<LookAt>
+			<longitude>13.794744</longitude>
+			<latitude>50.228576</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>13.795744,50.228576,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>TP 5</name>
+		<LookAt>
+			<longitude>13.768655</longitude>
+			<latitude>50.124809</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>13.769655,50.124809,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>FP</name>
+		<LookAt>
+			<longitude>14.036817</longitude>
+			<latitude>50.161759</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>14.037817,50.161759,0</coordinates>
+		</Point>
+	</Placemark>
+</Document>
+</kml>

--- a/frontend/map-corridors/src/__tests__/fixtures/RF_RED.kml
+++ b/frontend/map-corridors/src/__tests__/fixtures/RF_RED.kml
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">
+<Document>
+	<Style id="myStyleLine">
+		<LineStyle>
+			<color>ff00ffff</color>
+			<width>2.0</width>
+		</LineStyle>
+	</Style>
+	
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.161469,48.940207,0 18.027792,48.956468,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.027792,48.956468,0 17.952273,48.866893,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.952273,48.866893,0 17.802765,48.870596,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.802765,48.870596,0 17.830081,48.772229,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.830081,48.772229,0 17.705347,48.819613,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.705347,48.819613,0 17.730187,48.715908,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.730187,48.715908,0 17.726734,48.715444,0 17.723231,48.715066,0 17.71971,48.714773,0 17.716175,48.714567,0 17.712631,48.714447,0 17.709083,48.714414,0 17.705537,48.714467,0 17.701995,48.714608,0 17.698465,48.714834,0 17.69495,48.715147,0 17.691455,48.715545,0 17.687986,48.716028,0 17.684546,48.716596,0 17.681141,48.717248,0 17.677776,48.717982,0 17.674454,48.718798,0 17.671181,48.719694,0 17.667961,48.720669,0 17.664799,48.721723,0 17.661699,48.722853,0 17.658664,48.724058,0 17.6557,48.725336,0 17.65281,48.726686,0 17.649999,48.728105,0 17.64727,48.729592,0 17.644627,48.731144,0 17.642073,48.73276,0 17.639613,48.734437,0 17.637249,48.736174,0 17.634984,48.737966,0 17.632823,48.739813,0 17.630767,48.741711,0 17.62882,48.743658,0 17.626984,48.745651,0 17.625261,48.747687,0 17.623655,48.749764,0 17.622168,48.751879,0 17.6208,48.754029,0 17.619555,48.756211,0 17.618468,48.758421,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.618468,48.758421,0 17.520015,48.812303,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.520015,48.812303,0 17.51829,48.81629,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.516564,48.820277,0 17.514839,48.824264,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.513113,48.828251,0 17.511386,48.832238,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.50966,48.836225,0 17.507933,48.840212,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.506206,48.844199,0 17.504478,48.848186,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.502751,48.852173,0 17.501023,48.85616,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.499295,48.860147,0 17.497566,48.864133,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.495837,48.86812,0 17.494108,48.872107,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.492379,48.876094,0 17.490649,48.88008,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.488919,48.884067,0 17.487189,48.888053,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.485458,48.89204,0 17.483727,48.896027,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.481996,48.900013,0 17.480264,48.904,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.478533,48.907986,0 17.4768,48.911972,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.4768,48.911973,0 17.540693,48.984606,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.540693,48.984606,0 17.661668,48.913646,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.661668,48.913646,0 17.753205,48.974442,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.753205,48.974442,0 17.738244,49.059132,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.738244,49.059132,0 17.740612,49.057305,0 17.743146,49.055551,0 17.745797,49.053873,0 17.748561,49.052275,0 17.751432,49.050759,0 17.754404,49.049329,0 17.75747,49.047988,0 17.760625,49.046738,0 17.763863,49.045582,0 17.767177,49.044522,0 17.77056,49.043561,0 17.774005,49.042699,0 17.777506,49.04194,0 17.781056,49.041284,0 17.784647,49.040732,0 17.788272,49.040287,0 17.791924,49.039948,0 17.795595,49.039717,0 17.799278,49.039594,0 17.802967,49.039579,0 17.806652,49.039672,0 17.810328,49.039872,0 17.813985,49.040181,0 17.817619,49.040596,0 17.821219,49.041118,0 17.824781,49.041745,0 17.828296,49.042475,0 17.831757,49.043308,0 17.835158,49.044241,0 17.838491,49.045274,0 17.84175,49.046403,0 17.844929,49.047626,0 17.84802,49.048942,0 17.851019,49.050347,0 17.853918,49.051838,0 17.856711,49.053413,0 17.859394,49.055068,0 17.861961,49.056801,0 17.864407,49.058607,0 17.866683,49.060483,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.866683,49.060483,0 18.007177,49.075108,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.007177,49.075108,0 18.10492,48.994263,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.163767385542,48.9483964515501,0 18.161469,48.940207,0 18.1591713660785,48.9320175031029,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.0300911349009,48.964657451537,0 18.027792,48.956468,0 18.025493617397,48.9482785030898,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.9411959685082,48.8709248493558,0 17.952273,48.866893,0 17.9633482451877,48.8628600883327,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.8032290090452,48.8789178242052,0 17.802765,48.870596,0 17.8023011427501,48.8622741739947,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.8176515959095,48.7707320758534,0 17.830081,48.772229,0 17.8425111453912,48.7737245859189,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.7116570559679,48.8268300978697,0 17.705347,48.819613,0 17.6990387587263,48.8123955586768,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.717720149455,48.7146100688122,0 17.730187,48.715908,0 17.742654493911,48.7172045845509,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.6064287865356,48.7559006948086,0 17.618468,48.758421,0 17.6305084220791,48.7609400494843,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.5280896669408,48.8187119656419,0 17.520015,48.812303,0 17.5119423952968,48.8058934716165,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.4779045090247,48.9202687246017,0 17.4768,48.911973,0 17.4756958551832,48.9036772650001,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.5516768260231,48.9804367714446,0 17.540693,48.984606,0 17.5297073374393,48.9887741871688,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.6532207283528,48.9074393266267,0 17.661668,48.913646,0 17.6701173726228,48.919852055209,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.7622192627955,48.9685826646481,0 17.753205,48.974442,0 17.7441886198639,48.9803006340831,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.750867845613,49.0600905110697,0 17.738244,49.059132,0 17.7256206413327,49.058172113883,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>17.8767306241137,49.055384501348,0 17.866683,49.060483,0 17.8566333159414,49.0655806276283,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.0091598266027,49.0668825210643,0 18.007177,49.075108,0 18.0051935191419,49.0833334452212,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.0949698191793,48.9890940442356,0 18.10492,48.994263,0 18.1148722472982,48.9994310986739,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.1876214316412,48.9923453629661,0 18.1849365136101,48.9943886216355,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<Placemark>
+		<styleUrl>#myStyleLine</styleUrl>
+		<LineString>
+			<coordinates>18.2004056265784,48.9995783629641,0 18.1977203186509,49.0016216216335,0 </coordinates>
+		</LineString>
+	</Placemark>
+	<StyleMap id="msn_ylw-pushpin">
+		<Pair>
+			<key>normal</key>
+			<styleUrl>#sn_ylw-pushpin</styleUrl>
+		</Pair>
+		<Pair>
+			<key>highlight</key>
+			<styleUrl>#sh_ylw-pushpin</styleUrl>
+		</Pair>
+	</StyleMap>
+	<Style id="sn_ylw-pushpin">
+		<IconStyle>
+			<color>00ffffff</color>
+			<scale>1.1</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Style id="sh_ylw-pushpin">
+		<IconStyle>
+			<color>00ffffff</color>
+			<scale>1.3</scale>
+			<Icon>
+				<href>http://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href>
+			</Icon>
+			<hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/>
+		</IconStyle>
+	</Style>
+	<Placemark>
+		<name>SP</name>
+		<LookAt>
+			<longitude>18.161469</longitude>
+			<latitude>48.940207</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>18.162469,48.940207,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 1</name>
+		<LookAt>
+			<longitude>18.027792</longitude>
+			<latitude>48.956468</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>18.028792,48.956468,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 2</name>
+		<LookAt>
+			<longitude>17.952273</longitude>
+			<latitude>48.866893</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.953273,48.866893,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 3</name>
+		<LookAt>
+			<longitude>17.802765</longitude>
+			<latitude>48.870596</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.803765,48.870596,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 4</name>
+		<LookAt>
+			<longitude>17.830081</longitude>
+			<latitude>48.772229</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.831081,48.772229,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 5</name>
+		<LookAt>
+			<longitude>17.705347</longitude>
+			<latitude>48.819613</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.706347,48.819613,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 6</name>
+		<LookAt>
+			<longitude>17.730187</longitude>
+			<latitude>48.715908</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.731187,48.715908,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 7</name>
+		<LookAt>
+			<longitude>17.618468</longitude>
+			<latitude>48.758421</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.619468,48.758421,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 8</name>
+		<LookAt>
+			<longitude>17.520015</longitude>
+			<latitude>48.812303</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.521015,48.812303,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 9</name>
+		<LookAt>
+			<longitude>17.4768</longitude>
+			<latitude>48.911973</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.4778,48.911973,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 10</name>
+		<LookAt>
+			<longitude>17.540693</longitude>
+			<latitude>48.984606</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.541693,48.984606,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 11</name>
+		<LookAt>
+			<longitude>17.661668</longitude>
+			<latitude>48.913646</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.662668,48.913646,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 12</name>
+		<LookAt>
+			<longitude>17.753205</longitude>
+			<latitude>48.974442</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.754205,48.974442,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 13</name>
+		<LookAt>
+			<longitude>17.738244</longitude>
+			<latitude>49.059132</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.739244,49.059132,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 14</name>
+		<LookAt>
+			<longitude>17.866683</longitude>
+			<latitude>49.060483</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>17.867683,49.060483,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>CP 15</name>
+		<LookAt>
+			<longitude>18.007177</longitude>
+			<latitude>49.075108</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>18.008177,49.075108,0</coordinates>
+		</Point>
+	</Placemark>
+	<Placemark>
+		<name>FP</name>
+		<LookAt>
+			<longitude>18.10492</longitude>
+			<latitude>48.994263</latitude>
+		</LookAt>
+		<styleUrl>#msn_ylw-pushpin</styleUrl>
+		<Point>
+			<coordinates>18.10592,48.994263,0</coordinates>
+		</Point>
+	</Placemark>
+</Document>
+</kml>

--- a/frontend/map-corridors/src/__tests__/slugify.test.ts
+++ b/frontend/map-corridors/src/__tests__/slugify.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { slugifyForFilename } from '@airq/shared-storage'
+
+describe('slugifyForFilename', () => {
+  it('lowercases ASCII names', () => {
+    expect(slugifyForFilename('PLZEN 2026')).toBe('plzen-2026')
+  })
+
+  it('strips Czech diacritics', () => {
+    expect(slugifyForFilename('Plzeň')).toBe('plzen')
+    expect(slugifyForFilename('Letecká rally Šumava')).toBe('letecka-rally-sumava')
+    expect(slugifyForFilename('Žďár nad Sázavou')).toBe('zdar-nad-sazavou')
+  })
+
+  it('replaces whitespace with single dash', () => {
+    expect(slugifyForFilename('Brno   jaro')).toBe('brno-jaro')
+    expect(slugifyForFilename('Brno\tjaro')).toBe('brno-jaro')
+  })
+
+  it('collapses runs of punctuation/separators to single dash', () => {
+    expect(slugifyForFilename('Brno -- jaro / 2026')).toBe('brno-jaro-2026')
+    expect(slugifyForFilename('Brno – jaro')).toBe('brno-jaro') // en-dash
+    expect(slugifyForFilename('Foo___Bar')).toBe('foo-bar')
+  })
+
+  it('trims leading and trailing dashes', () => {
+    expect(slugifyForFilename('  Plzeň  ')).toBe('plzen')
+    expect(slugifyForFilename('---Plzeň---')).toBe('plzen')
+  })
+
+  it('returns empty string when nothing slug-worthy remains', () => {
+    expect(slugifyForFilename('   ')).toBe('')
+    expect(slugifyForFilename('!!!')).toBe('')
+    expect(slugifyForFilename('')).toBe('')
+  })
+})

--- a/frontend/map-corridors/src/__tests__/slugify.test.ts
+++ b/frontend/map-corridors/src/__tests__/slugify.test.ts
@@ -33,4 +33,17 @@ describe('slugifyForFilename', () => {
     expect(slugifyForFilename('!!!')).toBe('')
     expect(slugifyForFilename('')).toBe('')
   })
+
+  // Pins the documented "non-Latin scripts are dropped, not transliterated"
+  // contract from slugify.ts — caller is responsible for falling back to a
+  // default filename when this returns empty. Without this test the JSDoc
+  // claim is unverified and a future "be helpful, transliterate" change
+  // could silently break the fallback path callers rely on.
+  it('drops non-Latin scripts rather than transliterating them', () => {
+    expect(slugifyForFilename('Москва')).toBe('')           // all-Cyrillic
+    expect(slugifyForFilename('Москва 2026')).toBe('2026')  // Cyrillic + ASCII digits → only digits survive
+    expect(slugifyForFilename('北京')).toBe('')              // CJK
+    expect(slugifyForFilename('Αθήνα')).toBe('')            // Greek (NFD-decomposes accents, no Latin base survives)
+    expect(slugifyForFilename('القاهرة')).toBe('')          // Arabic
+  })
 })

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -10,6 +10,11 @@ import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
+import {
+  LIVE_GROUND_MARKER_ICON_PX,
+  LIVE_MARKER_DOT_BORDER_RADIUS_PX,
+  LIVE_MARKER_DOT_PX,
+} from '../utils/markerSizes'
 
 type Overlay = {
   id: string
@@ -370,9 +375,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             }}
           >
             <div style={{
-              width: 8,
-              height: 8,
-              borderRadius: 4,
+              width: LIVE_MARKER_DOT_PX,
+              height: LIVE_MARKER_DOT_PX,
+              borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
               background: '#FFFF00',
               border: '1px solid #333333',
               cursor: 'pointer',
@@ -584,9 +589,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               }}
             >
               <div style={{
-                width: 8,
-                height: 8,
-                borderRadius: 4,
+                width: LIVE_MARKER_DOT_PX,
+                height: LIVE_MARKER_DOT_PX,
+                borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
                 background: '#FF9800',
                 border: '1px solid #333333',
                 cursor: 'pointer',
@@ -603,7 +608,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
                 display: 'flex',
                 alignItems: 'center',
               }}>
-                <Icon size={16} />
+                <Icon size={LIVE_GROUND_MARKER_ICON_PX} />
               </div>
             </Marker>
             {gmp.activeGroundMarkerId === gm.id && (

--- a/frontend/map-corridors/src/types/electron.d.ts
+++ b/frontend/map-corridors/src/types/electron.d.ts
@@ -16,7 +16,7 @@ declare module '@airq/shared-storage' {
     goHome?: () => void
     navigateToApp?: (app: string, competitionId: string) => void
     openMapboxSettings?: () => void
-    saveMapImage?: (base64: string, defaultDir?: string) => Promise<string | null>
+    saveMapImage?: (base64: string, defaultDir?: string, fileName?: string) => Promise<string | null>
     savePdf?: (base64: string, fileName: string, defaultDir?: string) => Promise<string | null>
     getConfig?: (key: string) => Promise<string | undefined>
     setConfig?: (key: string, value: string) => Promise<void>

--- a/frontend/map-corridors/src/utils/kmlMerge.ts
+++ b/frontend/map-corridors/src/utils/kmlMerge.ts
@@ -1,4 +1,5 @@
 import type { Feature, FeatureCollection, GeoJSON, LineString, Point } from 'geojson'
+import { KML_GROUND_MARKER_ICON_SCALE, KML_PHOTO_MARKER_ICON_SCALE } from './markerSizes'
 
 const KML_NS = 'http://www.opengis.net/kml/2.2'
 
@@ -109,15 +110,14 @@ function ensureGroundMarkerStyle(doc: Document, type: string, iconHref: string) 
   // pin tip) on the marker's lat/lng — feedback 2026-04-25: the symbol now
   // sits in a square at the top with a pin underneath, so the point of
   // contact is the bottom of the canvas, not the centre.
-  // scale=0.6 makes the icon visually match the yellow photo pushpins at
-  // typical map zooms — feedback 2026-04-25: "make it smaller when zoomed
-  // out, to visually match other elements". The source PNG is 128×192,
-  // 1.5× taller than Google's standard pushpin, so a sub-1 scale evens
-  // them out; the symbol stays legible when the user zooms in.
+  // The base icon scale was originally 0.6 to match the yellow photo
+  // pushpins at typical map zooms (feedback 2026-04-25). It now lives in
+  // `markerSizes.ts` and was bumped +50% (feedback 2026-05-10) so markers
+  // read clearly at the zoom levels users actually browse to.
   ensureStyle(
     doc,
     id,
-    `<IconStyle><scale>0.6</scale><Icon><href>${escapeXmlAttr(iconHref)}</href></Icon><hotSpot x="0.5" y="0" xunits="fraction" yunits="fraction"/></IconStyle><LabelStyle><scale>0</scale></LabelStyle>`,
+    `<IconStyle><scale>${KML_GROUND_MARKER_ICON_SCALE}</scale><Icon><href>${escapeXmlAttr(iconHref)}</href></Icon><hotSpot x="0.5" y="0" xunits="fraction" yunits="fraction"/></IconStyle><LabelStyle><scale>0</scale></LabelStyle>`,
   )
   return id
 }
@@ -166,7 +166,7 @@ export function appendFeaturesToKML(originalKml: string, extra: GeoJSON, docName
   ensureStyle(
     xml,
     'photoMarker',
-    '<IconStyle><color>ff00ffff</color><scale>1.1</scale><Icon><href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href></Icon><hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/></IconStyle><LabelStyle><scale>0.9</scale></LabelStyle>',
+    `<IconStyle><color>ff00ffff</color><scale>${KML_PHOTO_MARKER_ICON_SCALE}</scale><Icon><href>https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png</href></Icon><hotSpot x="20" y="2" xunits="pixels" yunits="pixels"/></IconStyle><LabelStyle><scale>0.9</scale></LabelStyle>`,
   )
 
   // Register one IconStyle per used ground-marker type (feedback 2026-04-18:

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -173,9 +173,11 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     const scaleX = mapCanvas.width / dims.width
     const scaleY = mapCanvas.height / dims.height
 
-    // Composite photo markers. Screen uses 8px diameter; print was tuned up to
-    // 36px diameter originally — testing feedback (2026-04-18) said that was too
-    // large on paper, so we drop to 20px diameter (10px radius) here.
+    // Composite photo markers. Screen now uses 12px diameter (was 8); print
+    // was originally tuned to 20px (10px radius) after the 2026-04-18 round
+    // when 36px looked too dominant on A4, then bumped +50% to 30px (15px
+    // radius) at the 2026-05-10 round to match the ground-marker bump. Both
+    // values now live in `markerSizes.ts` as the single source of truth.
     const markerRadius = PRINT_MARKER_DOT_RADIUS * scaleX
     const fontSize = Math.round(42 * scaleX)
 

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -3,6 +3,7 @@ import type { LngLatBoundsLike, StyleSpecification } from 'mapbox-gl'
 import type { GeoJSON } from 'geojson'
 import { groundMarkerSvgString } from '../components/GroundMarkerIcons'
 import type { GroundMarkerType, PhotoLabel } from '../types/markers'
+import { PRINT_GROUND_ICON_SIZE, PRINT_MARKER_DOT_RADIUS } from './markerSizes'
 
 type OverlayConfig = {
   id: string
@@ -175,7 +176,7 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     // Composite photo markers. Screen uses 8px diameter; print was tuned up to
     // 36px diameter originally — testing feedback (2026-04-18) said that was too
     // large on paper, so we drop to 20px diameter (10px radius) here.
-    const markerRadius = 10 * scaleX
+    const markerRadius = PRINT_MARKER_DOT_RADIUS * scaleX
     const fontSize = Math.round(42 * scaleX)
 
     for (const m of markers) {
@@ -221,10 +222,10 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     // is a correctness bug, not a cosmetic one.
     const gms = options.groundMarkers || []
     if (gms.length) {
-      // Match the photo-marker label pill height (~46 px) so the two symbol
-      // types read at the same visual weight on A4 (feedback 2026-04-18 —
-      // 72 px made ground markers dominate their photo neighbours).
-      const iconSize = Math.round(40 * scaleX)
+      // Base icon size originally tuned (40) so the two symbol types read at
+      // similar visual weight on A4 (feedback 2026-04-18). Bumped +50% to 60
+      // (feedback 2026-05-10) — markers were undersized on print.
+      const iconSize = Math.round(PRINT_GROUND_ICON_SIZE * scaleX)
       const uniqueTypes = [...new Set(gms.map(gm => gm.type))]
       const gmImages = new Map<GroundMarkerType, HTMLImageElement>()
       const failedTypes = new Set<GroundMarkerType>()

--- a/frontend/map-corridors/src/utils/markerSizes.ts
+++ b/frontend/map-corridors/src/utils/markerSizes.ts
@@ -1,0 +1,33 @@
+/**
+ * Single source of truth for marker dimensions across the three surfaces:
+ * the live editor map, the printed/PNG map capture, and the KML export.
+ *
+ * Sizes were uniformly enlarged by ~50% (feedback 2026-05-10 — markers were
+ * too small to read on a printed competition map and in Google Earth at
+ * normal zoom). Tweak here, not at call sites.
+ */
+
+/* ──────────────────────────────────────────────────────────────────────
+ *  Live on-screen map (MapProviderView.tsx)
+ *  Pixel sizes for the small DOM markers placed at marker lat/lng.
+ *  Previous values are left as a // comment so the +50% history is
+ *  visible without a git blame round-trip.
+ * ────────────────────────────────────────────────────────────────────── */
+export const LIVE_MARKER_DOT_PX = 12             // was 8
+export const LIVE_MARKER_DOT_BORDER_RADIUS_PX = 6 // was 4
+export const LIVE_GROUND_MARKER_ICON_PX = 24     // was 16
+
+/* ──────────────────────────────────────────────────────────────────────
+ *  Printed / PNG map capture (mapCapture.ts)
+ *  Multiplied by `scaleX` at use sites to match the print canvas size.
+ * ────────────────────────────────────────────────────────────────────── */
+export const PRINT_MARKER_DOT_RADIUS = 15        // was 10
+export const PRINT_GROUND_ICON_SIZE = 60         // was 40
+
+/* ──────────────────────────────────────────────────────────────────────
+ *  KML export (kmlMerge.ts)
+ *  Values written into <IconStyle><scale> in the exported KML so Google
+ *  Earth / Maps render markers at a comparable size.
+ * ────────────────────────────────────────────────────────────────────── */
+export const KML_GROUND_MARKER_ICON_SCALE = 0.9  // was 0.6
+export const KML_PHOTO_MARKER_ICON_SCALE = 1.65  // was 1.1

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -121,6 +121,7 @@ function AppApi() {
   const refreshSession = supportsRefresh ? sessionHookResult.refreshSession : undefined;
   const supportsApplyToAll = Boolean(sessionHookResult.applySettingToAll);
   const applySettingToAll = supportsApplyToAll ? sessionHookResult.applySettingToAll : undefined;
+  const applyLabelPositionToAll = sessionHookResult.applyLabelPositionToAll;
   
   const { currentRatio } = useAspectRatio();
   const { generateLabel } = useLabeling();
@@ -1028,6 +1029,7 @@ function AppApi() {
                         circleMode={circleMode}
                         onCircleModeToggle={() => setCircleMode(!circleMode)}
                         onApplyToAll={supportsApplyToAll && applySettingToAll ? (setting, value) => applySettingToAll(setting, value) : undefined}
+                        onSyncLabelPositionToAll={applyLabelPositionToAll ? (position) => applyLabelPositionToAll(position) : undefined}
                       />
                     </Box>
                   </Box>

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -121,7 +121,13 @@ function AppApi() {
   const refreshSession = supportsRefresh ? sessionHookResult.refreshSession : undefined;
   const supportsApplyToAll = Boolean(sessionHookResult.applySettingToAll);
   const applySettingToAll = supportsApplyToAll ? sessionHookResult.applySettingToAll : undefined;
-  const applyLabelPositionToAll = sessionHookResult.applyLabelPositionToAll;
+  // Mirrors the supportsApplyToAll pattern above. Without this Boolean gate
+  // the prop would be always-truthy (the hook unconditionally exposes the
+  // function) and the "Sync corner to all" button would render even on a
+  // hook variant that doesn't implement label sync — a click then becomes a
+  // silent no-op. Consistent gating across all session-bulk operations.
+  const supportsApplyLabelPositionToAll = Boolean(sessionHookResult.applyLabelPositionToAll);
+  const applyLabelPositionToAll = supportsApplyLabelPositionToAll ? sessionHookResult.applyLabelPositionToAll : undefined;
   
   const { currentRatio } = useAspectRatio();
   const { generateLabel } = useLabeling();
@@ -351,8 +357,15 @@ function AppApi() {
 
       await generatePDF(set1WithLabels, set2WithLabels, sessionId, currentRatio.ratio, session.competition_name, effectiveLayout, t, session.mode, currentCompetition?.id);
     } catch (error) {
+      // Surface to the user — previously this was a TODO ("Could add user
+      // notification here") and a generatePDF render failure produced a
+      // silent partial export. The hi-res render path can throw on memory
+      // pressure / blob URL issues / mid-export photo state changes; the
+      // user needs to know the export was aborted (or partial), not be left
+      // wondering why the dialog never opened.
       console.error('PDF generation failed:', error);
-      // Could add user notification here
+      const message = error instanceof Error ? error.message : String(error);
+      alert(message);
     }
   };
 
@@ -1029,7 +1042,7 @@ function AppApi() {
                         circleMode={circleMode}
                         onCircleModeToggle={() => setCircleMode(!circleMode)}
                         onApplyToAll={supportsApplyToAll && applySettingToAll ? (setting, value) => applySettingToAll(setting, value) : undefined}
-                        onSyncLabelPositionToAll={applyLabelPositionToAll ? (position) => applyLabelPositionToAll(position) : undefined}
+                        onSyncLabelPositionToAll={supportsApplyLabelPositionToAll && applyLabelPositionToAll ? (position) => applyLabelPositionToAll(position) : undefined}
                       />
                     </Box>
                   </Box>

--- a/frontend/photo-helper/src/__tests__/canvasStatePatch.test.ts
+++ b/frontend/photo-helper/src/__tests__/canvasStatePatch.test.ts
@@ -3,9 +3,11 @@ import {
   applySettingPatch,
   applySettingToAllPhotos,
   applySettingToAllInSession,
+  applyLabelPositionToAllPhotos,
+  applyLabelPositionToAllInSession,
   DEFAULT_CANVAS_STATE,
 } from '../utils/canvasStatePatch';
-import type { CanvasState, PhotoSessionShape } from '../utils/canvasStatePatch';
+import type { CanvasState, LabelPosition, PhotoSessionShape } from '../utils/canvasStatePatch';
 
 function makePhoto(id: string, overrides: Partial<CanvasState> = {}) {
   return {
@@ -290,5 +292,180 @@ describe('applySettingToAllInSession', () => {
     const result = applySettingToAllInSession(session, 'brightness', Number.NaN);
     expect(result.version).toBe(session.version + 1);
     expect(result.sets.set1.photos[0].canvasState.brightness).toBe(25);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyLabelPositionToAllPhotos — array of photos
+//
+// Label position is a string union, so it gets its own helper rather than
+// reusing the numeric `applySettingToAllPhotos`. These tests mirror the
+// applySettingToAllPhotos suite so a future refactor that drifts the two
+// code paths apart fails loudly.
+// ---------------------------------------------------------------------------
+describe('applyLabelPositionToAllPhotos', () => {
+  it('applies label position to all photos', () => {
+    const photos = [makePhoto('a'), makePhoto('b'), makePhoto('c')];
+    const result = applyLabelPositionToAllPhotos(photos, 'top-right');
+    for (const p of result) {
+      expect(p.canvasState.labelPosition).toBe('top-right');
+    }
+  });
+
+  it('skips the excluded photo', () => {
+    const photos = [
+      makePhoto('a', { labelPosition: 'top-left' }),
+      makePhoto('b', { labelPosition: 'bottom-left' }),
+    ];
+    const result = applyLabelPositionToAllPhotos(photos, 'bottom-right', 'a');
+    expect(result[0].canvasState.labelPosition).toBe('top-left');
+    expect(result[1].canvasState.labelPosition).toBe('bottom-right');
+  });
+
+  it('handles empty array', () => {
+    const result = applyLabelPositionToAllPhotos([], 'top-right');
+    expect(result).toEqual([]);
+  });
+
+  it('handles undefined photos', () => {
+    const result = applyLabelPositionToAllPhotos(undefined, 'top-right');
+    expect(result).toEqual([]);
+  });
+
+  it('handles null photos', () => {
+    const result = applyLabelPositionToAllPhotos(null, 'top-right');
+    expect(result).toEqual([]);
+  });
+
+  it('does not mutate original photos or their canvasStates', () => {
+    const photos = [makePhoto('a', { labelPosition: 'top-left' })];
+    const result = applyLabelPositionToAllPhotos(photos, 'bottom-right');
+    expect(photos[0].canvasState.labelPosition).toBe('top-left');
+    expect(result[0]).not.toBe(photos[0]);
+    expect(result[0].canvasState).not.toBe(photos[0].canvasState);
+  });
+
+  it('preserves extra photo fields and other canvasState fields', () => {
+    const photos = [
+      {
+        id: 'x',
+        canvasState: { ...DEFAULT_CANVAS_STATE, brightness: 42, scale: 2.5 },
+        label: 'test',
+        url: '/img.jpg',
+      },
+    ];
+    const result = applyLabelPositionToAllPhotos(photos, 'top-right');
+    expect(result[0].label).toBe('test');
+    expect(result[0].url).toBe('/img.jpg');
+    expect(result[0].canvasState.labelPosition).toBe('top-right');
+    expect(result[0].canvasState.brightness).toBe(42);
+    expect(result[0].canvasState.scale).toBe(2.5);
+  });
+
+  it('accepts every legal LabelPosition value', () => {
+    const positions: LabelPosition[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+    for (const pos of positions) {
+      const photos = [makePhoto('a')];
+      const result = applyLabelPositionToAllPhotos(photos, pos);
+      expect(result[0].canvasState.labelPosition).toBe(pos);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyLabelPositionToAllInSession — session-level transformer
+//
+// Mirrors the applySettingToAllInSession suite so any divergence between the
+// two helpers (version bump, updatedAt refresh, both-set traversal,
+// immutability) is caught in CI rather than at "sync corner" click-time.
+// ---------------------------------------------------------------------------
+describe('applyLabelPositionToAllInSession', () => {
+  type TestPhoto = { id: string; canvasState: CanvasState; label?: string };
+  type TestSession = PhotoSessionShape<TestPhoto> & { id: string; mode: 'track' };
+
+  const makeSession = (): TestSession => ({
+    id: 'session-1',
+    mode: 'track',
+    version: 7,
+    updatedAt: '2020-01-01T00:00:00.000Z',
+    sets: {
+      set1: {
+        title: 'SP - TP1',
+        photos: [makePhoto('a'), makePhoto('b', { labelPosition: 'top-left' })],
+      },
+      set2: {
+        title: 'TP1 - FP',
+        photos: [makePhoto('c', { labelPosition: 'bottom-right' })],
+      },
+    },
+  });
+
+  it('bumps version', () => {
+    const session = makeSession();
+    const result = applyLabelPositionToAllInSession(session, 'top-right');
+    expect(result.version).toBe(session.version + 1);
+  });
+
+  it('refreshes updatedAt to a new ISO string', () => {
+    const session = makeSession();
+    const result = applyLabelPositionToAllInSession(session, 'top-right');
+    expect(result.updatedAt).not.toBe(session.updatedAt);
+    expect(new Date(result.updatedAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('patches photos in both sets', () => {
+    const session = makeSession();
+    const result = applyLabelPositionToAllInSession(session, 'top-right');
+    expect(result.sets.set1.photos.every(p => p.canvasState.labelPosition === 'top-right')).toBe(true);
+    expect(result.sets.set2.photos.every(p => p.canvasState.labelPosition === 'top-right')).toBe(true);
+  });
+
+  it('preserves set titles and extra photo fields', () => {
+    const session = makeSession();
+    session.sets.set1.photos[0].label = 'A';
+    const result = applyLabelPositionToAllInSession(session, 'bottom-left');
+    expect(result.sets.set1.title).toBe('SP - TP1');
+    expect(result.sets.set2.title).toBe('TP1 - FP');
+    expect(result.sets.set1.photos[0].label).toBe('A');
+  });
+
+  it('respects excludePhotoId across both sets', () => {
+    const session = makeSession();
+    // Pre-set distinct corners so we can prove only the excluded id is left alone.
+    session.sets.set1.photos[0].canvasState.labelPosition = 'top-left';
+    session.sets.set1.photos[1].canvasState.labelPosition = 'top-right';
+    session.sets.set2.photos[0].canvasState.labelPosition = 'bottom-left';
+    const result = applyLabelPositionToAllInSession(session, 'bottom-right', 'b');
+    expect(result.sets.set1.photos[0].canvasState.labelPosition).toBe('bottom-right');
+    expect(result.sets.set1.photos[1].canvasState.labelPosition).toBe('top-right');
+    expect(result.sets.set2.photos[0].canvasState.labelPosition).toBe('bottom-right');
+  });
+
+  it('preserves non-sets session fields', () => {
+    const session = makeSession();
+    const result = applyLabelPositionToAllInSession(session, 'top-right');
+    expect(result.id).toBe('session-1');
+    expect(result.mode).toBe('track');
+  });
+
+  it('does not mutate the input session', () => {
+    const session = makeSession();
+    const originalVersion = session.version;
+    const originalUpdatedAt = session.updatedAt;
+    const originalLabelPos = session.sets.set1.photos[0].canvasState.labelPosition;
+    applyLabelPositionToAllInSession(session, 'bottom-right');
+    expect(session.version).toBe(originalVersion);
+    expect(session.updatedAt).toBe(originalUpdatedAt);
+    expect(session.sets.set1.photos[0].canvasState.labelPosition).toBe(originalLabelPos);
+  });
+
+  it('does not alias the input canvasState objects in the result', () => {
+    const session = makeSession();
+    const inputCanvasState = session.sets.set1.photos[0].canvasState;
+    const result = applyLabelPositionToAllInSession(session, 'top-right');
+    expect(result.sets.set1.photos[0].canvasState).not.toBe(inputCanvasState);
+    // Mutating the result must not leak into the input.
+    result.sets.set1.photos[0].canvasState.labelPosition = 'top-left';
+    expect(session.sets.set1.photos[0].canvasState.labelPosition).toBe(inputCanvasState.labelPosition);
   });
 });

--- a/frontend/photo-helper/src/__tests__/pdfLandscapeGrid.test.ts
+++ b/frontend/photo-helper/src/__tests__/pdfLandscapeGrid.test.ts
@@ -115,4 +115,66 @@ describe('calculateLandscapeGrid', () => {
       expect(layout.startY).toBeCloseTo(HEADER_TOP_PAD, 5);
     });
   });
+
+  describe("headerPlacement: 'left' (rotated side-header for 4:3)", () => {
+    // Side-header mode (feedback 2026-05-12): the rotated header lives in
+    // a left gutter, so it should eat WIDTH and leave the full page HEIGHT
+    // for photos. Default remains 'top' for back-compat. Production
+    // trigger is 4:3 — the FAI answer-sheet ratio, which is the case the
+    // side header actually helps (cells grow ~3% because the grid is
+    // height-constrained and there's horizontal slack to reclaim).
+    const ASPECT_4_3 = 4 / 3;
+    const SIDE_GUTTER = 22;
+
+    it("defaults to 'top' placement when the arg is omitted", () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, HEADER_HEIGHT, HEADER_TOP_PAD, 9);
+      expect(layout.headerPlacement).toBe('top');
+    });
+
+    it('left placement reclaims the full vertical extent for the grid', () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 9, 'left');
+      // The grid is centered vertically inside the full page height — its
+      // total height plus 2 * startY should equal A4 height (within
+      // floor-rounding tolerance).
+      const totalHeight = layout.photoHeight * layout.rows + layout.gap * (layout.rows - 1);
+      expect(2 * layout.startY + totalHeight).toBeCloseTo(A4_LANDSCAPE_HEIGHT_PT, 0);
+    });
+
+    it('left placement pushes the grid past the gutter horizontally', () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 9, 'left');
+      // Grid starts at or beyond the gutter (header occupies headerPad
+      // through headerPad + SIDE_GUTTER on the left).
+      expect(layout.startX).toBeGreaterThanOrEqual(HEADER_TOP_PAD + SIDE_GUTTER);
+    });
+
+    it("exposes headerX at the headerPad offset (caller uses it for placement)", () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 9, 'left');
+      expect(layout.headerX).toBeCloseTo(HEADER_TOP_PAD, 5);
+      // headerY is 0 in left-placement mode — caller centers the rotated
+      // image vertically itself using the rasterised image height.
+      expect(layout.headerY).toBe(0);
+    });
+
+    it('still respects the photo aspect ratio in left placement', () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 9, 'left');
+      expect(layout.photoWidth / layout.photoHeight).toBeCloseTo(ASPECT_4_3, 5);
+    });
+
+    it('grows 4:3 cells vs the top-header baseline (the whole point)', () => {
+      // The side-header trade only makes sense for height-constrained
+      // grids (4:3 on A4 landscape). Pin the gain so a future refactor
+      // that accidentally flips the constraint will fail this test.
+      const top = calculateLandscapeGrid(ASPECT_4_3, HEADER_HEIGHT, HEADER_TOP_PAD, 9, 'top');
+      const left = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 9, 'left');
+      expect(left.photoHeight).toBeGreaterThan(top.photoHeight);
+      expect(left.photoWidth).toBeGreaterThan(top.photoWidth);
+    });
+
+    it('5×2 grid also switches axis in left placement', () => {
+      const layout = calculateLandscapeGrid(ASPECT_4_3, SIDE_GUTTER, HEADER_TOP_PAD, 10, 'left');
+      expect(layout.cols).toBe(5);
+      expect(layout.rows).toBe(2);
+      expect(layout.headerPlacement).toBe('left');
+    });
+  });
 });

--- a/frontend/photo-helper/src/components/PhotoControls.tsx
+++ b/frontend/photo-helper/src/components/PhotoControls.tsx
@@ -74,6 +74,10 @@ interface PhotoControlsProps {
   circleMode?: boolean;
   onCircleModeToggle?: () => void;
   onApplyToAll?: (setting: CanvasSetting, value: number) => void; // Apply setting to all photos
+  // "Sync to all" for the label corner — separate from `onApplyToAll` because
+  // label position is a string union, not a number, and forcing it through
+  // the numeric path would break `CanvasSetting`'s type-safety contract.
+  onSyncLabelPositionToAll?: (position: LabelPosition) => void;
 }
 
 type LabelPosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
@@ -366,7 +370,8 @@ export const PhotoControls: React.FC<PhotoControlsProps> = ({
   onToggleOriginal,
   circleMode: externalCircleMode,
   onCircleModeToggle,
-  onApplyToAll
+  onApplyToAll,
+  onSyncLabelPositionToAll
 }) => {
   const { t } = useI18n();
   // Local state for immediate UI feedback
@@ -1222,8 +1227,20 @@ export const PhotoControls: React.FC<PhotoControlsProps> = ({
             ↘ {label}
           </Button>
         </Box>
+        {/* Sync corner to all photos in both sets (feedback 2026-05-10). */}
+        {onSyncLabelPositionToAll && (
+          <Button
+            variant="outlined"
+            size="small"
+            fullWidth
+            onClick={() => onSyncLabelPositionToAll(localLabelPosition)}
+            sx={{ mt: 0.75, fontSize: '0.7rem', py: 0.5 }}
+          >
+            {t('controls.syncLabelToAll')}
+          </Button>
+        )}
       </Box>
-      
+
       {/* Zoom - Compact */}
       <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
@@ -1332,8 +1349,20 @@ export const PhotoControls: React.FC<PhotoControlsProps> = ({
             ↘ {label}
           </Button>
         </Box>
+        {/* Sync corner to all photos in both sets (feedback 2026-05-10). */}
+        {onSyncLabelPositionToAll && (
+          <Button
+            variant="outlined"
+            size="small"
+            fullWidth
+            onClick={() => onSyncLabelPositionToAll(localLabelPosition)}
+            sx={{ mt: 0.75, fontSize: '0.7rem', py: 0.5 }}
+          >
+            {t('controls.syncLabelToAll')}
+          </Button>
+        )}
       </Box>
-      
+
       {/* Circle Overlay */}
       <Box sx={{ mt: 3, mb: 2 }}>
         <Typography variant="body2" sx={{ mb: 1, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.8rem' }}>

--- a/frontend/photo-helper/src/components/PhotoEditorApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoEditorApi.tsx
@@ -26,9 +26,9 @@ interface PhotoEditorApiProps {
 }
 
 // UNIFIED RENDERING SYSTEM - Same logic for grid and modal
-const BASE_WIDTH = 300;
+export const BASE_WIDTH = 300;
 
-const cropImageToAspectRatio = (
+export const cropImageToAspectRatio = (
   image: HTMLImageElement,
   targetAspect: number,
   canvasSize: { width: number; height: number },
@@ -93,7 +93,7 @@ const cropImageToAspectRatio = (
   return canvas;
 };
 
-const renderPhotoOnCanvas = async (
+export const renderPhotoOnCanvas = async (
   canvas: HTMLCanvasElement,
   image: HTMLImageElement,
   canvasState: Photo['canvasState'],
@@ -412,7 +412,7 @@ const renderPhotoOnCanvas = async (
 };
 
 // Draw circle overlay on canvas
-const drawCircle = (canvas: HTMLCanvasElement, circle: { x: number; y: number; radius: number; color: string }, scaleRatio: number) => {
+export const drawCircle = (canvas: HTMLCanvasElement, circle: { x: number; y: number; radius: number; color: string }, scaleRatio: number) => {
   const ctx = getCanvasContext(canvas);
   if (!ctx || !circle) return;
   
@@ -529,10 +529,18 @@ export const PhotoEditorApi: React.FC<PhotoEditorApiProps> = ({
   const gridCanvasSize = getCanvasSize(240);
   const largeCanvasSize = getCanvasSize(600); // Match the canvas size used below
   
-  // Dynamic canvas dimensions based on aspect ratio
+  // Dynamic canvas dimensions based on aspect ratio.
+  // Grid was previously 300 px wide — but the grid <canvas> is CSS-sized to
+  // 100% of its parent cell (typically 400–700 CSS px on a 1080p/1440p
+  // screen, often >1000 device px after devicePixelRatio scaling), so the
+  // browser was upscaling 2–4× and the preview looked pixelated even though
+  // the printed PDF was crisp (feedback 2026-05-10). Matching the modal's
+  // 600 px buffer means the grid canvas is now displayed at ≤1× scale on
+  // typical Windows displays. Drag stays fluid because `dragScaleFactor`
+  // already shrinks the temp canvas while the user is interacting.
   const canvasSize = size === 'large'
     ? getCanvasSize(600) // 2x scale for modal
-    : getCanvasSize(300); // Base size for grid
+    : getCanvasSize(600); // Bumped from 300 — see comment above.
 
   // Image is now loaded via useCachedImage hook above
   useEffect(() => {

--- a/frontend/photo-helper/src/contexts/AspectRatioContext.tsx
+++ b/frontend/photo-helper/src/contexts/AspectRatioContext.tsx
@@ -10,16 +10,13 @@ export interface AspectRatioOption {
   description: string;
 }
 
+// 4:3 listed first so it's the default — the FAI official answer-sheet uses
+// 87.3×65.1 mm cells (aspect ratio 1.341, essentially 4:3), and a 3×3 grid of
+// 4:3 photos is height-constrained on A4 landscape (grid aspect 1.333 < page
+// aspect 1.415), which is what produces the "photos fill A4 vertically with
+// white edges on the sides" look you see on the official sheet (feedback
+// 2026-05-12 — earlier "default to 3:2" was a misread of the official spec).
 export const ASPECT_RATIO_OPTIONS: AspectRatioOption[] = [
-  {
-    id: '3:2',
-    name: '3:2 DSLR',
-    ratio: 3 / 2,
-    widthRatio: 3,
-    heightRatio: 2,
-    cssRatio: '3/2',
-    description: 'DSLR'
-  },
   {
     id: '4:3',
     name: '4:3 Classic',
@@ -28,6 +25,15 @@ export const ASPECT_RATIO_OPTIONS: AspectRatioOption[] = [
     heightRatio: 3,
     cssRatio: '4/3',
     description: 'Classic'
+  },
+  {
+    id: '3:2',
+    name: '3:2 DSLR',
+    ratio: 3 / 2,
+    widthRatio: 3,
+    heightRatio: 2,
+    cssRatio: '3/2',
+    description: 'DSLR'
   },
   {
     id: '16:9',
@@ -52,7 +58,10 @@ interface AspectRatioContextType {
 const AspectRatioContext = createContext<AspectRatioContextType | null>(null);
 
 export const AspectRatioProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [currentRatio, setCurrentRatio] = useState<AspectRatioOption>(ASPECT_RATIO_OPTIONS[0]); // Default to 3:2
+  // Default to 4:3 (FAI official answer-sheet); ratio order in
+  // `ASPECT_RATIO_OPTIONS` keeps 4:3 at index 0 — see the comment on
+  // that constant for the rationale.
+  const [currentRatio, setCurrentRatio] = useState<AspectRatioOption>(ASPECT_RATIO_OPTIONS[0]);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const transitionTimeoutRef = useRef<number | null>(null);
 

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -14,7 +14,7 @@ import type { ApiPhotoSession } from '../types/api';
 import { competitionService } from '../services/competitionService';
 import { migrationService } from '../services/migrationService';
 import { useI18n } from '../contexts/I18nContext';
-import { applySettingToAllInSession, type CanvasSetting } from '../utils/canvasStatePatch';
+import { applyLabelPositionToAllInSession, applySettingToAllInSession, type CanvasSetting, type LabelPosition } from '../utils/canvasStatePatch';
 import { distributeRallyDrop } from '../utils/distributeRallyDrop';
 import { getGridCapacity } from '../utils/getGridCapacity';
 import { parseDiscipline } from '../utils/parseDiscipline';
@@ -644,6 +644,22 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     });
   }, [updateCurrentCompetition]);
 
+  // Sync label corner across every photo in both sets — see usePhotoSessionOPFS
+  // for the canonical comment. This wrapper keeps the competition-system
+  // surface symmetric with applySettingToAll.
+  const applyLabelPositionToAll = useCallback(async (position: LabelPosition, excludePhotoId?: string) => {
+    await updateCurrentCompetition(session => {
+      const normalized = {
+        ...session,
+        sets: {
+          set1: session.sets?.set1 || { title: '', photos: [] },
+          set2: session.sets?.set2 || { title: '', photos: [] },
+        },
+      };
+      return applyLabelPositionToAllInSession(normalized, position, excludePhotoId);
+    });
+  }, [updateCurrentCompetition]);
+
   const updatePhotoState = useCallback(async (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => {
     await updateCurrentCompetition(session => {
       // Ensure sets structure is valid
@@ -963,6 +979,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     }) as any,
     refreshSession: (async () => {}) as any,
     applySettingToAll,
+    applyLabelPositionToAll,
     
     // Cleanup & storage
     cleanupCandidates,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -647,7 +647,22 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   // Sync label corner across every photo in both sets — see usePhotoSessionOPFS
   // for the canonical comment. This wrapper keeps the competition-system
   // surface symmetric with applySettingToAll.
+  //
+  // The explicit !currentCompetition guard surfaces the "no active competition"
+  // race (user clicks Sync while a competition switch is in flight) as a
+  // user-visible error banner instead of letting `updateCurrentCompetition`'s
+  // silent early-return at line ~405 swallow the click. The button is also
+  // gated in AppApi via `supportsApplyLabelPositionToAll`, but a defensive
+  // guard here means future call sites can't reintroduce the silent failure.
   const applyLabelPositionToAll = useCallback(async (position: LabelPosition, excludePhotoId?: string) => {
+    if (!currentCompetition) {
+      // Match the in-file convention (lines 298, 332, 396) — hardcoded
+      // English error strings. The error banner is informational; the
+      // primary defence against this race is the supportsApplyLabelPosition
+      // gate in AppApi.tsx.
+      setError('No active competition to sync label corner');
+      return;
+    }
     await updateCurrentCompetition(session => {
       const normalized = {
         ...session,
@@ -658,7 +673,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       };
       return applyLabelPositionToAllInSession(normalized, position, excludePhotoId);
     });
-  }, [updateCurrentCompetition]);
+  }, [currentCompetition, updateCurrentCompetition]);
 
   const updatePhotoState = useCallback(async (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => {
     await updateCurrentCompetition(session => {

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Photo } from '../types';
 import type { ApiPhoto, ApiPhotoSession } from '../types/api';
-import { applySettingToAllInSession, type CanvasSetting } from '../utils/canvasStatePatch';
+import { applyLabelPositionToAllInSession, applySettingToAllInSession, type CanvasSetting, type LabelPosition } from '../utils/canvasStatePatch';
 import { deriveSet1FromSet2, deriveSet2FromSet1 } from '../utils/autoPrefillSetTitle';
 import { getGridCapacity, TURNING_POINT_PER_SET } from '../utils/getGridCapacity';
 import {
@@ -355,6 +355,19 @@ export function usePhotoSessionOPFS() {
     await updateStorageEstimate();
   }, [session, persistSession]);
 
+  // Sync label corner across every photo in both sets — used by the modal
+  // "Sync to all" button (feedback 2026-05-10). Same atomic-update pattern as
+  // applySettingToAll; mirrors the result into the mode-specific bucket so a
+  // later mode switch keeps the corner.
+  const applyLabelPositionToAll = useCallback(async (position: LabelPosition, excludePhotoId?: string) => {
+    if (!session) return;
+
+    const next: ApiPhotoSession = applyLabelPositionToAllInSession(session, position, excludePhotoId);
+    (next as ApiPhotoSession)[session.mode === 'track' ? 'setsTrack' : 'setsTurning'] = next.sets;
+    await persistSession(next);
+    await updateStorageEstimate();
+  }, [session, persistSession]);
+
   const updateSetTitle = useCallback(async (setKey: 'set1' | 'set2', title: string) => {
     if (!session) return;
     // Apply title
@@ -538,6 +551,7 @@ export function usePhotoSessionOPFS() {
     removePhoto,
     updatePhotoState,
     applySettingToAll,
+    applyLabelPositionToAll,
     updateSetTitle,
     updateSetTitles,
     reorderPhotos,

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -165,6 +165,7 @@
     "autoWhiteBalance": "Automatické vyvážení bílé",
     "autoShort": "Auto",
     "labelPosition": "Pozice popisku",
+    "syncLabelToAll": "Sjednotit roh u všech fotek",
     "resetAll": "Obnovit vše",
     "preview": "Náhled",
     "resetBrightness": "Obnovit jas",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -165,6 +165,7 @@
     "autoWhiteBalance": "Auto White Balance",
     "autoShort": "Auto",
     "labelPosition": "Label Position",
+    "syncLabelToAll": "Sync corner to all photos",
     "resetAll": "Reset All",
     "preview": "Preview",
     "resetBrightness": "Reset brightness",

--- a/frontend/photo-helper/src/utils/canvasStatePatch.ts
+++ b/frontend/photo-helper/src/utils/canvasStatePatch.ts
@@ -137,3 +137,52 @@ export function applySettingToAllInSession<
     },
   };
 }
+
+/**
+ * Label position is a string union (`'top-left' | 'top-right' | 'bottom-left'
+ * | 'bottom-right'`) rather than a number, so it sits outside `CanvasSetting`
+ * and gets its own narrow helper. Used by the modal "Sync to all" button so
+ * one click pins the same corner for every photo across both sets.
+ */
+export type LabelPosition = CanvasState['labelPosition'];
+
+export function applyLabelPositionToAllPhotos<
+  T extends { id: string; canvasState: CanvasState },
+>(
+  photos: T[] | undefined | null,
+  position: LabelPosition,
+  excludePhotoId?: string,
+): T[] {
+  if (!photos) return [];
+  return photos.map(p =>
+    p.id === excludePhotoId
+      ? p
+      : { ...p, canvasState: { ...p.canvasState, labelPosition: position } }
+  );
+}
+
+export function applyLabelPositionToAllInSession<
+  P extends { id: string; canvasState: CanvasState },
+  S extends PhotoSessionShape<P>,
+>(
+  session: S,
+  position: LabelPosition,
+  excludePhotoId?: string,
+): S {
+  return {
+    ...session,
+    version: session.version + 1,
+    updatedAt: new Date().toISOString(),
+    sets: {
+      ...session.sets,
+      set1: {
+        ...session.sets.set1,
+        photos: applyLabelPositionToAllPhotos(session.sets.set1.photos, position, excludePhotoId),
+      },
+      set2: {
+        ...session.sets.set2,
+        photos: applyLabelPositionToAllPhotos(session.sets.set2.photos, position, excludePhotoId),
+      },
+    },
+  };
+}

--- a/frontend/photo-helper/src/utils/canvasUtils.ts
+++ b/frontend/photo-helper/src/utils/canvasUtils.ts
@@ -95,15 +95,17 @@ export const drawLabel = (
     return;
   }
   
-  // Scale font size based on canvas size to maintain consistent visual appearance
-  // Base font size for 300x225 canvas, scale proportionally (reduced by 30% from 48px)
-  const baseFontSize = 34;
+  // Scale font size based on canvas size to maintain consistent visual appearance.
+  // Base font size for the 300px-wide on-screen canvas; scales proportionally for
+  // hi-res PDF renders. Bumped 34 → 68 (feedback 2026-05-12) so jury graders can
+  // read the photo number at arm's length on the printed sheet; `bold` removed
+  // at the same time — the heavier stroke at this size felt obtrusive.
+  const baseFontSize = 68;
   const baseCanvasWidth = 300;
   const scaleFactor = canvas.width / baseCanvasWidth;
   const fontSize = Math.round(baseFontSize * scaleFactor);
-  
-  // Label styling - 3x bigger than default with thin black border
-  ctx.font = `bold ${fontSize}px Arial`;
+
+  ctx.font = `${fontSize}px Arial`;
   ctx.fillStyle = 'white';
   ctx.strokeStyle = 'black';
   ctx.lineWidth = Math.max(1, Math.round(scaleFactor)); // Scale border width too

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -1,8 +1,19 @@
 import React from 'react';
 import { Document, Page, Image, pdf, StyleSheet } from '@react-pdf/renderer';
-import type { ApiPhotoSet } from '../types/api';
-import { dirnameOf } from '@airq/shared-storage';
+import type { ApiPhoto, ApiPhotoSet } from '../types/api';
+import { dirnameOf, slugifyForFilename } from '@airq/shared-storage';
 import { calculateLandscapeGrid } from './pdfLandscapeGrid';
+import { getImageCache } from './imageCache';
+import { BASE_WIDTH, drawCircle, renderPhotoOnCanvas } from '../components/PhotoEditorApi';
+
+// Hi-res target width for photos embedded in the PDF.
+// At 1600 px wide, a 280 pt landscape A4 cell prints at >400 DPI —
+// well above print quality. The on-screen canvas (300 px) was the
+// pixelation cause: it was being upscaled ~4× by the PDF/printer.
+const PDF_PHOTO_TARGET_WIDTH = 1600;
+// JPEG quality for embedded photos. 0.95 is the practical sweet spot —
+// near-lossless visually, file size manageable for 9–10 photos per page.
+const PDF_PHOTO_JPEG_QUALITY = 0.95;
 
 // Polyfill Buffer for @react-pdf/renderer
 import { Buffer } from 'buffer';
@@ -37,7 +48,14 @@ const createTextImage = (text: string, isRotated: boolean = true, fontSize: numb
     const FONT_SIZE = fontSize; // Configurable font size
     const FONT_FAMILY = 'Arial, sans-serif'; // Excellent Unicode support
     const HORIZONTAL_PADDING = 40;
-    const VERTICAL_PADDING = 12;
+    // Vertical padding around the rasterised text, in logical pt. Originally
+    // 12 pt; reduced to 4 pt (feedback 2026-05-10 — header band ate too much
+    // vertical real estate, leaving photos visibly smaller than the page
+    // could accommodate). For non-rotated headers VP becomes the entire
+    // empty space above + below the text inside the image; for rotated
+    // (portrait) headers VP becomes the gutter width, so a smaller value
+    // also gives portrait pages more room for photos.
+    const VERTICAL_PADDING = 4;
     const MIN_ROTATED_HEIGHT = 400; // Minimum height for rotated text
     
     // Configure font for text measurement
@@ -188,25 +206,71 @@ export const generatePDF = async (
     return t ? t('pdf.header.trackSet2') : 'enroute photos second set'
   }
   
-  // Get canvas data URL for a photo
-  const getPhotoDataUrl = (photoId: string, setKey: 'set1' | 'set2'): string | null => {
+  // Render the photo to a hi-res offscreen canvas and return a JPEG data URL.
+  // The on-screen grid canvas is only 300 px wide, which the PDF/printer was
+  // upscaling ~4× for an A4 cell at 300 DPI — that was the pixelation cause.
+  // Re-rendering at PDF_PHOTO_TARGET_WIDTH bakes in zoom/pan/effects/label/circle
+  // at print resolution, then the PDF embeds a sharp JPEG.
+  const getPhotoDataUrl = async (photo: ApiPhoto): Promise<string | null> => {
     try {
-      const canvasElement = document.querySelector(`canvas[data-photo-id="${photoId}"][data-set-key="${setKey}"]`) as HTMLCanvasElement;
-      if (canvasElement) {
-        return canvasElement.toDataURL('image/jpeg', 0.9);
+      // Loaded images are normally already cached by the editor grid; this
+      // reuses them and falls back to a load if missing (e.g., off-screen).
+      const cache = getImageCache();
+      const image = await cache.getImageByUrl(photo.url);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = PDF_PHOTO_TARGET_WIDTH;
+      canvas.height = Math.round(PDF_PHOTO_TARGET_WIDTH / aspectRatio);
+
+      // Pass undefined webglManager → forces CPU path. PDF generation is a
+      // one-shot operation and we want a deterministic, high-quality result
+      // without competing for the editor's WebGL context.
+      await renderPhotoOnCanvas(
+        canvas,
+        image,
+        photo.canvasState,
+        photo.label,
+        undefined,
+        undefined,
+        false,
+        null,
+        undefined,
+        aspectRatio,
+        BASE_WIDTH / aspectRatio,
+        false,
+        true,
+      );
+
+      // Circle overlay (drawn after the photo, same as the live editor).
+      const circle = photo.canvasState.circle;
+      if (circle && circle.visible) {
+        drawCircle(canvas, circle, canvas.width / BASE_WIDTH);
       }
-      
-      const fallbackCanvas = document.querySelector(`canvas[data-photo-id="${photoId}"]`) as HTMLCanvasElement;
-      if (fallbackCanvas) {
-        return fallbackCanvas.toDataURL('image/jpeg', 0.9);
-      }
-      
-      return null;
+
+      return canvas.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY);
     } catch (error) {
-      console.warn(`Failed to get canvas data for photo ${photoId}:`, error);
+      console.warn(`Failed to render hi-res photo for PDF (${photo.id}):`, error);
+      // Last-resort fallback: scrape whatever the on-screen canvas has so
+      // the PDF still produces output rather than failing the whole export.
+      try {
+        const canvasElement = document.querySelector(`canvas[data-photo-id="${photo.id}"]`) as HTMLCanvasElement | null;
+        if (canvasElement) {
+          return canvasElement.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY);
+        }
+      } catch {/* ignore */}
       return null;
     }
   };
+
+  // Landscape pages render the rotated header on the left for 4:3 photos —
+  // the FAI official answer-sheet ratio. A 3×3 grid of 4:3 photos is
+  // height-constrained on A4 landscape (grid aspect 1.333 < page aspect
+  // 1.415), so the grid already fills the page vertically with horizontal
+  // slack on the sides. Moving the header into that side slack reclaims
+  // the ~22pt top band, growing cells from ≈254×191pt to ≈261×196pt
+  // (feedback 2026-05-12). Other aspect ratios keep the top band because
+  // they don't have horizontal slack to host the rotated header.
+  const useSideHeader = layoutMode === 'landscape' && Math.abs(aspectRatio - 4/3) < 1e-6;
 
   // Clean layout calculations
   // portraitGutterWidth: measured width of rotated header gutter (portrait mode)
@@ -216,7 +280,13 @@ export const generatePDF = async (
   // landscape grid (3×3 vs 5×2) for rally turning-point pages with 10
   // photos (feedback 2026-05-03). Defaults to a value that selects the
   // legacy 3×3 to keep all existing call-sites unchanged.
-  const calculateLayout = (portraitGutterWidth: number = 15, landscapeHeaderHeight: number = 25, headerTopPad: number = 2.83, pageCount: number = 0) => {
+  const calculateLayout = (
+    portraitGutterWidth: number = 15,
+    landscapeHeaderExtent: number = 25,
+    headerTopPad: number = 2.83,
+    pageCount: number = 0,
+    landscapeHeaderPlacement: 'top' | 'left' = 'top',
+  ) => {
     if (layoutMode === 'portrait') {
       // A4 Portrait: 595 x 842 points
       const pageWidth = 595;
@@ -260,7 +330,7 @@ export const generatePDF = async (
       // `pdfLandscapeGrid.ts` so the boundary at pageCount >= 10 and the
       // centering arithmetic are unit-testable. Returns the same shape
       // the previous inline block produced.
-      return calculateLandscapeGrid(aspectRatio, landscapeHeaderHeight, headerTopPad, pageCount);
+      return calculateLandscapeGrid(aspectRatio, landscapeHeaderExtent, headerTopPad, pageCount, landscapeHeaderPlacement);
     }
   };
 
@@ -273,7 +343,7 @@ export const generatePDF = async (
   });
 
   // Create a single page (compute a local layout per page)
-  const createPage = (photoSet: ApiPhotoSet, setTitle: string, pageKey: string) => {
+  const createPage = async (photoSet: ApiPhotoSet, setTitle: string, pageKey: string) => {
     const elements: any[] = [];
     // Per-page count drives the landscape rally turning-point grid
     // selection (3×3 vs 5×2). Other modes ignore it.
@@ -322,17 +392,71 @@ export const generatePDF = async (
           })
         );
       }
-    } else {
-      // Horizontal header as images (landscape) — prepend the mode label so
-      // the reader can tell at a glance what kind of sheet they're holding.
+    } else if (useSideHeader) {
+      // Landscape + 4:3 → rotated header in a left gutter (same idea as
+      // portrait). Concatenates the same mode label + setTitle |
+      // competition string so the printed sheet reads identically; the
+      // promo line is omitted in side-mode because there is no horizontal
+      // band left to host it without overlapping the photo grid.
       const titleAndCompetition = setTitle && competitionName
         ? `${setTitle} | ${competitionName}`
         : setTitle || competitionName || '';
       const mergedTitleText = titleAndCompetition
         ? `${modeLabel} • ${titleAndCompetition}`
         : modeLabel;
-      const mergedTitleImage = createTextImage(mergedTitleText, false, 18); // Main font size
-      
+      const promotionalText = BRANDING_ENABLED
+        ? (t
+          ? `${t('pdf.promotional.line1')} ${t('pdf.promotional.line2')}`
+          : 'created using zavody.behounek.it')
+        : '';
+      const headerText = mergedTitleText
+        ? (promotionalText ? `${mergedTitleText} • ${promotionalText}` : mergedTitleText)
+        : promotionalText;
+      // 14pt font for the rotated landscape header — the gutter is short
+      // (~595pt of vertical room) so we can afford a slightly larger size
+      // than portrait (which defaults to 18pt but has 842pt to play with).
+      const headerImage = createTextImage(headerText, true, 14);
+      if (headerImage) {
+        const headerTopPad = 2.83; // ~1mm from the left edge
+        const measuredGutter = Math.max(15, Math.ceil(headerImage.width));
+        localLayout = calculateLayout(15, measuredGutter, headerTopPad, pageCount, 'left');
+        // Center the rasterised header image vertically within the page —
+        // the image is taller than its text (MIN_ROTATED_HEIGHT=400) but
+        // the text is drawn at the image's centre, so centering the
+        // image centers the text.
+        const pageHeight = 595; // A4 landscape height
+        const topPosition = (pageHeight - headerImage.height) / 2;
+        elements.push(
+          React.createElement(Image, {
+            key: `header-${pageKey}`,
+            src: headerImage.dataUrl,
+            style: {
+              position: 'absolute',
+              left: localLayout.headerX,
+              top: topPosition,
+              width: headerImage.width,
+              height: headerImage.height,
+            }
+          })
+        );
+      }
+    } else {
+      // Horizontal header as images (landscape, non-4:3) — prepend the mode
+      // label so the reader can tell at a glance what kind of sheet they're
+      // holding. 4:3 photos use the side-header branch above to reclaim the
+      // ~22pt the top band would otherwise eat (feedback 2026-05-12).
+      const titleAndCompetition = setTitle && competitionName
+        ? `${setTitle} | ${competitionName}`
+        : setTitle || competitionName || '';
+      const mergedTitleText = titleAndCompetition
+        ? `${modeLabel} • ${titleAndCompetition}`
+        : modeLabel;
+      // 11pt header font keeps the top band tight (~23pt) for non-4:3
+      // ratios that still use it. Originally reduced from 18pt (feedback
+      // 2026-05-10) when 3:2 used this branch — kept at 11pt because the
+      // smaller band is the right default for 16:9 and any future ratio.
+      const mergedTitleImage = createTextImage(mergedTitleText, false, 11);
+
       // Create two-line promotional text with half the font size
       const promotionalLines = BRANDING_ENABLED
         ? (t
@@ -384,14 +508,22 @@ export const generatePDF = async (
       }
     }
     
+    // Render hi-res photo data URLs in parallel — each photo is independent
+    // and `renderPhotoOnCanvas` is async due to the optional `intelligentResize`.
+    const photoCount = localLayout.rows * localLayout.cols;
+    const photosToRender = photoSet.photos.slice(0, photoCount);
+    const dataUrls = await Promise.all(
+      photosToRender.map((p) => (p ? getPhotoDataUrl(p) : Promise.resolve(null)))
+    );
+
     // Add photos
     for (let row = 0; row < localLayout.rows; row++) {
       for (let col = 0; col < localLayout.cols; col++) {
         const index = row * localLayout.cols + col;
         const photo = photoSet.photos[index];
-        
+
         if (photo) {
-          const dataUrl = getPhotoDataUrl(photo.id, pageKey === 'set1' ? 'set1' : 'set2');
+          const dataUrl = dataUrls[index];
           if (dataUrl) {
             const x = localLayout.startX + col * (localLayout.photoWidth + localLayout.gap);
             const y = localLayout.startY + row * (localLayout.photoHeight + localLayout.gap);
@@ -424,15 +556,15 @@ export const generatePDF = async (
 
   // Create document
   const pages = [];
-  
+
   if (set1.photos.length > 0) {
-    pages.push(createPage(set1, set1.title, 'set1'));
+    pages.push(await createPage(set1, set1.title, 'set1'));
   }
-  
+
   if (set2.photos.length > 0) {
-    pages.push(createPage(set2, set2.title, 'set2'));
+    pages.push(await createPage(set2, set2.title, 'set2'));
   }
-  
+
   const pdfDocument = React.createElement(Document, {}, pages);
 
   // Generate and download
@@ -443,8 +575,15 @@ export const generatePDF = async (
     // Mode-aware download name so a folder of exports stays sortable —
     // feedback 2026-04-23: distinguish enroute (track) PDFs from
     // turning-point PDFs in the file name itself.
+    // Feedback 2026-05-10: also embed the slugified competition name when
+    // we have one, so a folder containing exports from several events stays
+    // self-identifying. The timestamp stays in the suffix because users
+    // re-export multiple times during prep and want to disambiguate runs.
     const filenamePrefix = mode === 'turningpoint' ? 'tp-photos' : 'enroute-photos';
-    const fileName = `${filenamePrefix}-${timestamp}.pdf`;
+    const competitionSlug = competitionName ? slugifyForFilename(competitionName) : '';
+    const fileName = competitionSlug
+      ? `${filenamePrefix}-${competitionSlug}-${timestamp}.pdf`
+      : `${filenamePrefix}-${timestamp}.pdf`;
 
     // Prefer the Electron save dialog when running inside the desktop
     // bundle so the file lands in the competition's working folder

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -206,12 +206,29 @@ export const generatePDF = async (
     return t ? t('pdf.header.trackSet2') : 'enroute photos second set'
   }
   
+  // Per-photo render result. `degraded` flags the case where the hi-res
+  // render threw but the on-screen DOM fallback succeeded — the PDF will
+  // still include the cell, but at the lower resolution of the live grid
+  // canvas, which is a visible quality regression vs the hi-res path.
+  // `failed` flags the case where BOTH paths failed and the cell would
+  // otherwise be silently omitted from the printed answer-sheet.
+  type PhotoRenderResult =
+    | { kind: 'ok'; dataUrl: string }
+    | { kind: 'degraded'; dataUrl: string; photoId: string }
+    | { kind: 'failed'; photoId: string; error: unknown };
+
   // Render the photo to a hi-res offscreen canvas and return a JPEG data URL.
   // The on-screen grid canvas is only 300 px wide, which the PDF/printer was
   // upscaling ~4× for an A4 cell at 300 DPI — that was the pixelation cause.
   // Re-rendering at PDF_PHOTO_TARGET_WIDTH bakes in zoom/pan/effects/label/circle
   // at print resolution, then the PDF embeds a sharp JPEG.
-  const getPhotoDataUrl = async (photo: ApiPhoto): Promise<string | null> => {
+  //
+  // Returns a tagged result rather than `null` on failure so the page-level
+  // caller can collect failures and surface them to the user. The previous
+  // shape (`Promise<string | null>`) let a render failure silently omit a
+  // photo cell from the printed sheet — for a competition answer-sheet
+  // workflow that's a correctness bug, not cosmetic (feedback 2026-05-12).
+  const getPhotoDataUrl = async (photo: ApiPhoto): Promise<PhotoRenderResult> => {
     try {
       // Loaded images are normally already cached by the editor grid; this
       // reuses them and falls back to a load if missing (e.g., off-screen).
@@ -247,20 +264,33 @@ export const generatePDF = async (
         drawCircle(canvas, circle, canvas.width / BASE_WIDTH);
       }
 
-      return canvas.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY);
+      return { kind: 'ok', dataUrl: canvas.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY) };
     } catch (error) {
       console.warn(`Failed to render hi-res photo for PDF (${photo.id}):`, error);
       // Last-resort fallback: scrape whatever the on-screen canvas has so
       // the PDF still produces output rather than failing the whole export.
+      // Flagged as `degraded` so the caller can warn the user that some
+      // photos printed at the lower live-grid resolution.
       try {
         const canvasElement = document.querySelector(`canvas[data-photo-id="${photo.id}"]`) as HTMLCanvasElement | null;
         if (canvasElement) {
-          return canvasElement.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY);
+          return {
+            kind: 'degraded',
+            dataUrl: canvasElement.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY),
+            photoId: photo.id,
+          };
         }
       } catch {/* ignore */}
-      return null;
+      return { kind: 'failed', photoId: photo.id, error };
     }
   };
+
+  // Collected across the whole `generatePDF` run so the caller (UI button
+  // handler) can surface a single combined alert at the end instead of one
+  // per page. `failed` is the show-stopper case: cell would be blank.
+  // `degraded` is the soft-warning case: cell is present but lower quality.
+  const renderFailures: { photoId: string; error: unknown }[] = [];
+  const renderDegraded: string[] = [];
 
   // Landscape pages render the rotated header on the left for 4:3 photos —
   // the FAI official answer-sheet ratio. A 3×3 grid of 4:3 photos is
@@ -512,26 +542,37 @@ export const generatePDF = async (
     // and `renderPhotoOnCanvas` is async due to the optional `intelligentResize`.
     const photoCount = localLayout.rows * localLayout.cols;
     const photosToRender = photoSet.photos.slice(0, photoCount);
-    const dataUrls = await Promise.all(
+    const renderResults: (PhotoRenderResult | null)[] = await Promise.all(
       photosToRender.map((p) => (p ? getPhotoDataUrl(p) : Promise.resolve(null)))
     );
 
-    // Add photos
+    // Add photos. Use the tagged result so render failures don't silently
+    // omit cells from the printed sheet — failures get tracked at the
+    // generatePDF level and surfaced to the user as a single combined alert
+    // after both pages have rendered.
     for (let row = 0; row < localLayout.rows; row++) {
       for (let col = 0; col < localLayout.cols; col++) {
         const index = row * localLayout.cols + col;
         const photo = photoSet.photos[index];
 
         if (photo) {
-          const dataUrl = dataUrls[index];
-          if (dataUrl) {
+          const result = renderResults[index];
+          if (!result) continue; // index past photos[].length; not a failure
+          if (result.kind === 'failed') {
+            renderFailures.push({ photoId: result.photoId, error: result.error });
+            continue;
+          }
+          if (result.kind === 'degraded') {
+            renderDegraded.push(result.photoId);
+          }
+          {
             const x = localLayout.startX + col * (localLayout.photoWidth + localLayout.gap);
             const y = localLayout.startY + row * (localLayout.photoHeight + localLayout.gap);
             
             elements.push(
               React.createElement(Image, {
                 key: `photo-${pageKey}-${index}`,
-                src: dataUrl,
+                src: result.dataUrl,
                 style: {
                   position: 'absolute',
                   left: x,
@@ -566,6 +607,32 @@ export const generatePDF = async (
   }
 
   const pdfDocument = React.createElement(Document, {}, pages);
+
+  // Surface per-photo render failures BEFORE we ship a partial PDF to the
+  // user. Previously a thrown render would log a console.warn and produce a
+  // PDF with silently blank cells — for an FAI answer-sheet, that's a
+  // correctness bug (feedback 2026-05-12). Caller (UI button handler) is
+  // expected to wrap `generatePDF` in try/catch and alert on this error.
+  if (renderFailures.length > 0) {
+    const ids = renderFailures.map(f => f.photoId).join(', ');
+    const err = new Error(
+      `PDF export aborted: ${renderFailures.length} photo(s) failed to render (${ids}). ` +
+      `Re-open the affected photos and try again.`,
+    );
+    // Attach the underlying error array for callers that want to log or
+    // present the original cause chain.
+    (err as Error & { renderFailures?: unknown[] }).renderFailures = renderFailures;
+    throw err;
+  }
+  // Degraded path: hi-res render failed but the on-screen fallback succeeded,
+  // so the PDF still has every cell — just at the lower live-grid resolution
+  // for the affected ids. Log so this shows up in DevTools without blocking
+  // the export; UI can decide whether to surface a soft warning.
+  if (renderDegraded.length > 0) {
+    console.warn(
+      `[generatePDF] ${renderDegraded.length} photo(s) used the DOM-canvas fallback (lower resolution): ${renderDegraded.join(', ')}`,
+    );
+  }
 
   // Generate and download
   try {

--- a/frontend/photo-helper/src/utils/pdfLandscapeGrid.ts
+++ b/frontend/photo-helper/src/utils/pdfLandscapeGrid.ts
@@ -7,16 +7,25 @@
  *
  * Inputs:
  *   • aspectRatio — photo aspect ratio (width / height)
- *   • landscapeHeaderHeight — measured height of the rasterised header
- *   • headerTopPad — top padding for header text in points (~1mm)
+ *   • headerExtent — measured size of the rasterised header (height when
+ *     placed on top, width when placed on the left)
+ *   • headerPad — padding between the header text and the photo grid (~1mm)
  *   • pageCount — number of photos on this specific page; >= 10 triggers
  *     5×2, else 3×3. Per-page so set1=10 / set2=7 mixes (5×2 page + 3×3
  *     page with 2 trailing empties) work as expected.
+ *   • headerPlacement — 'top' (default, full-width band above grid) or
+ *     'left' (rotated gutter beside grid, like portrait). The 'left'
+ *     variant is used for 4:3 photos (the FAI official answer-sheet
+ *     ratio) so the rotated header lives in the horizontal slack the
+ *     height-constrained 4:3 grid leaves on the sides, reclaiming the
+ *     ~22pt the top band would otherwise eat (feedback 2026-05-12).
  */
 export const A4_LANDSCAPE_WIDTH_PT = 842;
 export const A4_LANDSCAPE_HEIGHT_PT = 595;
 export const PDF_LANDSCAPE_GAP_PT = 2.83; // ~1mm in points
 export const PDF_LANDSCAPE_MARGIN_PT = 0; // edge-less layout
+
+export type LandscapeHeaderPlacement = 'top' | 'left';
 
 export type LandscapeGridLayout = {
   photoWidth: number;
@@ -27,18 +36,21 @@ export type LandscapeGridLayout = {
   cols: number;
   rows: number;
   headerY: number;
+  headerX: number;
+  headerPlacement: LandscapeHeaderPlacement;
 };
 
 export function calculateLandscapeGrid(
   aspectRatio: number,
-  landscapeHeaderHeight: number,
-  headerTopPad: number,
+  headerExtent: number,
+  headerPad: number,
   pageCount: number,
+  headerPlacement: LandscapeHeaderPlacement = 'top',
 ): LandscapeGridLayout {
   const pageWidth = A4_LANDSCAPE_WIDTH_PT;
   const pageHeight = A4_LANDSCAPE_HEIGHT_PT;
   const margin = PDF_LANDSCAPE_MARGIN_PT;
-  const headerHeight = Math.max(0, landscapeHeaderHeight || 0);
+  const headerSize = Math.max(0, headerExtent || 0);
   const gap = PDF_LANDSCAPE_GAP_PT;
 
   // pageCount >= 10 → 5×2; else 3×3. Trigger purely on `pageCount` so the
@@ -47,8 +59,14 @@ export function calculateLandscapeGrid(
   const cols = pageCount >= 10 ? 5 : 3;
   const rows = pageCount >= 10 ? 2 : 3;
 
-  const availableWidth = pageWidth - 2 * margin;
-  const availableHeight = pageHeight - headerTopPad - headerHeight;
+  // Header eats width when on the left, height when on top. The opposite
+  // axis is left untouched so the grid can reclaim it.
+  const availableWidth = headerPlacement === 'left'
+    ? pageWidth - 2 * margin - headerPad - headerSize
+    : pageWidth - 2 * margin;
+  const availableHeight = headerPlacement === 'left'
+    ? pageHeight - 2 * margin
+    : pageHeight - headerPad - headerSize;
 
   const photoWidth = Math.floor((availableWidth - (cols - 1) * gap) / cols);
   const photoHeight = Math.floor((availableHeight - (rows - 1) * gap) / rows);
@@ -58,8 +76,25 @@ export function calculateLandscapeGrid(
   const correctedWidth = correctedHeight * aspectRatio;
 
   const totalWidth = correctedWidth * cols + gap * (cols - 1);
-  const startX = margin + (availableWidth - totalWidth) / 2;
-  const startY = headerTopPad + headerHeight;
+  const totalHeight = correctedHeight * rows + gap * (rows - 1);
+
+  // Left header → grid is shifted right past the gutter and centered
+  // vertically. Top header → original behaviour: grid hugs the header
+  // top-down and centers horizontally only.
+  const startX = headerPlacement === 'left'
+    ? headerPad + headerSize + (availableWidth - totalWidth) / 2
+    : margin + (availableWidth - totalWidth) / 2;
+  const startY = headerPlacement === 'left'
+    ? margin + (availableHeight - totalHeight) / 2
+    : headerPad + headerSize;
+
+  // `headerX`/`headerY` describe where the caller should place the
+  // rasterised header image. For 'top' the header sits flush against the
+  // top-pad on the left side. For 'left' it hugs the left edge and the
+  // caller decides the vertical centering (depends on the rasterised
+  // image height, which lives at the caller).
+  const headerY = headerPlacement === 'left' ? 0 : headerPad;
+  const headerX = headerPlacement === 'left' ? headerPad : 0;
 
   return {
     photoWidth: correctedWidth,
@@ -69,6 +104,8 @@ export function calculateLandscapeGrid(
     gap,
     cols,
     rows,
-    headerY: headerTopPad,
+    headerY,
+    headerX,
+    headerPlacement,
   };
 }

--- a/frontend/shared-storage/src/index.ts
+++ b/frontend/shared-storage/src/index.ts
@@ -26,6 +26,7 @@ export type {
 } from './types';
 
 export { dirnameOf } from './pathUtils';
+export { slugifyForFilename } from './slugify';
 
 import type { StorageInterface, StorageType } from './types';
 import { OPFSStorage, opfsStorage } from './opfsStorage';

--- a/frontend/shared-storage/src/slugify.ts
+++ b/frontend/shared-storage/src/slugify.ts
@@ -4,12 +4,22 @@
  *   "Plzeň 2026"          → "plzen-2026"
  *   "Brno – jaro / 2026"  → "brno-jaro-2026"
  *   "  ___  "             → ""   (caller decides on a fallback)
+ *   "Москва 2026"         → "2026"  (Cyrillic letters dropped — see below)
+ *   "北京"                 → ""     (non-Latin scripts collapse to empty)
  *
  * Steps: lowercase → NFD normalise → strip combining marks (diacritics,
- * U+0300..U+036F) → collapse any run of non-alphanumeric characters to a
+ * U+0300..U+036F) → collapse any run of non-`[a-z0-9]` characters to a
  * single dash → trim leading/trailing dashes. Returns an empty string when
  * the input slugs down to nothing so callers can fall back to a default
  * filename.
+ *
+ * Scope: this handles Latin diacritics (Czech/Slovak š,č,ř,ž,ý,á,í,é,ú,ů,ó,
+ * ď,ť,ň,ľ,ĺ,ŕ, plus all other NFD-decomposable Latin scripts). Non-Latin
+ * scripts (Cyrillic, Greek, CJK, Arabic, …) are NOT transliterated — they
+ * are simply dropped, since transliteration is locale-dependent and a
+ * filename slug isn't the right layer to encode language policy. Callers
+ * MUST check for an empty result and fall back to a default filename when
+ * the source is non-Latin only.
  */
 export function slugifyForFilename(input: string): string {
   return input

--- a/frontend/shared-storage/src/slugify.ts
+++ b/frontend/shared-storage/src/slugify.ts
@@ -1,0 +1,21 @@
+/**
+ * Slugify a competition (or any) name for use in exported file names.
+ *
+ *   "Plzeň 2026"          → "plzen-2026"
+ *   "Brno – jaro / 2026"  → "brno-jaro-2026"
+ *   "  ___  "             → ""   (caller decides on a fallback)
+ *
+ * Steps: lowercase → NFD normalise → strip combining marks (diacritics,
+ * U+0300..U+036F) → collapse any run of non-alphanumeric characters to a
+ * single dash → trim leading/trailing dashes. Returns an empty string when
+ * the input slugs down to nothing so callers can fall back to a default
+ * filename.
+ */
+export function slugifyForFilename(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Summary
- **map-corridors:** configurable marker sizes (`markerSizes.ts`) and KML export filenames slugified via shared `slugifyForFilename` — survives Cyrillic / diacritic / whitespace round-trips. Test fixtures cover the rename path.
- **shared-storage:** extract `slugifyForFilename` into its own module so both apps share one definition.
- **photo-helper:** default aspect ratio reverted from 3:2 to **4:3** (matches FAI official answer-sheet, 87.3×65.1mm ≈ 1.341). Landscape 4:3 pages render a **rotated header in the left gutter** instead of a top band — grid claims the full 595pt vertical extent, cells grow ≈3%. `calculateLandscapeGrid` gains a `headerPlacement: 'top' | 'left'` param with pinned-gain tests. **Photo number labels** doubled in size (font 34 → 68) and no longer bold. **"Sync corner to all photos"** action in PhotoControls so the label corner can be propagated across both sets in one click.
- **desktop:** version bump to 2.8.13 (unpacked + portable .exe artifacts produced locally).

## Test plan
- [ ] `pnpm --filter @airq/photo-helper test` — 236/236 green locally (incl. new `headerPlacement: 'left'` cases pinning 4:3 cell-size gain)
- [ ] `pnpm --filter @airq/map-corridors test` — green incl. new `slugify.test.ts`
- [ ] `pnpm --filter @airq/photo-helper tsc --noEmit` — clean
- [ ] Manual: precision track set defaults to 4:3, generates a PDF where photos fill A4 vertically with ~10mm side margins (matches official sheet)
- [ ] Manual: rally turning-point landscape PDF renders rotated title on the left, photo numbers visibly larger
- [ ] Manual: "Sync corner to all photos" propagates across set1 + set2
- [ ] Manual: KML export of a Cyrillic-named corridor lands a slugified filename on disk
- [ ] Manual: launch the portable v2.8.13 .exe — landing page, both sub-apps, language switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)