### PR TITLE
chore(deps): migrate pnpm overrides to pnpm-workspace.yaml + pin ip-address >=10.1.1 #minor

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,27 +7,5 @@
     "dev:map-corridors": "pnpm --filter @airq/map-corridors dev",
     "build:all": "pnpm -r build",
     "lint": "pnpm -r lint"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "canvas",
-      "core-js",
-      "electron",
-      "electron-winstaller",
-      "esbuild"
-    ],
-    "overrides": {
-      "@xmldom/xmldom": "0.8.13",
-      "postcss": "8.5.10",
-      "flatted": "^3.4.2",
-      "lodash": "^4.18.1",
-      "picomatch": "^4.0.4",
-      "tar": "^7.5.11",
-      "yaml@<1.10.3": "^1.10.3",
-      "brace-expansion@<1.1.13": "^1.1.13",
-      "brace-expansion@>=2.0.0 <2.0.3": "^2.0.3",
-      "brace-expansion@>=4.0.0 <5.0.5": "^5.0.5",
-      "protocol-buffers-schema@<3.6.1": "3.6.1"
-    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
   brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
   protocol-buffers-schema@<3.6.1: 3.6.1
+  ip-address@<10.1.1: ^10.1.1
 
 importers:
 
@@ -2654,8 +2655,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
@@ -7394,7 +7395,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -8241,7 +8242,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sort-asc@0.2.0: {}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -4,3 +4,48 @@ packages:
   - photo-helper
   - map-corridors
   - desktop
+
+# `onlyBuiltDependencies` allowlist — packages with `postinstall`/`install`
+# lifecycle scripts that pnpm v10+ blocks by default for supply-chain safety.
+# Each entry below has been individually reviewed; everything else stays
+# blocked. Migrated from `frontend/package.json` (pnpm.onlyBuiltDependencies)
+# at PR #61 — pnpm v10 deprecated that location and v11 stops honouring it.
+onlyBuiltDependencies:
+  - canvas
+  - core-js
+  - electron
+  - electron-winstaller
+  - esbuild
+
+# Security overrides. These pin transitive resolutions to versions that
+# carry CVE patches. The conditional `pkg@<version` syntax means the
+# override only fires when a transitive resolution would otherwise yield
+# the vulnerable range — so it's a no-op when upstream has already moved
+# on, and we don't have to remember to remove entries. Carets are
+# intentional here (unlike direct-dep deps where exact pinning is the
+# default per global CLAUDE.md): an override is itself a security pin, so
+# `^10.1.1` means "the lowest patched 10.x or newer", which is the
+# tightest range that still allows future patch-level updates without
+# requiring a manual revisit.
+#
+# Migrated from `frontend/package.json` (pnpm.overrides) at PR #61 — same
+# pnpm v10 deprecation reason as above.
+overrides:
+  '@xmldom/xmldom': '0.8.13'
+  postcss: '8.5.10'
+  flatted: '^3.4.2'
+  lodash: '^4.18.1'
+  picomatch: '^4.0.4'
+  tar: '^7.5.11'
+  'yaml@<1.10.3': '^1.10.3'
+  'brace-expansion@<1.1.13': '^1.1.13'
+  'brace-expansion@>=2.0.0 <2.0.3': '^2.0.3'
+  'brace-expansion@>=4.0.0 <5.0.5': '^5.0.5'
+  'protocol-buffers-schema@<3.6.1': '3.6.1'
+  # CVE-2026-42338 / GHSA-v2v4-37r5-5v8g — XSS in ip-address Address6
+  # HTML-emitting methods. Patched in 10.1.1. We only pull this in
+  # transitively via electron-builder → node-gyp → socks-proxy-agent;
+  # no consumer in our code calls the vulnerable methods (group/link/
+  # spanAll/parseMessage), so real-world exposure here is zero — the
+  # override is defense-in-depth + cleans the Dependabot alert.
+  'ip-address@<10.1.1': '^10.1.1'


### PR DESCRIPTION
## Summary

- **Migrate** `pnpm.overrides` + `pnpm.onlyBuiltDependencies` from `frontend/package.json` to `frontend/pnpm-workspace.yaml`. pnpm v10 prints a deprecation warning on every install for the package.json location; v11 stops honouring it. Overrides do currently take effect on v10.30.0, so this is forward-compatible cleanup, not a bug-fix.
- **Pin** `ip-address >= 10.1.1` to clear Dependabot alert #147 (CVE-2026-42338, XSS in `Address6` HTML-emitting methods, medium / CVSS 5.3). We only pull `ip-address` in transitively via the `electron-builder → node-gyp → socks-proxy-agent → socks` chain at build time; none of those consumers call the vulnerable methods, so real-world exposure here is zero. Override is defense-in-depth + alert hygiene.

## Lockfile delta

Surgical — only `ip-address@10.1.0 → 10.2.0`, single consumer `socks@2.8.7` re-resolved. No collateral churn.

```
ip-address@10.2.0
└─ socks@2.8.7 → socks-proxy-agent → @npmcli/agent → make-fetch-happen
   → node-gyp → @electron/rebuild → app-builder-lib → electron-builder
      └─ @airq/desktop (devDependencies)
```

## Test plan

- [x] `pnpm install` — deprecation warning gone (was: `WARN The field pnpm.overrides was found in frontend/package.json. This will not take effect.`)
- [x] `pnpm install --frozen-lockfile` — lockfile in sync (CI parity)
- [x] `pnpm -r why ip-address` — single resolution, `10.2.0` (>= patched 10.1.1)
- [x] `pnpm -r test` — 530/530 green (photo-helper 252, map-corridors 239, desktop 39)
- [x] `tsc --noEmit` — clean on photo-helper, map-corridors, shared-storage
- [ ] After merge: confirm Dependabot alert #147 auto-closes once the new lockfile reaches main

## Notes

- `packageManager` field stays in `package.json` — it's a Corepack convention, not a pnpm one.
- The conditional `ip-address@<10.1.1: ^10.1.1` syntax matches the existing pattern (`yaml@<1.10.3: ^1.10.3`, `brace-expansion@<1.1.13: ^1.1.13`, etc.) — the override only fires when transitive resolution would otherwise yield the vulnerable range, so it auto-no-ops once upstream catches up.
- Carets in security overrides are intentional (vs. the exact-version pinning rule for direct deps in CLAUDE.md): an override is itself a security pin, and `^10.1.1` means "tightest range that still allows future patch-level updates without a manual revisit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)