### PR TITLE
feat(photo-helper): candidate photo pool for cull-from-many workflow #minor

### DIFF
--- a/docs/CANDIDATE_PHOTOS.md
+++ b/docs/CANDIDATE_PHOTOS.md
@@ -1,0 +1,292 @@
+# Candidate Photos — design doc
+
+Status: implementation in PR `feat/candidate-photos`. Doc is the single source
+of truth for the contract; if implementation diverges, update the doc.
+
+---
+
+## Why
+
+Today the photo-helper conflates two things:
+
+- **Workspace** — the photos the user is considering.
+- **Print layout** — the photos that will appear on the PDF.
+
+Both live in the same 9-or-10-slot grid. Drop more than capacity and the user
+gets an error. So they pre-cull mentally before dragging in, and any post-drop
+"actually, let's try this other shot" requires deleting one slot photo before
+adding the candidate. The actual competition workflow is the opposite:
+shoot/collect 20–40 candidate photos, then cull to 9 (or 9+9) once you can see
+edits applied.
+
+The fix is a **candidate pool**: a slotless holding area, visually distinct
+from the final grid, that participates in the same edit model but is not
+printed.
+
+## Decisions locked
+
+| Decision | Choice | Why |
+|---|---|---|
+| Drop heuristic | Smart: `>= capacity → candidates`, `< capacity → slots` | No new prompt; today's small-drop UX preserved |
+| Reject state | 3-state: `pick` / `neutral` / `reject` | User asked for it. Rejects stay visible but greyed; filter to hide |
+| Compare view | Out of scope for v1 | User said deferrable |
+| Post-export cleanup | Offer to delete unused candidates after successful PDF | Storage hygiene |
+| Pool scope | Global per session (not per mode) | Simpler; mode-switching while culling is rare. v2 can split if needed |
+| PR strategy | Single feature PR, draft | User asked |
+
+## Out of scope for v1
+
+- Side-by-side compare modal with synced zoom
+- "Apply edit to all candidates" (apply-to-all stays slot-only)
+- Auto-pick suggestions (sharpness/exposure scoring)
+- Keyboard shortcuts (P/X/U)
+- Cross-app candidate sharing with map-corridors
+
+---
+
+## Data model
+
+### Type changes (`src/types/api.ts`)
+
+```ts
+export type CandidateFlag = 'pick' | 'neutral' | 'reject';
+
+export interface ApiPhoto {
+  // ...existing fields unchanged
+  flag?: CandidateFlag;          // only meaningful while in candidates pool
+}
+
+export interface CandidatePool {
+  photos: ApiPhoto[];            // unordered logically; preserves insert order
+}
+
+export interface ApiPhotoSession {
+  // ...existing fields unchanged
+  sets: { set1, set2 };
+  candidates?: CandidatePool;    // NEW — optional for backward compat
+  setsTrack?, setsTurning?       // unchanged
+}
+```
+
+**Why optional `candidates`:** older sessions on disk don't have it. Code
+that reads it does `session.candidates?.photos ?? []`. Code that writes it
+always normalizes to `{ photos: [] }` so subsequent reads are stable.
+
+**Why optional `flag`:** when a photo is in a slot, the flag is meaningless
+(slot membership is the commitment). When promoted from tray → slot, flag is
+cleared. When demoted from slot → tray, flag is set to `'pick'` (it was good
+enough to slot once, so it's a strong candidate by default).
+
+**Why global, not per-mode:** the mode buckets (`setsTrack`, `setsTurning`)
+exist so a mode switch preserves slot membership. Candidates are a workspace
+concept — the user is choosing photos for *this competition*, not for a
+specific mode. Splitting candidates per mode complicates the model and only
+helps users who mid-cull switch from rally-track to turning-point on the same
+batch, which is an edge case. Keep it simple.
+
+### Persistence
+
+`competitionService.ts` already touches `sets`, `setsTrack`, `setsTurning` in:
+
+- `sanitizeSessionForStorage` — strip `blob:` URLs before write
+- `saveSessionPhotos` — write photo blobs to disk
+- `loadSessionPhotos` — rebuild `blob:` URLs on load
+
+All three extend to handle `session.candidates` the same way. The candidate
+photos use the same `photos/` directory in the competition folder — photo IDs
+are unique across slots and candidates, so there's no collision.
+
+`calculatePhotoCount` is **unchanged** — competition metadata's `photoCount`
+is the *slot* count (what the user sees as "ready to print"). Candidate count
+is shown separately in the tray header.
+
+---
+
+## UI
+
+### Tray placement
+
+Above Set 1 in `AppApi.tsx`. Hidden when `candidates.photos.length === 0` so
+existing UX is untouched for users who don't use the feature.
+
+```
+┌─ Candidates (23 total) ──────────────────────────────────── [collapse] ┐
+│ Filter: [All ▼] · Sort: [Upload time ▼]                                 │
+│   ★ Picks (8) · Neutral (12) · ✗ Rejects (3)                            │
+│ [thumb][thumb][thumb][thumb][thumb][thumb][thumb][thumb][thumb] →       │
+│ [thumb][thumb][thumb][thumb][thumb][thumb][thumb][thumb][thumb] →       │
+└──────────────────────────────────────────────────────────────────────────┘
+
+┌─ Set 1: SP – TP3 ────────────────────────────────────────────────────┐
+│ [A][B][C][D][E][F][G][H][I]                                          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Thumb anatomy
+
+- Image
+- Small flag badge: `★` (yellow), no badge (neutral), `✗` (red)
+- Click → opens the same `PhotoEditorApi` modal as slot photos
+- Right-click / long-press → context menu (Pick / Neutral / Reject / Delete / Send to Set 1 / Send to Set 2)
+- Draggable → drag source for slot promotion
+
+### Filter
+
+Click a pill (or use the dropdown) to filter the tray view:
+
+| Filter | Shows |
+|---|---|
+| All (default) | Picks + Neutral; Rejects greyed (50% opacity) |
+| Picks | Only `flag === 'pick'` |
+| Neutral | Only `flag !== 'pick' && flag !== 'reject'` |
+| Rejects | Only `flag === 'reject'` |
+| Hide rejects | Picks + Neutral, no greyed rejects |
+
+V1 ships **All** + **Hide rejects** toggle. Pill filters can come later if
+the toggle isn't enough.
+
+### Sort
+
+V1: upload time only (filename as tiebreaker). User-defined drag-reorder
+within the tray is a v1 stretch — implement if drag wiring is already in
+place; otherwise defer.
+
+---
+
+## Drag/drop interactions
+
+`dataTransfer` payload encodes source via a `kind` field:
+
+```
+text/plain  = JSON.stringify({ kind: 'slot', setKey, index, photoId })
+              or { kind: 'tray', photoId }
+```
+
+| Source | Target | Effect |
+|---|---|---|
+| Tray thumb | Empty slot | Promote: insert at slot index, shift others; clear flag |
+| Tray thumb | Occupied slot | **Swap**: target slot's photo goes back to tray as `pick`; tray photo takes the slot, flag cleared |
+| Slot photo | Tray (any drop within tray container) | Demote: photo enters tray with `flag = 'pick'` |
+| Slot photo | Slot (same set) | Existing reorder behavior, unchanged |
+| Slot photo | Slot (other set, rally-track) | Out of scope — two-step (slot → tray → slot) |
+| Tray thumb | Tray | No-op in v1 (manual sort deferred) |
+
+### Smart drop heuristic
+
+Pre-processing of incoming files in `addPhotosToSet` and the initial-drop path
+(`onInitialFilesDropped`):
+
+```
+remaining = capacity(targetSet) - currentPhotoCount(targetSet)
+if files.length <= remaining:
+    fill targetSet (today's behavior)
+else:
+    all files → candidates
+```
+
+For the initial empty-session drop (no specific target set), the target is
+`set1`. So dropping 30 files on a fresh competition → all to candidates. 9
+files → fills set1.
+
+For the rally turning-point initial drop, the existing `distributeRallyDrop`
+helper distributes across set1 + set2 (capacity = 20). The smart heuristic
+applies at that total-capacity level: drop ≤ 20 distributes; drop > 20 routes
+to candidates.
+
+---
+
+## Editor modal behavior
+
+The modal works identically for tray and slot photos. The only differences:
+
+- **Label** passed to the editor is `''` for tray photos (no slot index yet).
+  The label-position picker still works; canvasState persists.
+- **"Apply to all"** in the modal applies to **slots only** (v1). Tray photos
+  are skipped. A tooltip clarifies: "Applies to photos in print sets, not
+  candidates."
+
+Edits to tray photos travel with the photo id when promoted. `canvasState` is
+already on the photo object, so this is automatic.
+
+---
+
+## PDF export
+
+`buildPdfSets` is **unchanged**. It reads only `session.sets.set1` and
+`set2`. Tray photos never reach the PDF.
+
+Post-export, if the export succeeds and the tray is non-empty:
+
+```
+Dialog: "Delete N unused candidate photos?"
+Body:   "You have N candidate photos that aren't in the final set.
+         Removing them frees ~NN MB and keeps storage tidy."
+Buttons: [Keep candidates]  [Delete N candidates]
+```
+
+Estimate ~3 MB per photo (matches the existing `estimateCompetitionSize`
+heuristic). Dialog dismisses if the user closes the PDF preview without
+acting.
+
+---
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Mode switch (track ↔ turningpoint) | Candidates persist (global pool). Slot transitions via existing per-mode bucket logic. |
+| Discipline = precision (single-set track) | "Send to Set 2" hidden in context menu. Tray + Set 1 only. |
+| Layout flip with slot at threshold | `getGridCapacity` guard in `addPhotosToSet` still fires. Swap with a slot photo at the 9-vs-10 boundary uses the same guard. |
+| Reset session | Existing reset clears slots; extend to clear candidates and revoke their blob URLs. |
+| Delete competition | Existing path deletes the competition dir incl. all photos. Unchanged. |
+| Storage limit reached | Existing `isStorageLow` warning fires. New: tray header shows "⚠ Many candidates (47, ~140 MB)" once count > 30 OR `isStorageLow === true`. |
+| Shuffle button | Unchanged — shuffles slots only. Tooltip clarifies. |
+| Apply-to-all (brightness etc.) | Slot-only, as today. Out of scope to extend to candidates. |
+| 20MB image cap | Unchanged — applies whether dropping to slots or candidates. |
+| Blob URL lifecycle | Tray photos get URLs the same way slot photos do (`getPhotoURL`). On removal: revoke. On mode switch: candidates' URLs are NOT revoked (global pool, stays loaded). |
+
+---
+
+## Implementation phasing (single PR, ordered commits)
+
+1. Types (`api.ts`)
+2. `competitionService` persistence (sanitize / save / load)
+3. Hook surface: `useCompetitionSystem` candidate operations + smart-drop
+4. Hook surface: `usePhotoSessionOPFS` mirror (legacy path parity)
+5. `CandidateTray` component
+6. `PhotoGridApi` drop-target accepts `kind=tray`; tray accepts `kind=slot`
+7. `AppApi` mounts tray, wires actions, post-export cleanup dialog
+8. Locales (en + cs with diacritics)
+9. Unit tests (smart-drop, state transitions, persistence roundtrip)
+
+Single PR, single squash on merge.
+
+---
+
+## Test plan
+
+### Unit (vitest)
+
+- `smartDropRoute.test.ts` — given (files, target-set, currentCount, capacity), return either `{ kind: 'slot', files }` or `{ kind: 'tray', files }`. Cover boundary at exactly `capacity`.
+- `candidateTransitions.test.ts` — `promoteToSlot`, `demoteToTray`, `swap`, `setFlag` — start state → end state on a session shape.
+- `competitionServiceRoundtrip.test.ts` — sanitize → write JSON → read JSON → load. Candidates survive with empty URLs after sanitize, get URLs back on load.
+
+### Manual smoke (recorded as a check in the PR)
+
+1. Drop 30 photos on empty session → all in tray, slots empty.
+2. Drag 5 tray thumbs into set1 → labels A–E appear.
+3. Drag a slot photo back to tray → label disappears; tray badge shows `★`.
+4. Drag a tray thumb onto an occupied slot → swap; old slot photo back in tray.
+5. Flag a tray photo as reject → greyed, badge `✗`. Toggle "Hide rejects" → vanishes.
+6. Export PDF → only slot photos appear. Dialog offers to delete N candidates.
+7. Switch mode track ↔ turningpoint → candidates unchanged; slots swap as today.
+8. Refresh page → tray repopulates from OPFS with flags + canvasState intact.
+
+---
+
+## Risks / future work
+
+- **OPFS quota:** 30+ candidates × ~3 MB = ~100 MB. Plus existing slot photos. The `isStorageLow` warning handles this, but if it becomes a real pain point, candidate photos could be stored at a lower resolution (decode + downscale on import) since they're only seen as thumbnails. Out of scope for v1.
+- **Per-mode candidates:** if users complain about cross-mode pool confusion, split into `setsTrack.candidates` / `setsTurning.candidates` mirroring slots. Migration is straightforward.
+- **Compare view:** the deferred 1v1 / 2x2 compare modal would slot in naturally — open from a multi-select in the tray.
+- **Auto-suggest picks:** ML/heuristic-based pick scoring (sharpness, faces, exposure) — possible future.

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.8.13",
+  "version": "2.9.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/photo-helper/package.json
+++ b/frontend/photo-helper/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/vite": "^4.1.11",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.1.0",
+    "@testing-library/user-event": "14.5.2",
     "@types/node": "^25.0.3",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -61,6 +61,7 @@ import type { Discipline } from './utils/parseDiscipline';
 import { buildPdfSets } from './utils/buildPdfSets';
 import { pickEffectiveLayout } from './utils/pickEffectiveLayout';
 import { deriveSet2FromSet1 } from './utils/autoPrefillSetTitle';
+import { getGridCapacity } from './utils/getGridCapacity';
 import type { ApiPhoto } from './types/api';
 
 function AppApi() {
@@ -167,12 +168,34 @@ function AppApi() {
   // like the photos "disappeared" from the user's perspective.
   const [dropToast, setDropToast] = useState<{ count: number } | null>(null);
 
+  // Hint snackbar for cross-set slot→slot drags (out of scope in v1 per
+  // docs/CANDIDATE_PHOTOS.md). Previously a silent no-op (PR #62 review I4).
+  const [crossSetHintOpen, setCrossSetHintOpen] = useState(false);
+
   // Wrapper around the hook's `addPhotosToSet` that surfaces the smart-drop
   // routing result. Calling sites stay simple — they just pass files + set.
   const handleAddToSet = async (files: File[], setKey: 'set1' | 'set2') => {
-    const result = await addPhotosToSet(files, setKey);
-    if (result && (result as any).routedTo === 'tray' && (result as any).count > 0) {
-      setDropToast({ count: (result as any).count });
+    try {
+      const result = await addPhotosToSet(files, setKey);
+      if (result && result.routedTo === 'tray' && result.count > 0) {
+        setDropToast({ count: result.count });
+      }
+    } catch (err) {
+      console.error('handleAddToSet failed:', err);
+    }
+  };
+
+  // Initial drop for rally turning-point distributes across set1+set2; on total
+  // overflow the hook routes everything to the candidate tray. Surface the toast
+  // the same way `handleAddToSet` does (PR #62 review I1).
+  const handleInitialTurningPointDrop = async (files: File[]) => {
+    try {
+      const result = await addPhotosToTurningPoint(files);
+      if (result && result.routedTo === 'tray' && result.count > 0) {
+        setDropToast({ count: result.count });
+      }
+    } catch (err) {
+      console.error('handleInitialTurningPointDrop failed:', err);
     }
   };
 
@@ -266,24 +289,41 @@ function AppApi() {
     setSelectedPhoto({ photo, setKey: 'candidates', label: '' });
   };
 
-  // Tray → slot promotion. The hook handles swap-on-occupied semantics; we
-  // just route the candidate id and target slot.
-  const handleCandidateDropped = (setKey: 'set1' | 'set2') => (candidateId: string, slotIndex: number) => {
-    if (promoteCandidateToSlot) promoteCandidateToSlot(candidateId, setKey, slotIndex);
+  // Tray → slot promotion. The hook handles swap-on-occupied semantics and the
+  // capacity clamp for out-of-range indices (PR #62 review C1).
+  const handleCandidateDropped = (setKey: 'set1' | 'set2') => async (candidateId: string, slotIndex: number) => {
+    if (!promoteCandidateToSlot) return;
+    try {
+      await promoteCandidateToSlot(candidateId, setKey, slotIndex);
+    } catch (err) {
+      console.error('promoteCandidateToSlot failed:', err);
+    }
   };
 
   // Slot → tray demotion when a slot photo is dragged onto the tray drop zone.
-  const handleSlotDroppedToTray = (payload: { setKey: 'set1' | 'set2'; photoId: string }) => {
-    if (demoteSlotToCandidate) demoteSlotToCandidate(payload.setKey, payload.photoId);
+  const handleSlotDroppedToTray = async (payload: { setKey: 'set1' | 'set2'; photoId: string }) => {
+    if (!demoteSlotToCandidate) return;
+    try {
+      await demoteSlotToCandidate(payload.setKey, payload.photoId);
+    } catch (err) {
+      console.error('demoteSlotToCandidate failed:', err);
+    }
   };
 
-  // "Send to Set X" from the tray context menu — appends to the next slot.
-  // If the target set is full, the hook's promote logic swaps with the last
-  // slot photo (demoted as pick).
-  const handleSendCandidateToSet = (photoId: string, setKey: 'set1' | 'set2') => {
+  // "Send to Set X" from the tray toolbar. If the target set is full, we ask
+  // the hook for a swap with the LAST slot photo by passing `capacity - 1`;
+  // otherwise we append at the next empty index. The hook clamps anyway, but
+  // computing it here keeps the intent explicit at the call site.
+  const handleSendCandidateToSet = async (photoId: string, setKey: 'set1' | 'set2') => {
     if (!session || !promoteCandidateToSlot) return;
-    const slotIndex = session.sets[setKey].photos.length;
-    promoteCandidateToSlot(photoId, setKey, slotIndex);
+    const capacity = getGridCapacity(session as any);
+    const slotCount = session.sets[setKey].photos.length;
+    const slotIndex = slotCount < capacity ? slotCount : Math.max(0, capacity - 1);
+    try {
+      await promoteCandidateToSlot(photoId, setKey, slotIndex);
+    } catch (err) {
+      console.error('handleSendCandidateToSet failed:', err);
+    }
   };
 
   const handlePhotoUpdate = (setKey: 'set1' | 'set2' | 'candidates', photoId: string, canvasState: any) => {
@@ -442,8 +482,17 @@ function AppApi() {
   };
 
   const handleCleanupCandidatesConfirm = async () => {
-    if (clearAllCandidates) await clearAllCandidates();
-    setCleanupCandidatesDialog(null);
+    if (!clearAllCandidates) return;
+    try {
+      await clearAllCandidates();
+      setCleanupCandidatesDialog(null);
+    } catch (err) {
+      // PR #62 review I6: previously dismissed even on failure. Keep the
+      // dialog open and surface the error so the user knows the action
+      // didn't complete.
+      console.error('handleCleanupCandidatesConfirm failed:', err);
+      alert(err instanceof Error ? err.message : 'Failed to delete candidates');
+    }
   };
   const handleCleanupCandidatesDecline = () => setCleanupCandidatesDialog(null);
 
@@ -725,7 +774,7 @@ function AppApi() {
                capped at 9 so single-set flow still applies. */
             onInitialFilesDropped={isPrecision
               ? (files) => handleAddToSet(files, 'set1')
-              : (files) => addPhotosToTurningPoint(files)}
+              : handleInitialTurningPointDrop}
             onPhotoClick={handlePhotoClick}
             onPhotoUpdate={handlePhotoUpdate}
             onPhotoRemove={handlePhotoRemove}
@@ -788,6 +837,7 @@ function AppApi() {
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set1', fromIndex, toIndex)}
                         onFilesDropped={(files) => handleAddToSet(files, 'set1')}
                         onCandidateDropped={handleCandidateDropped('set1')}
+                        onCrossSetDropRejected={() => setCrossSetHintOpen(true)}
                         maxPhotosOverride={isPrecision && session.mode === 'track' ? 10 : undefined}
                       />
                     </Paper>
@@ -839,6 +889,7 @@ function AppApi() {
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set2', fromIndex, toIndex)}
                         onFilesDropped={(files) => handleAddToSet(files, 'set2')}
                         onCandidateDropped={handleCandidateDropped('set2')}
+                        onCrossSetDropRejected={() => setCrossSetHintOpen(true)}
                       />
                     </Paper>
                   )
@@ -1247,6 +1298,16 @@ function AppApi() {
         onClose={() => setDropToast(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         message={dropToast ? t('candidates.smartDropToast', { count: dropToast.count }) : ''}
+      />
+
+      {/* Hint when the user tries an unsupported cross-set slot drag (PR #62
+          review I4). The two-step via the tray works; this just tells them. */}
+      <Snackbar
+        open={crossSetHintOpen}
+        autoHideDuration={5000}
+        onClose={() => setCrossSetHintOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={t('candidates.crossSetHint')}
       />
 
       {/* Post-export candidate cleanup dialog */}

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -103,7 +103,7 @@ function AppApi() {
     demoteSlotToCandidate,
     setCandidateFlag,
     updateCandidatePhotoState,
-    clearAllCandidates,
+    deleteCandidates,
   } = sessionHookResult;
 
   // Candidate photos — derived from session for stable rendering. The pool
@@ -158,9 +158,10 @@ function AppApi() {
   const [renameText, setRenameText] = useState('');
 
   // Post-export cleanup dialog (offers to delete unused candidates after a
-  // successful PDF generation). State holds the count snapshot at export
-  // time so the user sees the same figure on the dialog as in the toast.
-  const [cleanupCandidatesDialog, setCleanupCandidatesDialog] = useState<{ count: number; sizeMB: number } | null>(null);
+  // successful PDF generation). Snapshots BOTH the count AND the specific
+  // candidate ids at export time so adding more candidates between dialog
+  // open and confirm doesn't sweep them away (PR #62 review IMP-4).
+  const [cleanupCandidatesDialog, setCleanupCandidatesDialog] = useState<{ count: number; sizeMB: number; ids: string[] } | null>(null);
 
   // Snackbar shown when smart-drop routes a slot-targeted batch into the
   // candidate tray (because the batch exceeded remaining slot capacity).
@@ -172,16 +173,20 @@ function AppApi() {
   // docs/CANDIDATE_PHOTOS.md). Previously a silent no-op (PR #62 review I4).
   const [crossSetHintOpen, setCrossSetHintOpen] = useState(false);
 
+  // Error snackbar for cleanup-dialog failures (PR #62 review IMP-5). The
+  // hook's `deleteCandidates` rethrows on OPFS partial failure (CRIT-3); the
+  // snackbar replaces the previous blocking `alert()` and is i18n-friendly.
+  const [cleanupErrorToast, setCleanupErrorToast] = useState<string | null>(null);
+
   // Wrapper around the hook's `addPhotosToSet` that surfaces the smart-drop
   // routing result. Calling sites stay simple — they just pass files + set.
+  // The hook owns error reporting via `setError` → global Alert (PR #62
+  // review IMP-8: dropped dead AppApi try/catch); we just react to the
+  // 'ok'-arm tray-routing for the toast.
   const handleAddToSet = async (files: File[], setKey: 'set1' | 'set2') => {
-    try {
-      const result = await addPhotosToSet(files, setKey);
-      if (result && result.routedTo === 'tray' && result.count > 0) {
-        setDropToast({ count: result.count });
-      }
-    } catch (err) {
-      console.error('handleAddToSet failed:', err);
+    const result = await addPhotosToSet(files, setKey);
+    if (result?.kind === 'ok' && result.routedTo === 'tray' && result.count > 0) {
+      setDropToast({ count: result.count });
     }
   };
 
@@ -189,13 +194,9 @@ function AppApi() {
   // overflow the hook routes everything to the candidate tray. Surface the toast
   // the same way `handleAddToSet` does (PR #62 review I1).
   const handleInitialTurningPointDrop = async (files: File[]) => {
-    try {
-      const result = await addPhotosToTurningPoint(files);
-      if (result && result.routedTo === 'tray' && result.count > 0) {
-        setDropToast({ count: result.count });
-      }
-    } catch (err) {
-      console.error('handleInitialTurningPointDrop failed:', err);
+    const result = await addPhotosToTurningPoint(files);
+    if (result?.kind === 'ok' && result.routedTo === 'tray' && result.count > 0) {
+      setDropToast({ count: result.count });
     }
   };
 
@@ -290,24 +291,18 @@ function AppApi() {
   };
 
   // Tray → slot promotion. The hook handles swap-on-occupied semantics and the
-  // capacity clamp for out-of-range indices (PR #62 review C1).
+  // capacity clamp for out-of-range indices (PR #62 review C1). Errors are
+  // routed through the hook's internal try/catch → global error banner; no
+  // local try/catch needed (PR #62 review IMP-8 — dead catch was misleading).
   const handleCandidateDropped = (setKey: 'set1' | 'set2') => async (candidateId: string, slotIndex: number) => {
     if (!promoteCandidateToSlot) return;
-    try {
-      await promoteCandidateToSlot(candidateId, setKey, slotIndex);
-    } catch (err) {
-      console.error('promoteCandidateToSlot failed:', err);
-    }
+    await promoteCandidateToSlot(candidateId, setKey, slotIndex);
   };
 
   // Slot → tray demotion when a slot photo is dragged onto the tray drop zone.
   const handleSlotDroppedToTray = async (payload: { setKey: 'set1' | 'set2'; photoId: string }) => {
     if (!demoteSlotToCandidate) return;
-    try {
-      await demoteSlotToCandidate(payload.setKey, payload.photoId);
-    } catch (err) {
-      console.error('demoteSlotToCandidate failed:', err);
-    }
+    await demoteSlotToCandidate(payload.setKey, payload.photoId);
   };
 
   // "Send to Set X" from the tray toolbar. If the target set is full, we ask
@@ -319,20 +314,20 @@ function AppApi() {
     const capacity = getGridCapacity(session as any);
     const slotCount = session.sets[setKey].photos.length;
     const slotIndex = slotCount < capacity ? slotCount : Math.max(0, capacity - 1);
-    try {
-      await promoteCandidateToSlot(photoId, setKey, slotIndex);
-    } catch (err) {
-      console.error('handleSendCandidateToSet failed:', err);
-    }
+    await promoteCandidateToSlot(photoId, setKey, slotIndex);
   };
 
-  const handlePhotoUpdate = (setKey: 'set1' | 'set2' | 'candidates', photoId: string, canvasState: any) => {
+  const handlePhotoUpdate = (setKey: 'set1' | 'set2' | 'candidates', photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     // Dispatch to the right backend method — slot photos go through
-    // updatePhotoState, candidates through updateCandidatePhotoState.
+    // updatePhotoState, candidates through updateCandidatePhotoState. The
+    // explicit `void` prefix marks fire-and-forget intent (PR #62 review
+    // IMP-8) — hook owns its error reporting via `setError`, and we want the
+    // optimistic local state update below to happen synchronously rather
+    // than waiting on persistence.
     if (setKey === 'candidates') {
-      if (updateCandidatePhotoState) updateCandidatePhotoState(photoId, canvasState);
+      if (updateCandidatePhotoState) void updateCandidatePhotoState(photoId, canvasState);
     } else {
-      updatePhotoState(setKey, photoId, canvasState);
+      void updatePhotoState(setKey, photoId, canvasState);
     }
 
     // Optimistically update selected photo immediately for instant UI feedback
@@ -348,15 +343,16 @@ function AppApi() {
   };
 
   const handlePhotoRemove = (setKey: 'set1' | 'set2' | 'candidates', photoId: string) => {
-    if (setKey === 'candidates') {
-      if (removeCandidate) removeCandidate(photoId);
-    } else {
-      removePhoto(setKey, photoId);
-    }
-
-    // Close detailed editor if this photo was selected
+    // Close editor optimistically; persistence is fire-and-forget (errors
+    // surface via the global Alert from `setError`). Explicit `void`
+    // documents the intent (PR #62 review IMP-8).
     if (selectedPhoto?.photo.id === photoId) {
       setSelectedPhoto(null);
+    }
+    if (setKey === 'candidates') {
+      if (removeCandidate) void removeCandidate(photoId);
+    } else {
+      void removePhoto(setKey, photoId);
     }
   };
 
@@ -462,10 +458,13 @@ function AppApi() {
       // Post-export prompt: offer to clean up unused candidate photos so the
       // user doesn't accumulate them across competitions. ~3 MB per photo
       // matches the heuristic in `competitionService.estimateCompetitionSize`.
+      // Snapshot the specific candidate ids so adding more candidates between
+      // dialog open and confirm doesn't sweep them away (PR #62 review IMP-4).
       if (candidatePhotos.length > 0) {
         setCleanupCandidatesDialog({
           count: candidatePhotos.length,
           sizeMB: Math.round(candidatePhotos.length * 3),
+          ids: candidatePhotos.map((p) => p.id),
         });
       }
     } catch (error) {
@@ -482,16 +481,24 @@ function AppApi() {
   };
 
   const handleCleanupCandidatesConfirm = async () => {
-    if (!clearAllCandidates) return;
+    const dialog = cleanupCandidatesDialog;
+    if (!dialog || !deleteCandidates) return;
     try {
-      await clearAllCandidates();
+      // Targeted delete using the snapshot ids (PR #62 review IMP-4). The
+      // hook rethrows on OPFS partial failure so the dialog stays open and
+      // the user knows it didn't complete (PR #62 review CRIT-3 — previously
+      // `clearAllCandidates` swallowed failures internally, making the
+      // outer try/catch unreachable dead code).
+      await deleteCandidates(dialog.ids);
       setCleanupCandidatesDialog(null);
     } catch (err) {
-      // PR #62 review I6: previously dismissed even on failure. Keep the
-      // dialog open and surface the error so the user knows the action
-      // didn't complete.
+      // PR #62 review IMP-5: replaced blocking `alert()` with a Snackbar
+      // consistent with the rest of the candidate-flow UX, and routed
+      // through `t()` so the message picks up the active locale rather than
+      // shipping an English exception message in the Czech UI.
       console.error('handleCleanupCandidatesConfirm failed:', err);
-      alert(err instanceof Error ? err.message : 'Failed to delete candidates');
+      const message = err instanceof Error ? err.message : t('candidates.cleanup.error');
+      setCleanupErrorToast(message);
     }
   };
   const handleCleanupCandidatesDecline = () => setCleanupCandidatesDialog(null);
@@ -751,10 +758,10 @@ function AppApi() {
         {(candidatePhotos.length > 0 || stats.totalPhotos > 0) && (
           <CandidateTray
             photos={candidatePhotos}
-            onAddFiles={(files) => { if (addPhotosToCandidates) addPhotosToCandidates(files); }}
+            onAddFiles={(files) => { if (addPhotosToCandidates) void addPhotosToCandidates(files); }}
             onPhotoClick={handleCandidateClick}
-            onSetFlag={(photoId, flag) => { if (setCandidateFlag) setCandidateFlag(photoId, flag); }}
-            onDelete={(photoId) => { if (removeCandidate) removeCandidate(photoId); }}
+            onSetFlag={(photoId, flag) => { if (setCandidateFlag) void setCandidateFlag(photoId, flag); }}
+            onDelete={(photoId) => { if (removeCandidate) void removeCandidate(photoId); }}
             onSendToSet={handleSendCandidateToSet}
             onSlotDroppedIn={handleSlotDroppedToTray}
             hideSet2={isPrecision && session?.mode === 'track'}
@@ -1308,6 +1315,17 @@ function AppApi() {
         onClose={() => setCrossSetHintOpen(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         message={t('candidates.crossSetHint')}
+      />
+
+      {/* Cleanup-dialog failure surface (PR #62 review IMP-5). Replaces a
+          blocking `alert()`; consistent with `dropToast`/`crossSetHint`
+          snackbars elsewhere in this view. */}
+      <Snackbar
+        open={Boolean(cleanupErrorToast)}
+        autoHideDuration={8000}
+        onClose={() => setCleanupErrorToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={cleanupErrorToast ?? ''}
       />
 
       {/* Post-export candidate cleanup dialog */}

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -22,7 +22,8 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
-  TextField
+  TextField,
+  Snackbar
 } from '@mui/material';
 import {
   FlightTakeoff,
@@ -33,10 +34,8 @@ import {
   Warning,
   Home,
   Map,
-  Add as AddIcon,
 } from '@mui/icons-material';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
-import { DropZone } from './components/DropZone';
 import { GridSizedDropZone } from './components/GridSizedDropZone';
 import { PhotoGridApi } from './components/PhotoGridApi';
 import { EditableHeading } from './components/EditableHeading';
@@ -162,6 +161,21 @@ function AppApi() {
   // time so the user sees the same figure on the dialog as in the toast.
   const [cleanupCandidatesDialog, setCleanupCandidatesDialog] = useState<{ count: number; sizeMB: number } | null>(null);
 
+  // Snackbar shown when smart-drop routes a slot-targeted batch into the
+  // candidate tray (because the batch exceeded remaining slot capacity).
+  // First dev-test feedback 2026-05-12: the routing was silent and felt
+  // like the photos "disappeared" from the user's perspective.
+  const [dropToast, setDropToast] = useState<{ count: number } | null>(null);
+
+  // Wrapper around the hook's `addPhotosToSet` that surfaces the smart-drop
+  // routing result. Calling sites stay simple — they just pass files + set.
+  const handleAddToSet = async (files: File[], setKey: 'set1' | 'set2') => {
+    const result = await addPhotosToSet(files, setKey);
+    if (result && (result as any).routedTo === 'tray' && (result as any).count > 0) {
+      setDropToast({ count: (result as any).count });
+    }
+  };
+
   // selectedPhoto.setKey === 'candidates' for tray-source photos. Label is
   // empty in that case (tray photos have no slot index). The modal reuses
   // the same editor and persistence dispatches to the right hook method.
@@ -200,23 +214,15 @@ function AppApi() {
     }
   }, [session?.layoutMode, setLayoutMode]);
 
-  // Precision discipline: slot count follows actual photo count (feedback 2026-04-18
-  // — a 10-slot layout with 9 photos printed an empty 10th tile).
-  //   turning   → always 9 slots (landscape 3×3) — spec is SP + TP1..TP7 + FP
-  //   track     → 10 slots (portrait 2×5) *only when* the user reaches 10 photos;
-  //               otherwise 9-slot landscape so the printed page isn't padded with
-  //               an empty tile. Uploading the 10th photo snaps to portrait.
-  useEffect(() => {
-    if (!isPrecision || !session?.mode) return;
-    const photoCount = session.sets.set1.photos.length;
-    const required: 'portrait' | 'landscape' = (session.mode === 'track' && photoCount === 10)
-      ? 'portrait'
-      : 'landscape';
-    if (layoutMode !== required) {
-      setLayoutMode(required);
-      updateLayoutMode(required);
-    }
-  }, [isPrecision, session?.mode, session?.sets.set1.photos.length, layoutMode, setLayoutMode, updateLayoutMode]);
+  // Precision-track auto-layout switching removed (first dev-test feedback
+  // 2026-05-12): the 9→10 portrait flip is gone. Users pick layout manually
+  // via `LayoutModeSelector`; capacity follows that choice via
+  // `getGridCapacity`. The candidate tray now absorbs any drop that exceeds
+  // the current slot capacity, so a "10th photo" no longer needs a special
+  // path. (Rally turning-point's grid column expand from 3×3 → 5×2 at 10
+  // photos in landscape is left in place — it's not a layout-mode change,
+  // just grid columns within landscape — but can be re-evaluated if it also
+  // feels confusing.)
 
   const handlePhotoClick = (photo: ApiPhoto, setKey: 'set1' | 'set2') => {
     const setPhotos = session?.sets[setKey].photos || [];
@@ -685,10 +691,15 @@ function AppApi() {
           </Alert>
         )}
 
-        {/* Candidate tray — slotless pool above the print layout. Hidden
-            when no candidates exist so existing UX is untouched until the
-            user opts in by dropping >capacity photos. */}
-        {candidatePhotos.length > 0 && (
+        {/* Candidate tray — slotless pool above the print layout. We render
+            it whenever EITHER candidates exist OR slots have photos. The
+            empty-state branch in CandidateTray itself shows a "drop more
+            here" dropzone — the only entry point for adding files once all
+            slots are full (otherwise the user gets stuck on a maxed-out
+            grid with no dropzone, first dev test 2026-05-12). Stays hidden
+            only on the truly-fresh empty state (no slots, no candidates)
+            so the initial DropZone hero remains unobstructed. */}
+        {(candidatePhotos.length > 0 || stats.totalPhotos > 0) && (
           <CandidateTray
             photos={candidatePhotos}
             onAddFiles={(files) => { if (addPhotosToCandidates) addPhotosToCandidates(files); }}
@@ -708,12 +719,12 @@ function AppApi() {
             set2={session.sets.set2}
             loading={loading}
             error={error}
-            onFilesDropped={(setKey, files) => addPhotosToSet(files, setKey)}
+            onFilesDropped={(setKey, files) => handleAddToSet(files, setKey)}
             /* Initial Rally drop can span 10-18 photos — distribute across
                both sets instead of overflowing set1 invisibly. Precision stays
                capped at 9 so single-set flow still applies. */
             onInitialFilesDropped={isPrecision
-              ? (files) => addPhotosToSet(files, 'set1')
+              ? (files) => handleAddToSet(files, 'set1')
               : (files) => addPhotosToTurningPoint(files)}
             onPhotoClick={handlePhotoClick}
             onPhotoUpdate={handlePhotoUpdate}
@@ -743,7 +754,7 @@ function AppApi() {
                       </Typography>
                     </Box>
                     <GridSizedDropZone
-                      onFilesDropped={(files) => addPhotosToSet(files, 'set1')}
+                      onFilesDropped={(files) => handleAddToSet(files, 'set1')}
                       setName={t('sets.set1')}
                       // Precision track allows up to 10 regardless of current
                       // layoutMode — a fresh 10-photo drop will switch the
@@ -775,7 +786,7 @@ function AppApi() {
                         onPhotoRemove={(photoId) => handlePhotoRemove('set1', photoId)}
                         onPhotoClick={(photo) => handlePhotoClick(photo, 'set1')}
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set1', fromIndex, toIndex)}
-                        onFilesDropped={(files) => addPhotosToSet(files, 'set1')}
+                        onFilesDropped={(files) => handleAddToSet(files, 'set1')}
                         onCandidateDropped={handleCandidateDropped('set1')}
                         maxPhotosOverride={isPrecision && session.mode === 'track' ? 10 : undefined}
                       />
@@ -796,7 +807,7 @@ function AppApi() {
                       </Typography>
                     </Box>
                     <GridSizedDropZone
-                      onFilesDropped={(files) => addPhotosToSet(files, 'set2')}
+                      onFilesDropped={(files) => handleAddToSet(files, 'set2')}
                       setName={t('sets.set2')}
                       maxPhotos={layoutMode === 'portrait' ? 10 : 9}
                       loading={loading}
@@ -826,7 +837,7 @@ function AppApi() {
                         onPhotoRemove={(photoId) => handlePhotoRemove('set2', photoId)}
                         onPhotoClick={(photo) => handlePhotoClick(photo, 'set2')}
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set2', fromIndex, toIndex)}
-                        onFilesDropped={(files) => addPhotosToSet(files, 'set2')}
+                        onFilesDropped={(files) => handleAddToSet(files, 'set2')}
                         onCandidateDropped={handleCandidateDropped('set2')}
                       />
                     </Paper>
@@ -835,49 +846,15 @@ function AppApi() {
               </Box>
             );
 
-            // Precision track mode: user feedback 2026-04-18 — single upload of
-            // up to 10 photos, no second set. Rally keeps the two-set layout.
+            // Precision track mode: single-set layout (no Set 2). The
+            // "Add 10th photo" affordance was removed with the auto-flip
+            // (first dev-test feedback 2026-05-12) — overflow now lands in
+            // the candidate tray, and users flip to portrait themselves
+            // when they want a 10-slot layout.
             if (isPrecision) {
-              // When the user has exactly 9 photos in landscape (3×3), the grid
-              // is full and offers no visible drop target for a 10th photo.
-              // Surface an explicit compact add-one affordance below the grid;
-              // dropping here triggers the layout auto-switch to portrait.
-              const showAddTenth = session?.mode === 'track' && stats.set1Photos === 9;
               return (
                 <Box sx={{ mb: 6 }}>
                   {Set1Component}
-                  {showAddTenth && (
-                    <Box sx={{ mt: 2 }}>
-                      <Paper
-                        elevation={1}
-                        sx={{
-                          p: 2,
-                          borderRadius: 2,
-                          border: '2px dashed',
-                          borderColor: 'primary.light',
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          gap: 1,
-                        }}
-                      >
-                        <AddIcon color="primary" />
-                        <Typography variant="body2" color="text.secondary">
-                          {t('upload.addTenthPhoto')}
-                        </Typography>
-                        <Box sx={{ width: '100%' }}>
-                          <DropZone
-                            onFilesDropped={(files) => addPhotosToSet(files.slice(0, 1), 'set1')}
-                            setName={t('upload.addTenthPhoto')}
-                            currentPhotoCount={9}
-                            maxPhotos={10}
-                            loading={loading}
-                            error={null}
-                          />
-                        </Box>
-                      </Paper>
-                    </Box>
-                  )}
                 </Box>
               );
             }
@@ -1261,6 +1238,16 @@ function AppApi() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Smart-drop notification — surfaces silent batches routed to the
+          candidate tray so the user doesn't think their photos vanished. */}
+      <Snackbar
+        open={Boolean(dropToast)}
+        autoHideDuration={6000}
+        onClose={() => setDropToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={dropToast ? t('candidates.smartDropToast', { count: dropToast.count }) : ''}
+      />
 
       {/* Post-export candidate cleanup dialog */}
       <Dialog

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -50,6 +50,7 @@ import { LayoutModeSelector } from './components/LayoutModeSelector';
 import { CompetitionSelector } from './components/CompetitionSelector';
 import { CreateCompetitionButton } from './components/CreateCompetitionButton';
 import { CleanupModal } from './components/CleanupModal';
+import { CandidateTray } from './components/CandidateTray';
 import { useAspectRatio } from './contexts/AspectRatioContext';
 import { useLabeling } from './contexts/LabelingContext';
 import { useI18n } from './contexts/I18nContext';
@@ -94,8 +95,20 @@ function AppApi() {
     performCleanup,
     dismissCleanup,
     updateStorageStats,
-    isDesktopManaged
+    isDesktopManaged,
+    // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
+    addPhotosToCandidates,
+    removeCandidate,
+    promoteCandidateToSlot,
+    demoteSlotToCandidate,
+    setCandidateFlag,
+    updateCandidatePhotoState,
+    clearAllCandidates,
   } = sessionHookResult;
+
+  // Candidate photos — derived from session for stable rendering. The pool
+  // is optional on older sessions, so default to empty.
+  const candidatePhotos: ApiPhoto[] = session?.candidates?.photos ?? [];
 
   // Session identifiers and storage stats come from the OPFS-backed
   // useCompetitionSystem hook — no network round-trip, so availability is
@@ -144,9 +157,17 @@ function AppApi() {
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renameText, setRenameText] = useState('');
 
+  // Post-export cleanup dialog (offers to delete unused candidates after a
+  // successful PDF generation). State holds the count snapshot at export
+  // time so the user sees the same figure on the dialog as in the toast.
+  const [cleanupCandidatesDialog, setCleanupCandidatesDialog] = useState<{ count: number; sizeMB: number } | null>(null);
+
+  // selectedPhoto.setKey === 'candidates' for tray-source photos. Label is
+  // empty in that case (tray photos have no slot index). The modal reuses
+  // the same editor and persistence dispatches to the right hook method.
   const [selectedPhoto, setSelectedPhoto] = useState<{
     photo: ApiPhoto;
-    setKey: 'set1' | 'set2';
+    setKey: 'set1' | 'set2' | 'candidates';
     label: string;
   } | null>(null);
   const [showOriginal, setShowOriginal] = useState(false);
@@ -226,16 +247,47 @@ function AppApi() {
       }
     }
 
-    setSelectedPhoto({ 
-      photo, 
-      setKey, 
+    setSelectedPhoto({
+      photo,
+      setKey,
       label
     });
   };
 
-  const handlePhotoUpdate = (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => {
-    // Update the backend first
-    updatePhotoState(setKey, photoId, canvasState);
+  // Click handler for tray thumbs — opens the same editor modal, label is
+  // empty because tray photos have no slot index yet.
+  const handleCandidateClick = (photo: ApiPhoto) => {
+    setSelectedPhoto({ photo, setKey: 'candidates', label: '' });
+  };
+
+  // Tray → slot promotion. The hook handles swap-on-occupied semantics; we
+  // just route the candidate id and target slot.
+  const handleCandidateDropped = (setKey: 'set1' | 'set2') => (candidateId: string, slotIndex: number) => {
+    if (promoteCandidateToSlot) promoteCandidateToSlot(candidateId, setKey, slotIndex);
+  };
+
+  // Slot → tray demotion when a slot photo is dragged onto the tray drop zone.
+  const handleSlotDroppedToTray = (payload: { setKey: 'set1' | 'set2'; photoId: string }) => {
+    if (demoteSlotToCandidate) demoteSlotToCandidate(payload.setKey, payload.photoId);
+  };
+
+  // "Send to Set X" from the tray context menu — appends to the next slot.
+  // If the target set is full, the hook's promote logic swaps with the last
+  // slot photo (demoted as pick).
+  const handleSendCandidateToSet = (photoId: string, setKey: 'set1' | 'set2') => {
+    if (!session || !promoteCandidateToSlot) return;
+    const slotIndex = session.sets[setKey].photos.length;
+    promoteCandidateToSlot(photoId, setKey, slotIndex);
+  };
+
+  const handlePhotoUpdate = (setKey: 'set1' | 'set2' | 'candidates', photoId: string, canvasState: any) => {
+    // Dispatch to the right backend method — slot photos go through
+    // updatePhotoState, candidates through updateCandidatePhotoState.
+    if (setKey === 'candidates') {
+      if (updateCandidatePhotoState) updateCandidatePhotoState(photoId, canvasState);
+    } else {
+      updatePhotoState(setKey, photoId, canvasState);
+    }
 
     // Optimistically update selected photo immediately for instant UI feedback
     if (selectedPhoto?.photo.id === photoId) {
@@ -249,8 +301,12 @@ function AppApi() {
     }
   };
 
-  const handlePhotoRemove = (setKey: 'set1' | 'set2', photoId: string) => {
-    removePhoto(setKey, photoId);
+  const handlePhotoRemove = (setKey: 'set1' | 'set2' | 'candidates', photoId: string) => {
+    if (setKey === 'candidates') {
+      if (removeCandidate) removeCandidate(photoId);
+    } else {
+      removePhoto(setKey, photoId);
+    }
 
     // Close detailed editor if this photo was selected
     if (selectedPhoto?.photo.id === photoId) {
@@ -356,6 +412,16 @@ function AppApi() {
       });
 
       await generatePDF(set1WithLabels, set2WithLabels, sessionId, currentRatio.ratio, session.competition_name, effectiveLayout, t, session.mode, currentCompetition?.id);
+
+      // Post-export prompt: offer to clean up unused candidate photos so the
+      // user doesn't accumulate them across competitions. ~3 MB per photo
+      // matches the heuristic in `competitionService.estimateCompetitionSize`.
+      if (candidatePhotos.length > 0) {
+        setCleanupCandidatesDialog({
+          count: candidatePhotos.length,
+          sizeMB: Math.round(candidatePhotos.length * 3),
+        });
+      }
     } catch (error) {
       // Surface to the user — previously this was a TODO ("Could add user
       // notification here") and a generatePDF render failure produced a
@@ -368,6 +434,12 @@ function AppApi() {
       alert(message);
     }
   };
+
+  const handleCleanupCandidatesConfirm = async () => {
+    if (clearAllCandidates) await clearAllCandidates();
+    setCleanupCandidatesDialog(null);
+  };
+  const handleCleanupCandidatesDecline = () => setCleanupCandidatesDialog(null);
 
   // Helper: safely apply a setting to all photos with sane defaults
   // applySettingToAll now provided by hook for atomic updates across photos
@@ -613,6 +685,22 @@ function AppApi() {
           </Alert>
         )}
 
+        {/* Candidate tray — slotless pool above the print layout. Hidden
+            when no candidates exist so existing UX is untouched until the
+            user opts in by dropping >capacity photos. */}
+        {candidatePhotos.length > 0 && (
+          <CandidateTray
+            photos={candidatePhotos}
+            onAddFiles={(files) => { if (addPhotosToCandidates) addPhotosToCandidates(files); }}
+            onPhotoClick={handleCandidateClick}
+            onSetFlag={(photoId, flag) => { if (setCandidateFlag) setCandidateFlag(photoId, flag); }}
+            onDelete={(photoId) => { if (removeCandidate) removeCandidate(photoId); }}
+            onSendToSet={handleSendCandidateToSet}
+            onSlotDroppedIn={handleSlotDroppedToTray}
+            hideSet2={isPrecision && session?.mode === 'track'}
+          />
+        )}
+
         {/* Conditional Layout based on mode */}
         {session?.mode === 'turningpoint' ? (
           <TurningPointLayout
@@ -631,6 +719,9 @@ function AppApi() {
             onPhotoUpdate={handlePhotoUpdate}
             onPhotoRemove={handlePhotoRemove}
             onPhotoMove={handlePhotoMove}
+            onCandidateDropped={(setKey, candidateId, slotIndex) =>
+              handleCandidateDropped(setKey)(candidateId, slotIndex)
+            }
             totalPhotoCount={stats.set1Photos + stats.set2Photos}
             isPrecision={isPrecision}
           />
@@ -685,6 +776,7 @@ function AppApi() {
                         onPhotoClick={(photo) => handlePhotoClick(photo, 'set1')}
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set1', fromIndex, toIndex)}
                         onFilesDropped={(files) => addPhotosToSet(files, 'set1')}
+                        onCandidateDropped={handleCandidateDropped('set1')}
                         maxPhotosOverride={isPrecision && session.mode === 'track' ? 10 : undefined}
                       />
                     </Paper>
@@ -735,6 +827,7 @@ function AppApi() {
                         onPhotoClick={(photo) => handlePhotoClick(photo, 'set2')}
                         onPhotoMove={(fromIndex, toIndex) => handlePhotoMove('set2', fromIndex, toIndex)}
                         onFilesDropped={(files) => addPhotosToSet(files, 'set2')}
+                        onCandidateDropped={handleCandidateDropped('set2')}
                       />
                     </Paper>
                   )
@@ -1159,12 +1252,45 @@ function AppApi() {
           <Button onClick={handleRenameCancel}>
             {t('competition.rename.cancel')}
           </Button>
-          <Button 
+          <Button
             onClick={handleRenameConfirm}
             variant="contained"
             disabled={!renameText.trim() || loading}
           >
             {loading ? t('common.loading') : t('competition.rename.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Post-export candidate cleanup dialog */}
+      <Dialog
+        open={Boolean(cleanupCandidatesDialog)}
+        onClose={handleCleanupCandidatesDecline}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>{t('candidates.cleanup.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {cleanupCandidatesDialog && t('candidates.cleanup.message', {
+              count: cleanupCandidatesDialog.count,
+              size: cleanupCandidatesDialog.sizeMB,
+            })}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCleanupCandidatesDecline}>
+            {t('candidates.cleanup.keep')}
+          </Button>
+          <Button
+            onClick={handleCleanupCandidatesConfirm}
+            color="error"
+            variant="contained"
+            disabled={loading}
+          >
+            {cleanupCandidatesDialog
+              ? t('candidates.cleanup.delete', { count: cleanupCandidatesDialog.count })
+              : t('candidates.cleanup.delete', { count: 0 })}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -489,8 +489,16 @@ function AppApi() {
       // the user knows it didn't complete (PR #62 review CRIT-3 — previously
       // `clearAllCandidates` swallowed failures internally, making the
       // outer try/catch unreachable dead code).
-      await deleteCandidates(dialog.ids);
+      const result = await deleteCandidates(dialog.ids);
       setCleanupCandidatesDialog(null);
+      // PR #62 review I6: when every snapshot id was promoted to a slot
+      // between dialog-open and confirm, the dialog used to close with a
+      // silent success — the user believed 5 photos of storage were freed
+      // but 0 were. Surface the snapshot-drift via the same Snackbar so
+      // expectations match reality.
+      if (result.deleted === 0 && result.skipped > 0) {
+        setCleanupErrorToast(t('candidates.cleanup.allPromoted', { count: result.skipped }));
+      }
     } catch (err) {
       // PR #62 review IMP-5: replaced blocking `alert()` with a Snackbar
       // consistent with the rest of the candidate-flow UX, and routed

--- a/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
+++ b/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
@@ -1,0 +1,263 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { CandidateTray, type CandidateTrayProps } from '../components/CandidateTray';
+import { serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
+import type { ApiPhoto, CandidateFlag } from '../types/api';
+
+// PR #62 review G7: the new CandidateTray component (516 LOC) shipped with
+// zero direct tests. The empty-state branch is the only entry point for
+// "drop more photos" once all slots are full (CRIT-2 fix made native drops
+// actually work via getRootProps composition). Pin those behaviours.
+
+// Stub `useI18n` so we don't need to spin up the whole I18nContext. Echoes
+// the key back so assertions can check `t('candidates.poolLabel')` →
+// the literal string `'candidates.poolLabel'`.
+vi.mock('../contexts/I18nContext', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+// Stub PhotoEditorApi — rendering it pulls in WebGL, canvas, image cache,
+// AspectRatioContext, etc. We only need the populated-state thumbnails to
+// have a draggable shell with the toolbar; the actual image render is
+// covered elsewhere. The mock keeps the test focused on tray behaviour.
+vi.mock('../components/PhotoEditorApi', () => ({
+  PhotoEditorApi: ({ photo }: { photo: ApiPhoto }) => (
+    <div data-testid={`mock-editor-${photo.id}`}>{photo.id}</div>
+  ),
+}));
+
+function p(id: string, flag?: CandidateFlag): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob:${id}`,
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 },
+      scale: 1,
+      brightness: 0,
+      contrast: 1,
+      sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    } as any,
+    label: '',
+    ...(flag !== undefined ? { flag } : {}),
+  };
+}
+
+function renderTray(overrides: Partial<CandidateTrayProps> = {}) {
+  const props: CandidateTrayProps = {
+    photos: [],
+    onAddFiles: vi.fn(),
+    onPhotoClick: vi.fn(),
+    onSetFlag: vi.fn(),
+    onDelete: vi.fn(),
+    onSendToSet: vi.fn(),
+    onSlotDroppedIn: vi.fn(),
+    ...overrides,
+  };
+  const result = render(<CandidateTray {...props} />);
+  return { ...result, props };
+}
+
+/**
+ * Build a DataTransfer-ish object that jsdom accepts on synthetic drop
+ * events. The native `DataTransfer` constructor isn't implemented; we
+ * stub `getData` / `setData` / `types` with a Map-backed shim.
+ */
+function makeDataTransfer(initial: Record<string, string> = {}): DataTransfer {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    types: [...store.keys()],
+    getData: (mime: string) => store.get(mime) ?? '',
+    setData: (mime: string, value: string) => { store.set(mime, value); },
+    dropEffect: 'move',
+    effectAllowed: 'move',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    clearData: () => store.clear(),
+    setDragImage: () => {},
+  } as unknown as DataTransfer;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CandidateTray — empty state (PR #62 review CRIT-2 fix region)', () => {
+  it('renders the candidate-pool drop hint when no photos are present', () => {
+    renderTray();
+    // Two text nodes from the empty branch — the bold pool label and the
+    // accessibility hint.
+    expect(screen.getByText('candidates.poolLabel')).toBeInTheDocument();
+    expect(screen.getByText('candidates.emptyHint')).toBeInTheDocument();
+  });
+
+  it('fires `onSlotDroppedIn` when a slot-source payload is dropped on the empty zone', () => {
+    const onSlotDroppedIn = vi.fn();
+    renderTray({ onSlotDroppedIn });
+    const dropTarget = screen.getByText('candidates.poolLabel').closest('div')!;
+    // Synthesise a slot-drag dataTransfer. CRIT-2 fix: handlers now compose
+    // through getRootProps, so the user-supplied onDrop fires for both the
+    // internal payload (this test) and native files (next test).
+    const dataTransfer = makeDataTransfer({
+      [DRAG_PAYLOAD_MIME]: serializeDragPayload({
+        kind: 'slot', setKey: 'set1', index: 2, photoId: 'photo-X',
+      }),
+    });
+    fireEvent.drop(dropTarget, { dataTransfer });
+    expect(onSlotDroppedIn).toHaveBeenCalledTimes(1);
+    expect(onSlotDroppedIn).toHaveBeenCalledWith({ setKey: 'set1', photoId: 'photo-X' });
+  });
+
+  it('ignores tray-source drag payloads (no-op in empty state)', () => {
+    const onSlotDroppedIn = vi.fn();
+    renderTray({ onSlotDroppedIn });
+    const dropTarget = screen.getByText('candidates.poolLabel').closest('div')!;
+    fireEvent.drop(dropTarget, {
+      dataTransfer: makeDataTransfer({
+        [DRAG_PAYLOAD_MIME]: serializeDragPayload({ kind: 'tray', photoId: 'tray-A' }),
+      }),
+    });
+    expect(onSlotDroppedIn).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed drag payloads silently (no crash, no callback)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const onSlotDroppedIn = vi.fn();
+    renderTray({ onSlotDroppedIn });
+    const dropTarget = screen.getByText('candidates.poolLabel').closest('div')!;
+    fireEvent.drop(dropTarget, {
+      dataTransfer: makeDataTransfer({ [DRAG_PAYLOAD_MIME]: 'not json' }),
+    });
+    expect(onSlotDroppedIn).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled(); // parseDragPayload logs the failure
+    warnSpy.mockRestore();
+  });
+});
+
+describe('CandidateTray — populated state', () => {
+  it('renders the candidates header with count', () => {
+    renderTray({ photos: [p('a', 'pick'), p('b'), p('c', 'reject')] });
+    // Header title uses t('candidates.title', { count: 3 }) → echoed as
+    // `candidates.title:{"count":3}` by our mock t().
+    expect(screen.getByText('candidates.title:{"count":3}')).toBeInTheDocument();
+  });
+
+  it('hides "Send to Set 2" button when hideSet2 is true (precision-track mode)', () => {
+    renderTray({ photos: [p('a')], hideSet2: true });
+    // The Send-to-Set-1 button is always rendered; Set-2 is gated behind hideSet2.
+    // Tooltip titles use t('candidates.sendToSet1') and t('candidates.sendToSet2').
+    // With our echo-style t(), they appear as those exact strings in aria-label /
+    // title attributes. We look for the absence of the Set 2 tooltip.
+    expect(screen.queryByLabelText('candidates.sendToSet2')).not.toBeInTheDocument();
+  });
+
+  it('shows "Send to Set 2" button when hideSet2 is false (default rally mode)', () => {
+    renderTray({ photos: [p('a')], hideSet2: false });
+    // Multiple elements (tooltip wrapper + button) share the title attribute,
+    // so just assert at least one Set-2 affordance is in the DOM.
+    expect(screen.queryAllByLabelText('candidates.sendToSet2').length).toBeGreaterThan(0);
+  });
+
+  it('renders all photo thumbnails by default (hideRejects off)', () => {
+    renderTray({ photos: [p('a', 'pick'), p('b'), p('c', 'reject')] });
+    expect(screen.getByTestId('mock-editor-a')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-editor-b')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-editor-c')).toBeInTheDocument();
+  });
+
+  it('toggling Hide Rejected removes rejected photos from the DOM', () => {
+    renderTray({ photos: [p('a', 'pick'), p('b', 'reject'), p('c')] });
+    // Find the toggle switch — the FormControlLabel wraps a label with the
+    // i18n string. Clicking the visible label flips the control.
+    const toggleLabel = screen.getByText('candidates.hideRejects');
+    fireEvent.click(toggleLabel);
+    expect(screen.getByTestId('mock-editor-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-editor-b')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mock-editor-c')).toBeInTheDocument();
+  });
+
+  it('fires onSendToSet when a "Send to Set 1" toolbar button is clicked', () => {
+    const onSendToSet = vi.fn();
+    renderTray({ photos: [p('photo-X')], onSendToSet });
+    const sendButtons = screen.getAllByLabelText('candidates.sendToSet1');
+    // First match is the tooltip wrapper, last is the actual IconButton.
+    fireEvent.click(sendButtons[sendButtons.length - 1]);
+    expect(onSendToSet).toHaveBeenCalledWith('photo-X', 'set1');
+  });
+
+  it('fires onSetFlag with "pick" when star button is clicked on a neutral photo', () => {
+    const onSetFlag = vi.fn();
+    renderTray({ photos: [p('photo-X')], onSetFlag });
+    const pickButtons = screen.getAllByLabelText('candidates.flag.pick');
+    fireEvent.click(pickButtons[pickButtons.length - 1]);
+    expect(onSetFlag).toHaveBeenCalledWith('photo-X', 'pick');
+  });
+
+  it('fires onSetFlag with "neutral" when star button is clicked on an already-picked photo', () => {
+    const onSetFlag = vi.fn();
+    renderTray({ photos: [p('photo-X', 'pick')], onSetFlag });
+    const pickButtons = screen.getAllByLabelText('candidates.flag.pick');
+    fireEvent.click(pickButtons[pickButtons.length - 1]);
+    expect(onSetFlag).toHaveBeenCalledWith('photo-X', 'neutral');
+  });
+
+  it('fires onDelete when delete button is clicked', () => {
+    const onDelete = vi.fn();
+    renderTray({ photos: [p('photo-X')], onDelete });
+    const deleteButtons = screen.getAllByLabelText('common.delete');
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+    expect(onDelete).toHaveBeenCalledWith('photo-X');
+  });
+
+  it('serialises a drag-payload with the tray protocol when a thumb starts dragging', () => {
+    renderTray({ photos: [p('photo-X')] });
+    // The draggable shell is the outer Box around the thumb. Its data-testid
+    // is on the mocked editor; the draggable parent is one level up.
+    const thumbInner = screen.getByTestId('mock-editor-photo-X');
+    const draggable = thumbInner.closest('[draggable="true"]') as HTMLElement;
+    expect(draggable).not.toBeNull();
+
+    const setData = vi.fn();
+    const dataTransfer = {
+      ...makeDataTransfer(),
+      setData,
+    } as unknown as DataTransfer;
+    fireEvent.dragStart(draggable, { dataTransfer });
+
+    // First call: the structured tray payload.
+    const trayCall = setData.mock.calls.find(
+      (call) => call[0] === DRAG_PAYLOAD_MIME,
+    );
+    expect(trayCall).toBeTruthy();
+    expect(JSON.parse(trayCall![1])).toEqual({ kind: 'tray', photoId: 'photo-X' });
+  });
+
+  it('fires onSlotDroppedIn when a slot photo is dropped onto the populated tray', () => {
+    const onSlotDroppedIn = vi.fn();
+    renderTray({ photos: [p('photo-X')], onSlotDroppedIn });
+    // The outer Paper carries the drop handler. Find it via the count header.
+    const header = screen.getByText('candidates.title:{"count":1}');
+    const outerPaper = header.closest('.MuiPaper-root') as HTMLElement;
+    expect(outerPaper).not.toBeNull();
+    fireEvent.drop(outerPaper, {
+      dataTransfer: makeDataTransfer({
+        [DRAG_PAYLOAD_MIME]: serializeDragPayload({
+          kind: 'slot', setKey: 'set2', index: 1, photoId: 'slot-photo',
+        }),
+      }),
+    });
+    expect(onSlotDroppedIn).toHaveBeenCalledWith({ setKey: 'set2', photoId: 'slot-photo' });
+  });
+});
+
+beforeEach(() => {
+  // Quiet expected warnings from malformed-payload test paths. Tests that
+  // explicitly assert console.warn override this with their own spy.
+});

--- a/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
+++ b/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
@@ -167,3 +167,48 @@ describe('buildPdfSets — non-mutation guarantee', () => {
     expect(set2).toEqual(frozen2);
   });
 });
+
+// PR #62 review G8: structural regression marker for the
+// "tray photos never reach the printed PDF" invariant. The candidate
+// pool is a *workspace* concept; promoting candidates into the printed
+// PDF would silently put the wrong photos in front of a judge.
+//
+// We pin this at the type level (`PdfSetsInput` has no candidates
+// channel) AND at the behavior level (driving the builder with both
+// containers populated and asserting only slot ids appear in output).
+describe('buildPdfSets — tray-photo leak guard (PR #62 review G8)', () => {
+  it('PdfSetsInput shape contains no `candidates` field', () => {
+    // Structural pin: if a future refactor adds `candidates?: CandidatePool`
+    // to PdfSetsInput, the type assertion below breaks at compile time and
+    // forces a deliberate review (does the PDF really want tray photos?).
+    type RequiredKeys = 'mode' | 'layoutMode' | 'isPrecision' | 'set1' | 'set2' | 'generateLabel';
+    type ActualKeys = keyof import('../utils/buildPdfSets').PdfSetsInput;
+    // Both directions: ActualKeys must be a subset of RequiredKeys (no
+    // extras like 'candidates') AND vice versa (no removals).
+    const _exhaustive1: RequiredKeys extends ActualKeys ? true : false = true;
+    const _exhaustive2: ActualKeys extends RequiredKeys ? true : false = true;
+    void _exhaustive1; void _exhaustive2;
+    expect(true).toBe(true);
+  });
+
+  it('only emits photos that came from set1/set2 — never references a candidate-only id', () => {
+    // Build sets with 3 slot ids and verify the output's photo ids match
+    // the input's set1+set2 ids exactly (no extra ids leaking in).
+    const result = buildPdfSets({
+      mode: 'track',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      set1: makeSet('s1', ['slot-a', 'slot-b']),
+      set2: makeSet('s2', ['slot-c']),
+      generateLabel: letterLabel,
+    });
+
+    const outputIds = [
+      ...result.set1WithLabels.photos.map(p => p.id),
+      ...result.set2WithLabels.photos.map(p => p.id),
+    ];
+    expect(outputIds).toEqual(['slot-a', 'slot-b', 'slot-c']);
+    // Sanity: no candidate-shaped ids materialise.
+    expect(outputIds.every(id => !id.startsWith('cand-'))).toBe(true);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/candidateFilter.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateFilter.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { filterCandidates, countByFlag } from '../utils/candidateFilter';
+import type { ApiPhoto, CandidateFlag } from '../types/api';
+
+// Filter helper for the CandidateTray view (PR #62 review gap B8). The
+// component was previously 507 lines of UI logic with no direct test; the
+// filter + count helpers are now isolated and behaviorally pinned here.
+
+function makePhoto(id: string, flag?: CandidateFlag | undefined): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob:${id}`,
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 },
+      scale: 1,
+      brightness: 0,
+      contrast: 1,
+      sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    } as any,
+    label: '',
+    ...(flag !== undefined ? { flag } : {}),
+  };
+}
+
+describe('filterCandidates', () => {
+  it('returns the same array reference when hideRejects is off (memo-friendly)', () => {
+    const photos = [makePhoto('a', 'pick'), makePhoto('b', 'reject'), makePhoto('c')];
+    const result = filterCandidates(photos, { hideRejects: false });
+    expect(result).toBe(photos);
+  });
+
+  it('removes only rejected photos when hideRejects is on', () => {
+    const photos = [makePhoto('a', 'pick'), makePhoto('b', 'reject'), makePhoto('c')];
+    const result = filterCandidates(photos, { hideRejects: true });
+    expect(result.map(p => p.id)).toEqual(['a', 'c']);
+  });
+
+  it('treats missing flag as not-rejected', () => {
+    const photos = [makePhoto('a'), makePhoto('b', 'pick'), makePhoto('c', 'reject')];
+    const result = filterCandidates(photos, { hideRejects: true });
+    expect(result.map(p => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns empty when every photo is rejected and toggle is on', () => {
+    const photos = [makePhoto('a', 'reject'), makePhoto('b', 'reject')];
+    expect(filterCandidates(photos, { hideRejects: true })).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const photos = [makePhoto('a', 'reject'), makePhoto('b', 'pick')];
+    const before = photos.map(p => p.id);
+    filterCandidates(photos, { hideRejects: true });
+    expect(photos.map(p => p.id)).toEqual(before);
+  });
+});
+
+describe('countByFlag', () => {
+  it('counts each flag bucket, treats missing flag as neutral', () => {
+    const photos = [
+      makePhoto('a', 'pick'),
+      makePhoto('b', 'pick'),
+      makePhoto('c'),
+      makePhoto('d', 'reject'),
+      makePhoto('e'),
+    ];
+    expect(countByFlag(photos)).toEqual({ pick: 2, neutral: 2, reject: 1, total: 5 });
+  });
+
+  it('zeros all counts on an empty pool', () => {
+    expect(countByFlag([])).toEqual({ pick: 0, neutral: 0, reject: 0, total: 0 });
+  });
+});

--- a/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
@@ -284,3 +284,50 @@ describe('flow: drop → promote → demote → flag → cleanup', () => {
     expect(session.candidates?.photos).toHaveLength(0);
   });
 });
+
+// PR #62 review G13: legacy sessions on disk don't have a `candidates`
+// field. The helpers must treat that the same as an empty pool, otherwise
+// reading an old session triggers a crash before the user can even
+// migrate. The hook layer never constructs `undefined` candidates today,
+// but persistence boundary code can.
+describe('candidate helpers handle undefined session.candidates (legacy)', () => {
+  function makeLegacySession(): ApiPhotoSession {
+    return {
+      id: 'sess-legacy',
+      version: 1,
+      createdAt: '2026-04-01T00:00:00Z',
+      updatedAt: '2026-04-01T00:00:00Z',
+      mode: 'track',
+      competition_name: 'Legacy',
+      sets: {
+        set1: { title: 'Set 1', photos: [] },
+        set2: { title: 'Set 2', photos: [] },
+      },
+      // candidates: intentionally absent
+    };
+  }
+
+  it('setCandidateFlag returns same session when candidates is undefined', () => {
+    const session = makeLegacySession();
+    const next = setCandidateFlag(session, 'any', 'pick');
+    expect(next).toBe(session);
+  });
+
+  it('removeCandidate returns same session when candidates is undefined', () => {
+    const session = makeLegacySession();
+    const next = removeCandidate(session, 'any');
+    expect(next).toBe(session);
+  });
+
+  it('clearAllCandidates returns same session when candidates is undefined', () => {
+    const session = makeLegacySession();
+    const next = clearAllCandidates(session);
+    expect(next).toBe(session);
+  });
+
+  it('updateCandidateCanvasState returns same session when candidates is undefined', () => {
+    const session = makeLegacySession();
+    const next = updateCandidateCanvasState(session, 'any', { brightness: 5 });
+    expect(next).toBe(session);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import {
+  promoteCandidateToSlot,
+  demoteSlotToCandidate,
+  setCandidateFlag,
+  removeCandidate,
+  clearAllCandidates,
+  updateCandidateCanvasState,
+} from '../utils/candidateTransitions';
+import type { ApiPhoto, ApiPhotoSession, CandidateFlag } from '../types/api';
+
+// Pure-helper tests — the hook layer calls these and then writes the result.
+// If these are correct, slot↔tray UX correctness reduces to "does the hook
+// call the right helper with the right arguments." See docs/CANDIDATE_PHOTOS.md.
+
+function makePhoto(id: string, extras: Partial<ApiPhoto> = {}): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob:${id}`,
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 },
+      scale: 1,
+      brightness: 0,
+      contrast: 1,
+      sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    } as any,
+    label: '',
+    ...extras,
+  };
+}
+
+function makeSession(
+  set1Photos: ApiPhoto[],
+  set2Photos: ApiPhoto[],
+  candidates: ApiPhoto[],
+): ApiPhotoSession {
+  return {
+    id: 'sess-1',
+    version: 1,
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+    mode: 'track',
+    competition_name: 'Test',
+    sets: {
+      set1: { title: 'Set 1', photos: set1Photos },
+      set2: { title: 'Set 2', photos: set2Photos },
+    },
+    candidates: { photos: candidates },
+  };
+}
+
+describe('promoteCandidateToSlot', () => {
+  it('promotes candidate into empty slot, clears flag', () => {
+    const cand = makePhoto('c1', { flag: 'pick' as CandidateFlag });
+    const session = makeSession([], [], [cand]);
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 0);
+
+    expect(next.candidates?.photos).toHaveLength(0);
+    expect(next.sets.set1.photos).toHaveLength(1);
+    expect(next.sets.set1.photos[0].id).toBe('c1');
+    expect(next.sets.set1.photos[0].flag).toBeUndefined();
+    expect(next.version).toBe(session.version + 1);
+  });
+
+  it('appends when slot index is past the end (clamped to append)', () => {
+    const cand = makePhoto('c1');
+    const existing = makePhoto('s1');
+    const session = makeSession([existing], [], [cand]);
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 99);
+
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['s1', 'c1']);
+    expect(next.candidates?.photos).toHaveLength(0);
+  });
+
+  it('swaps with occupied slot — old slot photo returns as pick', () => {
+    const cand = makePhoto('c1', { flag: 'neutral' as CandidateFlag });
+    const s1 = makePhoto('s1');
+    const s2 = makePhoto('s2');
+    const session = makeSession([s1, s2], [], [cand]);
+
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 0);
+
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['c1', 's2']);
+    expect(next.sets.set1.photos[0].flag).toBeUndefined();
+    expect(next.candidates?.photos).toHaveLength(1);
+    expect(next.candidates?.photos[0].id).toBe('s1');
+    expect(next.candidates?.photos[0].flag).toBe('pick');
+  });
+
+  it('preserves canvasState across promotion', () => {
+    const cand = makePhoto('c1');
+    cand.canvasState = { ...cand.canvasState, brightness: 0.5 } as any;
+    const session = makeSession([], [], [cand]);
+
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 0);
+    expect((next.sets.set1.photos[0].canvasState as any).brightness).toBe(0.5);
+  });
+
+  it('no-op when candidate id is unknown', () => {
+    const session = makeSession([], [], []);
+    const next = promoteCandidateToSlot(session, 'missing', 'set1', 0);
+    expect(next).toBe(session);
+  });
+});
+
+describe('demoteSlotToCandidate', () => {
+  it('demotes slot photo with default flag = pick', () => {
+    const s1 = makePhoto('s1');
+    const session = makeSession([s1], [], []);
+    const next = demoteSlotToCandidate(session, 'set1', 's1');
+
+    expect(next.sets.set1.photos).toHaveLength(0);
+    expect(next.candidates?.photos).toHaveLength(1);
+    expect(next.candidates?.photos[0].id).toBe('s1');
+    expect(next.candidates?.photos[0].flag).toBe('pick');
+  });
+
+  it('appends to existing candidates pool', () => {
+    const c1 = makePhoto('c1', { flag: 'reject' as CandidateFlag });
+    const s1 = makePhoto('s1');
+    const session = makeSession([s1], [], [c1]);
+
+    const next = demoteSlotToCandidate(session, 'set1', 's1');
+    expect(next.candidates?.photos.map(p => p.id)).toEqual(['c1', 's1']);
+    expect(next.candidates?.photos[0].flag).toBe('reject');
+    expect(next.candidates?.photos[1].flag).toBe('pick');
+  });
+
+  it('no-op when slot photo id is unknown', () => {
+    const session = makeSession([], [], []);
+    const next = demoteSlotToCandidate(session, 'set1', 'missing');
+    expect(next).toBe(session);
+  });
+});
+
+describe('setCandidateFlag', () => {
+  it('updates flag from pick → reject', () => {
+    const c1 = makePhoto('c1', { flag: 'pick' as CandidateFlag });
+    const session = makeSession([], [], [c1]);
+    const next = setCandidateFlag(session, 'c1', 'reject');
+    expect(next.candidates?.photos[0].flag).toBe('reject');
+  });
+
+  it('no-op when id is unknown', () => {
+    const c1 = makePhoto('c1');
+    const session = makeSession([], [], [c1]);
+    const next = setCandidateFlag(session, 'missing', 'reject');
+    expect(next).toBe(session);
+  });
+});
+
+describe('removeCandidate', () => {
+  it('drops the matching candidate, preserves others', () => {
+    const session = makeSession([], [], [makePhoto('c1'), makePhoto('c2'), makePhoto('c3')]);
+    const next = removeCandidate(session, 'c2');
+    expect(next.candidates?.photos.map(p => p.id)).toEqual(['c1', 'c3']);
+  });
+
+  it('no-op when id is unknown', () => {
+    const session = makeSession([], [], [makePhoto('c1')]);
+    const next = removeCandidate(session, 'missing');
+    expect(next).toBe(session);
+  });
+});
+
+describe('clearAllCandidates', () => {
+  it('empties the pool and bumps version', () => {
+    const session = makeSession([], [], [makePhoto('c1'), makePhoto('c2')]);
+    const next = clearAllCandidates(session);
+    expect(next.candidates?.photos).toHaveLength(0);
+    expect(next.version).toBe(session.version + 1);
+  });
+
+  it('no-op when pool is already empty', () => {
+    const session = makeSession([], [], []);
+    const next = clearAllCandidates(session);
+    expect(next).toBe(session);
+  });
+});
+
+describe('updateCandidateCanvasState', () => {
+  it('merges canvasState partial without dropping other fields', () => {
+    const c1 = makePhoto('c1');
+    c1.canvasState = { ...c1.canvasState, brightness: 0.2 } as any;
+    const session = makeSession([], [], [c1]);
+
+    const next = updateCandidateCanvasState(session, 'c1', { contrast: 1.5 });
+
+    expect((next.candidates?.photos[0].canvasState as any).brightness).toBe(0.2);
+    expect((next.candidates?.photos[0].canvasState as any).contrast).toBe(1.5);
+  });
+
+  it('no-op when id is unknown', () => {
+    const session = makeSession([], [], [makePhoto('c1')]);
+    const next = updateCandidateCanvasState(session, 'missing', { brightness: 1 });
+    expect(next).toBe(session);
+  });
+});
+
+describe('flow: drop → promote → demote → flag → cleanup', () => {
+  it('simulates the v1 cull workflow end-to-end', () => {
+    // Start with 3 candidates, empty slots.
+    let session = makeSession([], [], [
+      makePhoto('a', { flag: 'neutral' as CandidateFlag }),
+      makePhoto('b', { flag: 'neutral' as CandidateFlag }),
+      makePhoto('c', { flag: 'neutral' as CandidateFlag }),
+    ]);
+
+    // Mark 'a' as a pick.
+    session = setCandidateFlag(session, 'a', 'pick');
+    expect(session.candidates?.photos[0].flag).toBe('pick');
+
+    // Promote 'a' to set1.
+    session = promoteCandidateToSlot(session, 'a', 'set1', 0);
+    expect(session.sets.set1.photos[0].id).toBe('a');
+    expect(session.sets.set1.photos[0].flag).toBeUndefined();
+    expect(session.candidates?.photos).toHaveLength(2);
+
+    // Reject 'b'.
+    session = setCandidateFlag(session, 'b', 'reject');
+    expect(session.candidates?.photos.find(p => p.id === 'b')?.flag).toBe('reject');
+
+    // User changes their mind — demote 'a' back to tray.
+    session = demoteSlotToCandidate(session, 'set1', 'a');
+    expect(session.sets.set1.photos).toHaveLength(0);
+    expect(session.candidates?.photos.find(p => p.id === 'a')?.flag).toBe('pick');
+
+    // Final cleanup wipes the pool.
+    session = clearAllCandidates(session);
+    expect(session.candidates?.photos).toHaveLength(0);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
@@ -105,6 +105,56 @@ describe('promoteCandidateToSlot', () => {
     const next = promoteCandidateToSlot(session, 'missing', 'set1', 0);
     expect(next).toBe(session);
   });
+
+  // PR #62 review A1: pinning current behavior for negative `slotIndex` so a
+  // refactor (e.g., a stricter guard) doesn't silently change behavior. The
+  // hook wrapper now clamps `slotIndex` to a safe range, but the pure helper
+  // historically accepted negatives — `Math.min(-1, photos.length)` yields -1
+  // which `splice(-1, 0, x)` interprets as "insert before the last element".
+  it('with negative slotIndex on empty set: appends at index 0', () => {
+    const cand = makePhoto('c1');
+    const session = makeSession([], [], [cand]);
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', -1);
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['c1']);
+  });
+
+  it('with negative slotIndex on populated set: inserts before last element', () => {
+    const cand = makePhoto('c1');
+    const session = makeSession([makePhoto('s1'), makePhoto('s2')], [], [cand]);
+    // photos.length=2; slotIndex=-1; splice(min(-1,2)=-1, 0, c1) → ['s1','c1','s2']
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', -1);
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['s1', 'c1', 's2']);
+  });
+
+  // PR #62 review C1 + A3: when "Send to Set X" is called on a full set, the
+  // AppApi handler now passes `slotIndex = capacity - 1`, which lands in the
+  // swap branch. This test pins the helper-level behavior the handler relies on.
+  it('with slotIndex = length - 1 on full set: SWAPS with the last photo (not append)', () => {
+    const cand = makePhoto('c1', { flag: 'pick' as CandidateFlag });
+    const slots = Array.from({ length: 9 }, (_, i) => makePhoto(`s${i + 1}`));
+    const session = makeSession(slots, [], [cand]);
+
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 8);
+
+    expect(next.sets.set1.photos).toHaveLength(9);
+    expect(next.sets.set1.photos[8].id).toBe('c1');
+    expect(next.sets.set1.photos[8].flag).toBeUndefined();
+    expect(next.candidates?.photos.map(p => p.id)).toEqual(['s9']);
+    expect(next.candidates?.photos[0].flag).toBe('pick');
+  });
+
+  // Documents the original C1 bug, kept as a regression marker: with
+  // slotIndex == photos.length on a full set, the helper falls into the
+  // APPEND branch (NOT swap). This is why the hook wrapper / handler must
+  // clamp to capacity-1 before calling.
+  it('with slotIndex = length on full set: APPENDS past capacity (helper unaware of capacity)', () => {
+    const cand = makePhoto('c1');
+    const slots = Array.from({ length: 9 }, (_, i) => makePhoto(`s${i + 1}`));
+    const session = makeSession(slots, [], [cand]);
+    const next = promoteCandidateToSlot(session, 'c1', 'set1', 9);
+    expect(next.sets.set1.photos).toHaveLength(10);
+    expect(next.sets.set1.photos[9].id).toBe('c1');
+  });
 });
 
 describe('demoteSlotToCandidate', () => {

--- a/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
+++ b/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
@@ -30,7 +30,15 @@ function ensureChildDir(parent: Entry, name: string, create: boolean): Entry {
   if (parent.kind !== 'dir') throw new Error(`Not a directory`);
   let child = parent.children.get(name);
   if (!child) {
-    if (!create) throw new Error(`Directory missing: ${name}`);
+    if (!create) {
+      // Mirror real OPFS: a missing directory looked up with create:false
+      // throws a DOMException with name 'NotFoundError'. PR #62 review I3
+      // depends on this name to distinguish "already cleaned" from a real
+      // transient error.
+      const err = new Error(`Directory missing: ${name}`);
+      err.name = 'NotFoundError';
+      throw err;
+    }
     child = makeDir();
     parent.children.set(name, child);
   }
@@ -418,5 +426,49 @@ describe('competitionService — candidate pool roundtrip', () => {
 
     const result = await competitionService.deletePhotosByIds(created.id, ['keep', 'boom']);
     expect(result.failed).toEqual(['boom']);
+  });
+
+  // PR #62 review I3: pre-fix, ANY error opening the competition / photos dir
+  // was conflated with "doesn't exist" and the caller saw `{ failed: [] }`
+  // — orphan OPFS files accumulated silently while the cleanup dialog
+  // claimed success. The fix narrows the success-treated path to errors
+  // whose `name === 'NotFoundError'` (real OPFS semantics) and reports any
+  // other error as a partial failure with ALL ids in `failed`.
+  it('deletePhotosByIds reports all ids as failed when the dir lookup throws a non-NotFoundError', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const created = await competitionService.createCompetition('Boom', makeSession({ candidates: [makePhoto('a')] }));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Inject a transient error from the dir lookup. This is what OPFS would
+    // throw under lock contention or quota issues — NOT 'NotFoundError'.
+    const original = storageMock.getDirectoryHandle.bind(storageMock);
+    storageMock.getDirectoryHandle = (async (parent, name, options) => {
+      if (name === 'photos') {
+        // Lock contention from another tab — real OPFS surfaces this as
+        // 'InvalidStateError' or 'NoModificationAllowedError', not
+        // 'NotFoundError'. The fix MUST treat it as a failure.
+        const e = new Error('simulated transient OPFS error');
+        e.name = 'InvalidStateError';
+        throw e;
+      }
+      return original(parent, name, options);
+    }) as typeof storageMock.getDirectoryHandle;
+
+    const result = await competitionService.deletePhotosByIds(created.id, ['a', 'b', 'c']);
+    expect(result.failed).toEqual(['a', 'b', 'c']);
+    // The fix swapped console.warn for console.error on the real-failure
+    // branch so it's visible in production logs at the right severity.
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('deletePhotosByIds treats NotFoundError as already-cleaned (returns empty failed)', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    // Genuine "competition gone": the mock InMemoryStorage throws
+    // NotFoundError when getDirectoryHandle hits a non-existent name with
+    // create:false. PR #62 review I3 keeps this as the ONLY error type
+    // that's treated as success.
+    const result = await competitionService.deletePhotosByIds('comp-truly-gone', ['x', 'y']);
+    expect(result).toEqual({ failed: [] });
   });
 });

--- a/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
+++ b/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
@@ -26,13 +26,6 @@ type Entry =
 
 function makeDir(): Entry { return { kind: 'dir', children: new Map() }; }
 
-function getChildOrThrow(parent: Entry, name: string): Entry {
-  if (parent.kind !== 'dir') throw new Error(`Not a directory`);
-  const child = parent.children.get(name);
-  if (!child) throw new Error(`Entry not found: ${name}`);
-  return child;
-}
-
 function ensureChildDir(parent: Entry, name: string, create: boolean): Entry {
   if (parent.kind !== 'dir') throw new Error(`Not a directory`);
   let child = parent.children.get(name);
@@ -161,13 +154,11 @@ beforeEach(async () => {
   urlCounter = 0;
   createdUrls.clear();
   storageMock = new InMemoryStorage();
-  // @ts-expect-error — jsdom URL global
   globalThis.URL.createObjectURL = (blob: Blob) => {
     const id = `blob:test/${++urlCounter}`;
     createdUrls.set(id, blob);
     return id;
   };
-  // @ts-expect-error
   globalThis.URL.revokeObjectURL = (url: string) => { createdUrls.delete(url); };
   // Service's saveSessionPhotos calls `fetch(blob:url)` then `.blob()`. jsdom
   // doesn't implement that, so route through our map.
@@ -304,8 +295,13 @@ describe('competitionService — candidate pool roundtrip', () => {
 
   it('deletePhotosByIds is a safe no-op for an unknown competition id', async () => {
     const { competitionService } = await import('../services/competitionService');
-    // Should not throw — `saveSessionPhotos` deliberately swallows missing-dir.
-    await expect(competitionService.deletePhotosByIds('comp-nonexistent', ['x'])).resolves.toBeUndefined();
+    // Missing competition directory → treated as already-cleaned. `failed`
+    // is empty (the entries don't exist, so no per-id failure to report).
+    // Per PR #62 review CRIT-3 the function returns `{ failed }` so callers
+    // can surface partial OPFS failures.
+    await expect(
+      competitionService.deletePhotosByIds('comp-nonexistent', ['x'])
+    ).resolves.toEqual({ failed: [] });
   });
 
   it('updates and reloads — candidate flag changes are persisted even when photoCount is unchanged', async () => {
@@ -327,5 +323,100 @@ describe('competitionService — candidate pool roundtrip', () => {
 
     const reloaded = await competitionService.getCompetition(created.id);
     expect(reloaded!.session.candidates?.photos[0].flag).toBe('reject');
+  });
+
+  // PR #62 review G11: a session that has both mode buckets populated AND a
+  // candidate pool must round-trip cleanly — deduplication preserves the
+  // blob URL across containers, and each container loads back independently.
+  it('round-trips a session with setsTrack, setsTurning, AND candidates all populated', async () => {
+    const { competitionService } = await import('../services/competitionService');
+
+    // Build a "rich" session: same id shared across active sets, mode
+    // buckets, and a tray photo.
+    const shared = makePhoto('shared-1');
+    const trackOnly = makePhoto('track-only');
+    const turningOnly = makePhoto('turning-only');
+    const candOnly = makePhoto('cand-only', { flag: 'pick' });
+
+    const session: ApiPhotoSession = {
+      id: 'sess-rich',
+      version: 1,
+      createdAt: '2026-05-12T00:00:00Z',
+      updatedAt: '2026-05-12T00:00:00Z',
+      mode: 'track',
+      competition_name: 'Rich',
+      sets: { set1: { title: 'S1', photos: [shared] }, set2: { title: 'S2', photos: [] } },
+      setsTrack: { set1: { title: 'S1', photos: [shared, trackOnly] }, set2: { title: 'S2', photos: [] } },
+      setsTurning: { set1: { title: 'S1', photos: [turningOnly] }, set2: { title: 'S2', photos: [] } },
+      candidates: { photos: [candOnly] },
+    };
+
+    const created = await competitionService.createCompetition('Rich', session);
+    const reloaded = await competitionService.getCompetition(created.id);
+    expect(reloaded).toBeTruthy();
+
+    // All four containers come back with rehydrated blob URLs.
+    expect(reloaded!.session.sets.set1.photos.map(p => p.id)).toEqual(['shared-1']);
+    expect(reloaded!.session.setsTrack?.set1.photos.map(p => p.id)).toEqual(['shared-1', 'track-only']);
+    expect(reloaded!.session.setsTurning?.set1.photos.map(p => p.id)).toEqual(['turning-only']);
+    expect(reloaded!.session.candidates?.photos.map(p => p.id)).toEqual(['cand-only']);
+
+    // The shared id reloads with a blob URL in BOTH places (separate
+    // `URL.createObjectURL` calls — they are independent strings but both
+    // valid). Tests that the deduplication-by-id in `saveSessionPhotos`
+    // doesn't accidentally write only one copy.
+    const sharedInActive = reloaded!.session.sets.set1.photos[0];
+    const sharedInTrack = reloaded!.session.setsTrack!.set1.photos.find(p => p.id === 'shared-1')!;
+    expect(sharedInActive.url.startsWith('blob:')).toBe(true);
+    expect(sharedInTrack.url.startsWith('blob:')).toBe(true);
+
+    // Candidate-only id keeps its flag through the round-trip.
+    expect(reloaded!.session.candidates?.photos[0].flag).toBe('pick');
+  });
+
+  // PR #62 review G12: an OPFS blob that was evicted (cross-device sync,
+  // user wiping the photos/ subdir) must not crash the entire load —
+  // a single missing blob should not block opening the competition.
+  it('reloads gracefully when one candidate blob is missing on disk', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const c1 = makePhoto('c1');
+    const c2 = makePhoto('c2');
+    const created = await competitionService.createCompetition('MissingBlob', makeSession({ candidates: [c1, c2] }));
+
+    // Evict one blob by deleting it directly from the storage mock.
+    const photosDir = { path: `/competitions/${created.id}/photos` } as DirectoryHandle;
+    await storageMock.deletePhotoFile(photosDir, 'c1');
+
+    // Reload must not throw — the surviving blob loads as usual, the
+    // missing one either drops out or surfaces with a fallback. We assert
+    // only that the call resolves and the other photo is still reachable.
+    await expect(competitionService.getCompetition(created.id)).resolves.toBeTruthy();
+    const reloaded = await competitionService.getCompetition(created.id);
+    const ids = reloaded!.session.candidates?.photos.map(p => p.id) ?? [];
+    expect(ids).toContain('c2');
+  });
+
+  // PR #62 review CRIT-3: the new `{ failed }` return shape lets the cleanup
+  // dialog distinguish partial failure from success. Pin both branches.
+  it('deletePhotosByIds returns empty `failed` array on the happy path', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const created = await competitionService.createCompetition('OK', makeSession({ candidates: [makePhoto('a'), makePhoto('b')] }));
+    const result = await competitionService.deletePhotosByIds(created.id, ['a', 'b']);
+    expect(result).toEqual({ failed: [] });
+  });
+
+  it('deletePhotosByIds reports per-id failures in `failed`', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const created = await competitionService.createCompetition('Partial', makeSession({ candidates: [makePhoto('keep')] }));
+    // Stub `deletePhotoFile` to throw for one specific id so we exercise
+    // the partial-failure path without touching real OPFS.
+    const original = storageMock.deletePhotoFile.bind(storageMock);
+    storageMock.deletePhotoFile = (async (dir, id) => {
+      if (id === 'boom') throw new Error('simulated OPFS write error');
+      return original(dir, id);
+    }) as typeof storageMock.deletePhotoFile;
+
+    const result = await competitionService.deletePhotosByIds(created.id, ['keep', 'boom']);
+    expect(result.failed).toEqual(['boom']);
   });
 });

--- a/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
+++ b/frontend/photo-helper/src/__tests__/competitionServiceRoundtrip.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { DirectoryHandle, StorageInterface } from '@airq/shared-storage';
+import type { ApiPhoto, ApiPhotoSession } from '../types/api';
+// Note: competitionService is dynamic-imported inside each test so the
+// `vi.mock` hoist below takes effect before the service captures the mocked
+// `getStorage` reference. We then reset the singleton's cached handles in
+// `beforeEach` so each test starts on a fresh storageMock.
+
+// PR #62 review gap B1: docs/CANDIDATE_PHOTOS.md test plan promised
+// `competitionServiceRoundtrip.test.ts` but it was never written. This file
+// fills that gap: it pins sanitize → write JSON → read JSON → load (with blob
+// rehydration) so flag / canvasState / candidate-pool round-trip survive
+// future persistence refactors.
+
+// ── In-memory storage adapter ────────────────────────────────────────────────
+// Implements the StorageInterface contract enough for the roundtrip we care
+// about (dir lookup, writeJSON/readJSON, savePhotoFile/getPhotoBlob,
+// deletePhotoFile, list/clear, estimate). Mirrors OPFSStorage's "create or
+// fail" semantics. The competitionService consumes it through the singleton
+// `getStorage()`, so we mock the module export.
+
+type Entry =
+  | { kind: 'dir'; children: Map<string, Entry> }
+  | { kind: 'json'; data: unknown }
+  | { kind: 'blob'; blob: Blob; mime: string };
+
+function makeDir(): Entry { return { kind: 'dir', children: new Map() }; }
+
+function getChildOrThrow(parent: Entry, name: string): Entry {
+  if (parent.kind !== 'dir') throw new Error(`Not a directory`);
+  const child = parent.children.get(name);
+  if (!child) throw new Error(`Entry not found: ${name}`);
+  return child;
+}
+
+function ensureChildDir(parent: Entry, name: string, create: boolean): Entry {
+  if (parent.kind !== 'dir') throw new Error(`Not a directory`);
+  let child = parent.children.get(name);
+  if (!child) {
+    if (!create) throw new Error(`Directory missing: ${name}`);
+    child = makeDir();
+    parent.children.set(name, child);
+  }
+  if (child.kind !== 'dir') throw new Error(`Path is not a directory: ${name}`);
+  return child;
+}
+
+class InMemoryStorage implements StorageInterface {
+  // Each directory handle has a stable `path` so the service can compare them
+  // and the mock can resolve back to the underlying entry.
+  root: Entry = makeDir();
+  pathToEntry: Map<string, Entry> = new Map();
+
+  constructor() {
+    this.pathToEntry.set('/', this.root);
+  }
+
+  async init() {
+    const sessionsDir = ensureChildDir(this.root, 'sessions', true);
+    this.pathToEntry.set('/sessions', sessionsDir);
+    return {
+      root: { path: '/' } as DirectoryHandle,
+      sessions: { path: '/sessions' } as DirectoryHandle,
+    };
+  }
+
+  async ensureSessionDirs(_id: string) {
+    return {
+      dir: { path: '/' } as DirectoryHandle,
+      photos: { path: '/' } as DirectoryHandle,
+    };
+  }
+
+  async writeJSON(dir: DirectoryHandle, name: string, data: unknown) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${dir.path}`);
+    entry.children.set(name, { kind: 'json', data: JSON.parse(JSON.stringify(data)) });
+  }
+
+  async readJSON<T>(dir: DirectoryHandle, name: string): Promise<T | null> {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return null;
+    const file = entry.children.get(name);
+    if (!file || file.kind !== 'json') return null;
+    return JSON.parse(JSON.stringify(file.data)) as T;
+  }
+
+  async savePhotoFile(photosDir: DirectoryHandle, photoId: string, file: File) {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${photosDir.path}`);
+    const buf = await file.arrayBuffer();
+    entry.children.set(photoId, { kind: 'blob', blob: new Blob([buf], { type: file.type }), mime: file.type });
+  }
+
+  async getPhotoBlob(photosDir: DirectoryHandle, photoId: string): Promise<Blob> {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${photosDir.path}`);
+    const file = entry.children.get(photoId);
+    if (!file || file.kind !== 'blob') throw new Error(`Photo not found: ${photoId}`);
+    return file.blob;
+  }
+
+  async deletePhotoFile(photosDir: DirectoryHandle, photoId: string) {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') return;
+    entry.children.delete(photoId);
+  }
+
+  async clearDirectory(dir: DirectoryHandle) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return;
+    entry.children.clear();
+  }
+
+  async deleteSessionDir() { /* unused */ }
+
+  async getDirectoryHandle(parent: DirectoryHandle, name: string, options?: { create?: boolean }) {
+    const parentEntry = this.pathToEntry.get(parent.path);
+    if (!parentEntry) throw new Error(`Parent dir missing: ${parent.path}`);
+    const child = ensureChildDir(parentEntry, name, !!options?.create);
+    const childPath = parent.path === '/' ? `/${name}` : `${parent.path}/${name}`;
+    this.pathToEntry.set(childPath, child);
+    return { path: childPath } as DirectoryHandle;
+  }
+
+  async isAvailable() { return true; }
+
+  async getStorageEstimate() { return { usage: 0, quota: 1024 * 1024 * 1024 }; }
+
+  async listDirectory(dir: DirectoryHandle) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return [];
+    return [...entry.children.entries()].map(([name, e]) => ({
+      name,
+      isDirectory: e.kind === 'dir',
+    }));
+  }
+}
+
+let storageMock: InMemoryStorage;
+
+// Mock the shared-storage module BEFORE importing competitionService. The
+// service captures `getStorage()` at call time, so the mock just needs to
+// return our in-memory adapter consistently.
+vi.mock('@airq/shared-storage', async () => {
+  const actual = await vi.importActual<any>('@airq/shared-storage');
+  return {
+    ...actual,
+    initStorage: vi.fn(async () => storageMock),
+    getStorage: vi.fn(() => storageMock),
+  };
+});
+
+// Mock URL.createObjectURL / revokeObjectURL — jsdom provides them but they
+// return opaque strings that don't round-trip via fetch(). The service
+// rehydrates URLs via createObjectURL on load; for our roundtrip we only
+// care that the URL is a string starting with `blob:`.
+let urlCounter = 0;
+const createdUrls = new Map<string, Blob>();
+beforeEach(async () => {
+  urlCounter = 0;
+  createdUrls.clear();
+  storageMock = new InMemoryStorage();
+  // @ts-expect-error — jsdom URL global
+  globalThis.URL.createObjectURL = (blob: Blob) => {
+    const id = `blob:test/${++urlCounter}`;
+    createdUrls.set(id, blob);
+    return id;
+  };
+  // @ts-expect-error
+  globalThis.URL.revokeObjectURL = (url: string) => { createdUrls.delete(url); };
+  // Service's saveSessionPhotos calls `fetch(blob:url)` then `.blob()`. jsdom
+  // doesn't implement that, so route through our map.
+  globalThis.fetch = (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const blob = createdUrls.get(url);
+    if (!blob) return Promise.reject(new Error(`Mock fetch: unknown URL ${url}`));
+    return Promise.resolve({ blob: async () => blob } as any);
+  };
+  // The competitionService is a module-singleton that caches `this.storage`,
+  // `this.handles`, and `this.competitionsDir` on first `initialize()`. Wipe
+  // those between tests so `ensureInitialized` re-grabs the fresh mock.
+  const { competitionService } = await import('../services/competitionService');
+  (competitionService as any).storage = null;
+  (competitionService as any).handles = null;
+  (competitionService as any).competitionsDir = null;
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+function makePhoto(id: string, overrides: Partial<ApiPhoto> = {}): ApiPhoto {
+  const url = URL.createObjectURL(new Blob([id], { type: 'image/jpeg' }));
+  return {
+    id,
+    sessionId: 'sess-1',
+    url,
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 },
+      scale: 1,
+      brightness: 0,
+      contrast: 1,
+      sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    } as any,
+    label: '',
+    ...overrides,
+  };
+}
+
+function makeSession(opts: {
+  set1?: ApiPhoto[];
+  set2?: ApiPhoto[];
+  candidates?: ApiPhoto[];
+  includeCandidatesField?: boolean;
+}): ApiPhotoSession {
+  const base: ApiPhotoSession = {
+    id: 'sess-1',
+    version: 1,
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+    mode: 'track',
+    competition_name: 'Test',
+    sets: {
+      set1: { title: 'Set 1', photos: opts.set1 ?? [] },
+      set2: { title: 'Set 2', photos: opts.set2 ?? [] },
+    },
+  };
+  if (opts.includeCandidatesField !== false) {
+    base.candidates = { photos: opts.candidates ?? [] };
+  }
+  return base;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+describe('competitionService — candidate pool roundtrip', () => {
+  it('persists flags and canvasState through create → reload', async () => {
+    const { competitionService } = await import('../services/competitionService');
+
+    const cand1 = makePhoto('cand-1', { flag: 'pick' });
+    cand1.canvasState = { ...cand1.canvasState, brightness: 0.42 } as any;
+    const cand2 = makePhoto('cand-2', { flag: 'reject' });
+    const slot1 = makePhoto('slot-1');
+
+    const session = makeSession({ set1: [slot1], candidates: [cand1, cand2] });
+    const created = await competitionService.createCompetition('TestComp', session);
+
+    // Sanity: on-disk JSON has URLs stripped (sanitize) but flag + canvasState present.
+    const savedJson = await storageMock.readJSON<ApiPhotoSession>(
+      { path: `/competitions/${created.id}` } as DirectoryHandle,
+      'session.json',
+    );
+    expect(savedJson).toBeTruthy();
+    expect(savedJson!.candidates?.photos).toHaveLength(2);
+    expect(savedJson!.candidates?.photos.every(p => p.url === '')).toBe(true);
+    expect(savedJson!.candidates?.photos[0].flag).toBe('pick');
+    expect(savedJson!.candidates?.photos[1].flag).toBe('reject');
+    expect((savedJson!.candidates?.photos[0].canvasState as any).brightness).toBe(0.42);
+
+    // Reload — blob URLs rehydrated, candidate pool intact.
+    const reloaded = await competitionService.getCompetition(created.id);
+    expect(reloaded).toBeTruthy();
+    expect(reloaded!.session.candidates?.photos).toHaveLength(2);
+    const reloadedCand1 = reloaded!.session.candidates!.photos.find(p => p.id === 'cand-1')!;
+    expect(reloadedCand1.flag).toBe('pick');
+    expect(reloadedCand1.url.startsWith('blob:')).toBe(true);
+    expect((reloadedCand1.canvasState as any).brightness).toBe(0.42);
+    const reloadedCand2 = reloaded!.session.candidates!.photos.find(p => p.id === 'cand-2')!;
+    expect(reloadedCand2.flag).toBe('reject');
+    expect(reloaded!.session.sets.set1.photos[0].id).toBe('slot-1');
+    expect(reloaded!.session.sets.set1.photos[0].url.startsWith('blob:')).toBe(true);
+  });
+
+  it('handles legacy session without a candidates field', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const session = makeSession({ set1: [makePhoto('slot-1')], includeCandidatesField: false });
+    const created = await competitionService.createCompetition('Legacy', session);
+
+    const reloaded = await competitionService.getCompetition(created.id);
+    expect(reloaded).toBeTruthy();
+    // `loadCandidates(undefined)` returns undefined — the field round-trips as
+    // absent rather than `{ photos: [] }`. Code that reads it uses
+    // `session.candidates?.photos ?? []` per the contract.
+    expect(reloaded!.session.candidates).toBeUndefined();
+    expect(reloaded!.session.sets.set1.photos).toHaveLength(1);
+  });
+
+  it('deletePhotosByIds removes only the listed files from OPFS', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const c1 = makePhoto('c1');
+    const c2 = makePhoto('c2');
+    const c3 = makePhoto('c3');
+    const created = await competitionService.createCompetition('Cleanup', makeSession({ candidates: [c1, c2, c3] }));
+
+    const photosDir = { path: `/competitions/${created.id}/photos` } as DirectoryHandle;
+    const beforeNames = (await storageMock.listDirectory(photosDir)).map(e => e.name);
+    expect(new Set(beforeNames)).toEqual(new Set(['c1', 'c2', 'c3']));
+
+    await competitionService.deletePhotosByIds(created.id, ['c1', 'c3']);
+
+    const afterNames = (await storageMock.listDirectory(photosDir)).map(e => e.name);
+    expect(afterNames).toEqual(['c2']);
+  });
+
+  it('deletePhotosByIds is a safe no-op for an unknown competition id', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    // Should not throw — `saveSessionPhotos` deliberately swallows missing-dir.
+    await expect(competitionService.deletePhotosByIds('comp-nonexistent', ['x'])).resolves.toBeUndefined();
+  });
+
+  it('updates and reloads — candidate flag changes are persisted even when photoCount is unchanged', async () => {
+    const { competitionService } = await import('../services/competitionService');
+    const cand = makePhoto('cand-1', { flag: 'neutral' });
+    const created = await competitionService.createCompetition('FlagTest', makeSession({ candidates: [cand] }));
+
+    // Simulate `useCompetitionSystem.setCandidateFlag` writing back without
+    // `updatePhotos: true`. `updateCompetition` always writes session.json
+    // regardless of the flag, so the new flag MUST persist (PR #62 review).
+    const updatedSession = {
+      ...created.session,
+      candidates: { photos: [{ ...created.session.candidates!.photos[0], flag: 'reject' as const }] },
+    };
+    await competitionService.updateCompetition(
+      { ...created, session: updatedSession, lastModified: new Date().toISOString() },
+      { updatePhotos: false },
+    );
+
+    const reloaded = await competitionService.getCompetition(created.id);
+    expect(reloaded!.session.candidates?.photos[0].flag).toBe('reject');
+  });
+});

--- a/frontend/photo-helper/src/__tests__/dragPayload.test.ts
+++ b/frontend/photo-helper/src/__tests__/dragPayload.test.ts
@@ -133,6 +133,63 @@ describe('serializeDragPayload + parseDragPayload round-trip', () => {
   });
 });
 
+// PR #62 review I5: the original parser accepted any `typeof p.index === 'number'`
+// (so NaN, Infinity, negative, float, 1e20 all passed) and any string photoId
+// (including empty string). Downstream code in candidateTransitions clamps,
+// but defense-in-depth at the parser is cheap and removes a whole class of
+// "hostile or buggy producer" failure modes.
+describe('parseDragPayload — index/photoId bounds-checks (PR #62 review I5)', () => {
+  const slot = (overrides: Record<string, unknown>) =>
+    JSON.stringify({ kind: 'slot', setKey: 'set1', index: 0, photoId: 'p', ...overrides });
+
+  it('rejects slot payload with NaN index', () => {
+    // JSON serialises NaN to null, so we go around JSON.stringify here.
+    const raw = '{"kind":"slot","setKey":"set1","index":NaN,"photoId":"p"}';
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects slot payload with Infinity index', () => {
+    const raw = '{"kind":"slot","setKey":"set1","index":Infinity,"photoId":"p"}';
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects slot payload with negative index', () => {
+    expect(parseDragPayload(slot({ index: -1 }))).toBeNull();
+    expect(parseDragPayload(slot({ index: -999 }))).toBeNull();
+  });
+
+  it('rejects slot payload with float index', () => {
+    expect(parseDragPayload(slot({ index: 1.5 }))).toBeNull();
+    expect(parseDragPayload(slot({ index: 0.1 }))).toBeNull();
+  });
+
+  it('rejects slot payload with absurdly large index', () => {
+    expect(parseDragPayload(slot({ index: 1000 }))).toBeNull();
+    expect(parseDragPayload(slot({ index: 1e20 }))).toBeNull();
+  });
+
+  it('accepts boundary index values (0 and a realistic max)', () => {
+    expect(parseDragPayload(slot({ index: 0 }))).not.toBeNull();
+    expect(parseDragPayload(slot({ index: 999 }))).not.toBeNull();
+    expect(parseDragPayload(slot({ index: 9 }))).not.toBeNull(); // typical grid slot
+  });
+
+  it('rejects slot payload with empty-string photoId', () => {
+    expect(parseDragPayload(slot({ photoId: '' }))).toBeNull();
+  });
+
+  it('rejects tray payload with empty-string photoId', () => {
+    expect(parseDragPayload(JSON.stringify({ kind: 'tray', photoId: '' }))).toBeNull();
+  });
+
+  it('accepts tray payload with non-empty photoId', () => {
+    expect(parseDragPayload(JSON.stringify({ kind: 'tray', photoId: 'x' }))).toEqual({
+      kind: 'tray',
+      photoId: 'x',
+    });
+  });
+});
+
 describe('DRAG_PAYLOAD_MIME', () => {
   it('is the documented in-app MIME type and is stable across releases', () => {
     // Pinning the literal: changing this MIME breaks the drag contract

--- a/frontend/photo-helper/src/__tests__/dragPayload.test.ts
+++ b/frontend/photo-helper/src/__tests__/dragPayload.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  parseDragPayload,
+  serializeDragPayload,
+  DRAG_PAYLOAD_MIME,
+} from '../utils/dragPayload';
+
+// PR #62 review G3: the wire-format parser is the critical security
+// boundary for in-app drag-and-drop. The strict literal-union check on
+// `setKey` defends against `__proto__`-style prototype pollution where a
+// crafted payload would otherwise be used to index `session.sets[setKey]`
+// or `[modeKey]` — turning a drop into arbitrary object access. The check
+// used to live inline in both `PhotoGridApi.tsx` and `CandidateTray.tsx`;
+// this test pins it now that it's a shared helper.
+
+describe('parseDragPayload', () => {
+  it('returns null on null / undefined / empty input', () => {
+    expect(parseDragPayload(null)).toBeNull();
+    expect(parseDragPayload(undefined)).toBeNull();
+    expect(parseDragPayload('')).toBeNull();
+  });
+
+  it('returns null on malformed JSON (and logs a warning)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(parseDragPayload('{not json')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('malformed');
+    warnSpy.mockRestore();
+  });
+
+  it('returns null on JSON primitives (string, number, boolean, null)', () => {
+    expect(parseDragPayload('"a string"')).toBeNull();
+    expect(parseDragPayload('42')).toBeNull();
+    expect(parseDragPayload('true')).toBeNull();
+    expect(parseDragPayload('null')).toBeNull();
+  });
+
+  it('parses a valid tray payload', () => {
+    const raw = JSON.stringify({ kind: 'tray', photoId: 'photo-1' });
+    expect(parseDragPayload(raw)).toEqual({ kind: 'tray', photoId: 'photo-1' });
+  });
+
+  it('rejects tray payload with non-string photoId', () => {
+    expect(parseDragPayload(JSON.stringify({ kind: 'tray', photoId: 123 }))).toBeNull();
+    expect(parseDragPayload(JSON.stringify({ kind: 'tray', photoId: null }))).toBeNull();
+    expect(parseDragPayload(JSON.stringify({ kind: 'tray' }))).toBeNull();
+  });
+
+  it('parses a valid slot payload', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'set1', index: 3, photoId: 'photo-X' });
+    expect(parseDragPayload(raw)).toEqual({
+      kind: 'slot',
+      setKey: 'set1',
+      index: 3,
+      photoId: 'photo-X',
+    });
+  });
+
+  it('parses slot payload with setKey: set2', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'set2', index: 0, photoId: 'p' });
+    expect(parseDragPayload(raw)).toEqual({
+      kind: 'slot',
+      setKey: 'set2',
+      index: 0,
+      photoId: 'p',
+    });
+  });
+
+  // The critical security check: setKey is a literal union, and ANY other
+  // value (including string-typed `__proto__`, `constructor`, etc.) is
+  // rejected at the parser layer — downstream code never sees the foreign
+  // value. Failing any of these tests would re-enable prototype pollution.
+  it('rejects __proto__ as setKey (prototype pollution defense)', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: '__proto__', index: 0, photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects constructor as setKey', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'constructor', index: 0, photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects arbitrary string setKey', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'set3', index: 0, photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects empty-string setKey', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: '', index: 0, photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects slot payload with non-number index', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'set1', index: '3', photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects slot payload missing photoId', () => {
+    const raw = JSON.stringify({ kind: 'slot', setKey: 'set1', index: 0 });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects unrecognised kind', () => {
+    const raw = JSON.stringify({ kind: 'mystery', photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('rejects missing kind', () => {
+    const raw = JSON.stringify({ photoId: 'p' });
+    expect(parseDragPayload(raw)).toBeNull();
+  });
+
+  it('ignores extra fields without rejecting', () => {
+    const raw = JSON.stringify({
+      kind: 'tray',
+      photoId: 'p',
+      extra: { malicious: true },
+      injected: '__proto__',
+    });
+    expect(parseDragPayload(raw)).toEqual({ kind: 'tray', photoId: 'p' });
+  });
+});
+
+describe('serializeDragPayload + parseDragPayload round-trip', () => {
+  it('round-trips a tray payload', () => {
+    const original = { kind: 'tray' as const, photoId: 'photo-42' };
+    expect(parseDragPayload(serializeDragPayload(original))).toEqual(original);
+  });
+
+  it('round-trips a slot payload', () => {
+    const original = { kind: 'slot' as const, setKey: 'set1' as const, index: 5, photoId: 'photo-A' };
+    expect(parseDragPayload(serializeDragPayload(original))).toEqual(original);
+  });
+});
+
+describe('DRAG_PAYLOAD_MIME', () => {
+  it('is the documented in-app MIME type and is stable across releases', () => {
+    // Pinning the literal: changing this MIME breaks the drag contract
+    // between PhotoGridApi and CandidateTray. If you need to bump it,
+    // update both components AND remember the in-flight session
+    // compatibility (a previously serialised payload doesn't auto-migrate).
+    expect(DRAG_PAYLOAD_MIME).toBe('application/x-airq-photo');
+  });
+});
+
+beforeEach(() => {
+  // Quiet expected console.warn from the malformed-JSON path; tests that
+  // explicitly assert the warning re-enable it locally.
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/frontend/photo-helper/src/__tests__/sessionRefs.test.ts
+++ b/frontend/photo-helper/src/__tests__/sessionRefs.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { isPhotoReferencedInSession } from '../utils/sessionRefs';
+import type { ApiPhoto, ApiPhotoSession } from '../types/api';
+
+// PR #62 review IMP-2: the shared cross-bucket reference check used by every
+// candidate / slot deletion path. The OPFS file is shared across the active
+// `sets`, the per-mode buckets (`setsTrack`/`setsTurning`), and the
+// candidate pool. Deleting the file while ANY container still references
+// it would break the inactive mode on next load.
+
+function p(id: string): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob:${id}`,
+    filename: `${id}.jpg`,
+    canvasState: {} as any,
+    label: '',
+  };
+}
+
+function makeSession(opts: {
+  set1?: ApiPhoto[];
+  set2?: ApiPhoto[];
+  setsTrack?: { set1?: ApiPhoto[]; set2?: ApiPhoto[] };
+  setsTurning?: { set1?: ApiPhoto[]; set2?: ApiPhoto[] };
+  candidates?: ApiPhoto[];
+}): ApiPhotoSession {
+  const session: ApiPhotoSession = {
+    id: 'sess-1',
+    version: 1,
+    createdAt: '2026-05-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    mode: 'track',
+    competition_name: 'Test',
+    sets: {
+      set1: { title: 'Set 1', photos: opts.set1 ?? [] },
+      set2: { title: 'Set 2', photos: opts.set2 ?? [] },
+    },
+  };
+  if (opts.setsTrack) {
+    session.setsTrack = {
+      set1: { title: 'Set 1', photos: opts.setsTrack.set1 ?? [] },
+      set2: { title: 'Set 2', photos: opts.setsTrack.set2 ?? [] },
+    };
+  }
+  if (opts.setsTurning) {
+    session.setsTurning = {
+      set1: { title: 'Set 1', photos: opts.setsTurning.set1 ?? [] },
+      set2: { title: 'Set 2', photos: opts.setsTurning.set2 ?? [] },
+    };
+  }
+  if (opts.candidates) {
+    session.candidates = { photos: opts.candidates };
+  }
+  return session;
+}
+
+describe('isPhotoReferencedInSession', () => {
+  it('returns false for empty session', () => {
+    const s = makeSession({});
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(false);
+  });
+
+  it('returns false when id is not in any container', () => {
+    const s = makeSession({ set1: [p('a')], set2: [p('b')], candidates: [p('c')] });
+    expect(isPhotoReferencedInSession(s, 'missing')).toBe(false);
+  });
+
+  it('returns true when id is in active sets.set1', () => {
+    const s = makeSession({ set1: [p('x')] });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in active sets.set2', () => {
+    const s = makeSession({ set2: [p('x')] });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in setsTrack.set1', () => {
+    const s = makeSession({ setsTrack: { set1: [p('x')] } });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in setsTrack.set2', () => {
+    const s = makeSession({ setsTrack: { set2: [p('x')] } });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in setsTurning.set1', () => {
+    const s = makeSession({ setsTurning: { set1: [p('x')] } });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in setsTurning.set2', () => {
+    const s = makeSession({ setsTurning: { set2: [p('x')] } });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  it('returns true when id is in candidates pool', () => {
+    const s = makeSession({ candidates: [p('x')] });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  // The post-removePhoto state: `sets` no longer has photo, but the OTHER
+  // mode bucket still does. The shared OPFS file must NOT be deleted.
+  it('returns true when removed-from-active-sets photo still lives in the other mode bucket', () => {
+    const s = makeSession({
+      set1: [], // photo was just removed from here
+      setsTrack: { set1: [] }, // active mode bucket mirrored the removal
+      setsTurning: { set1: [p('x')] }, // OTHER mode bucket still references
+    });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+
+  // The post-removePhoto state with mirror applied: no other container
+  // references the id. The OPFS file is safe to delete.
+  it('returns false after slot removal mirrored into active bucket with no other refs', () => {
+    const s = makeSession({
+      set1: [], // photo was removed
+      setsTrack: { set1: [] }, // active bucket mirrored the removal
+      setsTurning: { set1: [] }, // inactive bucket also clean
+    });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(false);
+  });
+
+  // PR #62 review CRIT-3/IMP-2: the cleanup-dialog path must NOT
+  // delete a file that a slot still references, even if the same id is
+  // briefly present in candidates due to a race.
+  it('returns true when id is in BOTH candidates and a slot (defensive)', () => {
+    const s = makeSession({
+      set1: [p('x')],
+      candidates: [p('x')],
+    });
+    expect(isPhotoReferencedInSession(s, 'x')).toBe(true);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/slotDropDispatch.test.ts
+++ b/frontend/photo-helper/src/__tests__/slotDropDispatch.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { dispatchSlotDrop } from '../utils/slotDropDispatch';
+import type { DragPayload } from '../utils/dragPayload';
+
+// PR #62 review I4: the pre-fix `handleDrop` silently dropped native OS file
+// drops on occupied slots — neither the structured payload nor the text/plain
+// reorder matched, `e.preventDefault()` had already suppressed the dropzone
+// wrapper, and the files vanished from the cursor with no toast, no error,
+// no smart-drop routing. The extracted `dispatchSlotDrop` helper now decides
+// the action up-front so the component shell is pure dispatch and the rules
+// can be tested without rendering MUI/contexts/react-dropzone.
+
+const acceptAllImages = (f: File) => f.type.startsWith('image/');
+
+function makeFile(name: string, type = 'image/jpeg'): File {
+  return new File([new Uint8Array([0xFF])], name, { type });
+}
+
+describe('dispatchSlotDrop — structured payload dispatch', () => {
+  it('routes a tray payload to promote with the drop index', () => {
+    const payload: DragPayload = { kind: 'tray', photoId: 'cand-1' };
+    const action = dispatchSlotDrop({
+      payload,
+      textPlain: '',
+      files: [],
+      dropIndex: 3,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'promote', photoId: 'cand-1', dropIndex: 3 });
+  });
+
+  it('routes a cross-set slot payload to rejection', () => {
+    const payload: DragPayload = { kind: 'slot', setKey: 'set2', index: 4, photoId: 'p' };
+    const action = dispatchSlotDrop({
+      payload,
+      textPlain: '4',
+      files: [],
+      dropIndex: 1,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'cross-set-rejected' });
+  });
+
+  it('lets a same-set slot payload fall through to text/plain reorder', () => {
+    // Same-set drags emit BOTH the structured payload AND text/plain. The
+    // structured payload's setKey matches, so dispatch falls through to the
+    // legacy reorder path keyed on the integer index.
+    const payload: DragPayload = { kind: 'slot', setKey: 'set1', index: 2, photoId: 'p' };
+    const action = dispatchSlotDrop({
+      payload,
+      textPlain: '2',
+      files: [],
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'reorder', fromIndex: 2, toIndex: 5 });
+  });
+});
+
+describe('dispatchSlotDrop — text/plain reorder', () => {
+  it('routes integer text/plain to reorder when fromIndex != dropIndex', () => {
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '2',
+      files: [],
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'reorder', fromIndex: 2, toIndex: 5 });
+  });
+
+  it('returns none when fromIndex === dropIndex (no-op reorder)', () => {
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '3',
+      files: [],
+      dropIndex: 3,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'none' });
+  });
+
+  it('falls through reorder when text/plain is empty / NaN', () => {
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '',
+      files: [],
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'none' });
+  });
+});
+
+describe('dispatchSlotDrop — native file drop (PR #62 review I4)', () => {
+  it('routes native files to onFilesDropped when no payload and no reorder int', () => {
+    // The pre-I4 bug: occupied slot + native OS file drop → silently dropped.
+    const files = [makeFile('a.jpg'), makeFile('b.jpg')];
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '',
+      files,
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'files', files });
+  });
+
+  it('filters out non-image files via isValidImageFile', () => {
+    const valid = makeFile('photo.jpg', 'image/jpeg');
+    const invalid = makeFile('doc.pdf', 'application/pdf');
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '',
+      files: [valid, invalid],
+      dropIndex: 1,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'files', files: [valid] });
+  });
+
+  it('returns none when ALL native files are filtered out (no images)', () => {
+    // Don't fire `onFilesDropped([])` — that would be a meaningless smart-drop.
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '',
+      files: [makeFile('a.txt', 'text/plain')],
+      dropIndex: 1,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'none' });
+  });
+
+  it('does NOT fire files action when text/plain reorder matched (priority)', () => {
+    // A user dragging a slot photo in-grid may emit text/plain AND have
+    // dataTransfer.files leftover from somewhere. Reorder wins.
+    const files = [makeFile('a.jpg')];
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '2',
+      files,
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'reorder', fromIndex: 2, toIndex: 5 });
+  });
+
+  it('does NOT fire files action when tray payload matched (priority)', () => {
+    const files = [makeFile('a.jpg')];
+    const payload: DragPayload = { kind: 'tray', photoId: 'cand-1' };
+    const action = dispatchSlotDrop({
+      payload,
+      textPlain: '',
+      files,
+      dropIndex: 1,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'promote', photoId: 'cand-1', dropIndex: 1 });
+  });
+});
+
+describe('dispatchSlotDrop — empty/no-op cases', () => {
+  it('returns none when nothing is in the dataTransfer at all', () => {
+    const action = dispatchSlotDrop({
+      payload: null,
+      textPlain: '',
+      files: [],
+      dropIndex: 5,
+      setKey: 'set1',
+      isValidImageFile: acceptAllImages,
+    });
+    expect(action).toEqual({ kind: 'none' });
+  });
+});

--- a/frontend/photo-helper/src/__tests__/smartDropRoute.test.ts
+++ b/frontend/photo-helper/src/__tests__/smartDropRoute.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { routeDrop } from '../utils/smartDropRoute';
+
+// Smart-drop heuristic — boundaries matter. The whole batch goes to one
+// destination; we never partially fill slots and dump the remainder, because
+// that silently splits the user's intent and is hard to undo. See
+// docs/CANDIDATE_PHOTOS.md "Smart drop heuristic".
+
+const fakeFiles = (n: number) => Array.from({ length: n }, (_, i) => new File([''], `f${i}.jpg`));
+
+describe('routeDrop', () => {
+  it('empty batch → slot route, empty files', () => {
+    expect(routeDrop({ files: [], currentSlotCount: 0, slotCapacity: 9 }))
+      .toEqual({ kind: 'slot', files: [] });
+  });
+
+  it('drop fits exactly into remaining slot capacity → slot', () => {
+    const files = fakeFiles(4);
+    const result = routeDrop({ files, currentSlotCount: 5, slotCapacity: 9 });
+    expect(result.kind).toBe('slot');
+    expect(result.files).toHaveLength(4);
+  });
+
+  it('drop one less than remaining → slot', () => {
+    const files = fakeFiles(3);
+    expect(routeDrop({ files, currentSlotCount: 5, slotCapacity: 9 }).kind).toBe('slot');
+  });
+
+  it('drop one MORE than remaining → tray (whole batch)', () => {
+    const files = fakeFiles(5);
+    const result = routeDrop({ files, currentSlotCount: 5, slotCapacity: 9 });
+    expect(result.kind).toBe('tray');
+    expect(result.files).toHaveLength(5);
+  });
+
+  it('drop into already-full set → tray', () => {
+    const files = fakeFiles(2);
+    const result = routeDrop({ files, currentSlotCount: 9, slotCapacity: 9 });
+    expect(result.kind).toBe('tray');
+    expect(result.files).toHaveLength(2);
+  });
+
+  it('drop of 30 into empty 9-slot set → tray', () => {
+    const files = fakeFiles(30);
+    const result = routeDrop({ files, currentSlotCount: 0, slotCapacity: 9 });
+    expect(result.kind).toBe('tray');
+    expect(result.files).toHaveLength(30);
+  });
+
+  it('drop of 9 into empty 9-slot set → slot (boundary)', () => {
+    const files = fakeFiles(9);
+    const result = routeDrop({ files, currentSlotCount: 0, slotCapacity: 9 });
+    expect(result.kind).toBe('slot');
+  });
+
+  it('drop of 10 into empty 10-slot (portrait) set → slot (boundary)', () => {
+    const files = fakeFiles(10);
+    const result = routeDrop({ files, currentSlotCount: 0, slotCapacity: 10 });
+    expect(result.kind).toBe('slot');
+  });
+});

--- a/frontend/photo-helper/src/__tests__/smartDropRoute.test.ts
+++ b/frontend/photo-helper/src/__tests__/smartDropRoute.test.ts
@@ -58,4 +58,20 @@ describe('routeDrop', () => {
     const result = routeDrop({ files, currentSlotCount: 0, slotCapacity: 10 });
     expect(result.kind).toBe('slot');
   });
+
+  // PR #62 review A2: corrupted state (currentSlotCount already > capacity,
+  // possible after legacy layout flip). `Math.max(0, capacity - count)` clamps
+  // remaining to 0, so any drop routes to tray. The hook layer now also
+  // surfaces a setError, but the routing itself stays defensive.
+  it('drop into an over-cap set → tray (remaining clamped to 0)', () => {
+    const files = fakeFiles(1);
+    const result = routeDrop({ files, currentSlotCount: 11, slotCapacity: 9 });
+    expect(result.kind).toBe('tray');
+    expect(result.files).toHaveLength(1);
+  });
+
+  it('empty batch with over-cap set → slot (no-op, no spurious tray route)', () => {
+    const result = routeDrop({ files: [], currentSlotCount: 11, slotCapacity: 9 });
+    expect(result).toEqual({ kind: 'slot', files: [] });
+  });
 });

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -1,0 +1,380 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { DirectoryHandle, StorageInterface } from '@airq/shared-storage';
+
+// PR #62 review G1 / G2 / G5: the hook layer wraps the pure helpers with
+// capacity clamps, smart-drop routing, mode-bucket mirroring, and the
+// CRIT-3 partial-failure rethrow. The pure helpers are tested separately;
+// here we exercise the WRAPPER behaviours that exist only at the hook.
+//
+// The hook depends on `competitionService` (a module singleton over OPFS),
+// `migrationService`, and `useI18n`. We mock each so the test owns its
+// storage state and doesn't drag in unrelated initialization paths.
+
+// ── In-memory storage mock (re-used pattern from competitionServiceRoundtrip.test.ts) ─
+type Entry =
+  | { kind: 'dir'; children: Map<string, Entry> }
+  | { kind: 'json'; data: unknown }
+  | { kind: 'blob'; blob: Blob };
+
+function makeDir(): Entry { return { kind: 'dir', children: new Map() }; }
+function ensureChildDir(parent: Entry, name: string, create: boolean): Entry {
+  if (parent.kind !== 'dir') throw new Error(`Not a directory`);
+  let child = parent.children.get(name);
+  if (!child) {
+    if (!create) throw new Error(`Directory missing: ${name}`);
+    child = makeDir();
+    parent.children.set(name, child);
+  }
+  if (child.kind !== 'dir') throw new Error(`Path is not a directory: ${name}`);
+  return child;
+}
+
+class InMemoryStorage implements StorageInterface {
+  root: Entry = makeDir();
+  pathToEntry: Map<string, Entry> = new Map();
+
+  constructor() { this.pathToEntry.set('/', this.root); }
+
+  async init() {
+    const sessionsDir = ensureChildDir(this.root, 'sessions', true);
+    this.pathToEntry.set('/sessions', sessionsDir);
+    return {
+      root: { path: '/' } as DirectoryHandle,
+      sessions: { path: '/sessions' } as DirectoryHandle,
+    };
+  }
+  async ensureSessionDirs(_id: string) {
+    return {
+      dir: { path: '/' } as DirectoryHandle,
+      photos: { path: '/' } as DirectoryHandle,
+    };
+  }
+  async writeJSON(dir: DirectoryHandle, name: string, data: unknown) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${dir.path}`);
+    entry.children.set(name, { kind: 'json', data: JSON.parse(JSON.stringify(data)) });
+  }
+  async readJSON<T>(dir: DirectoryHandle, name: string): Promise<T | null> {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return null;
+    const file = entry.children.get(name);
+    if (!file || file.kind !== 'json') return null;
+    return JSON.parse(JSON.stringify(file.data)) as T;
+  }
+  async savePhotoFile(photosDir: DirectoryHandle, photoId: string, file: File) {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${photosDir.path}`);
+    const buf = await file.arrayBuffer();
+    entry.children.set(photoId, { kind: 'blob', blob: new Blob([buf], { type: file.type }) });
+  }
+  async getPhotoBlob(photosDir: DirectoryHandle, photoId: string): Promise<Blob> {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') throw new Error(`Bad dir: ${photosDir.path}`);
+    const file = entry.children.get(photoId);
+    if (!file || file.kind !== 'blob') throw new Error(`Photo not found: ${photoId}`);
+    return file.blob;
+  }
+  async deletePhotoFile(photosDir: DirectoryHandle, photoId: string) {
+    const entry = this.pathToEntry.get(photosDir.path);
+    if (!entry || entry.kind !== 'dir') return;
+    entry.children.delete(photoId);
+  }
+  async clearDirectory(dir: DirectoryHandle) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return;
+    entry.children.clear();
+  }
+  async deleteSessionDir() { /* unused */ }
+  async getDirectoryHandle(parent: DirectoryHandle, name: string, options?: { create?: boolean }) {
+    const parentEntry = this.pathToEntry.get(parent.path);
+    if (!parentEntry) throw new Error(`Parent dir missing: ${parent.path}`);
+    const child = ensureChildDir(parentEntry, name, !!options?.create);
+    const childPath = parent.path === '/' ? `/${name}` : `${parent.path}/${name}`;
+    this.pathToEntry.set(childPath, child);
+    return { path: childPath } as DirectoryHandle;
+  }
+  async isAvailable() { return true; }
+  async getStorageEstimate() { return { usage: 0, quota: 1024 * 1024 * 1024 }; }
+  async listDirectory(dir: DirectoryHandle) {
+    const entry = this.pathToEntry.get(dir.path);
+    if (!entry || entry.kind !== 'dir') return [];
+    return [...entry.children.entries()].map(([name, e]) => ({ name, isDirectory: e.kind === 'dir' }));
+  }
+}
+
+let storageMock: InMemoryStorage;
+
+vi.mock('@airq/shared-storage', async () => {
+  const actual = await vi.importActual<any>('@airq/shared-storage');
+  return {
+    ...actual,
+    initStorage: vi.fn(async () => storageMock),
+    getStorage: vi.fn(() => storageMock),
+  };
+});
+
+// Mock the i18n context — echo the key so assertions can check error
+// reasons without spinning up the I18nProvider tree.
+vi.mock('../contexts/I18nContext', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+// Skip the storage-migration path so initialise() doesn't try to scan
+// legacy sessions. Returning `migrated: false` keeps the hook's
+// migrationPerformed flag false but doesn't matter — we don't re-render.
+vi.mock('../services/migrationService', () => ({
+  migrationService: {
+    performMigration: vi.fn(async () => ({ migrated: false, message: '' })),
+  },
+}));
+
+let urlCounter = 0;
+const createdUrls = new Map<string, Blob>();
+
+beforeEach(async () => {
+  urlCounter = 0;
+  createdUrls.clear();
+  storageMock = new InMemoryStorage();
+  globalThis.URL.createObjectURL = (blob: Blob) => {
+    const id = `blob:test/${++urlCounter}`;
+    createdUrls.set(id, blob);
+    return id;
+  };
+  globalThis.URL.revokeObjectURL = (url: string) => { createdUrls.delete(url); };
+  globalThis.fetch = (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const blob = createdUrls.get(url);
+    if (!blob) return Promise.reject(new Error(`Mock fetch: unknown URL ${url}`));
+    return Promise.resolve({ blob: async () => blob } as any);
+  };
+  // competitionService is a module singleton — reset its caches each test.
+  const { competitionService } = await import('../services/competitionService');
+  (competitionService as any).storage = null;
+  (competitionService as any).handles = null;
+  (competitionService as any).competitionsDir = null;
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+function makeFile(name = 'photo.jpg'): File {
+  return new File([new Uint8Array([0xFF, 0xD8, 0xFF])], name, { type: 'image/jpeg' });
+}
+
+async function setup() {
+  const { useCompetitionSystem } = await import('../hooks/useCompetitionSystem');
+  const { result } = renderHook(() => useCompetitionSystem());
+  // Wait for the initial async init to settle and a competition to exist.
+  await waitFor(() => {
+    expect(result.current.loading).toBe(false);
+    expect(result.current.currentCompetition).not.toBeNull();
+  }, { timeout: 5000 });
+  return result;
+}
+
+describe('useCompetitionSystem — smart-drop integration (PR #62 review G1)', () => {
+  it('addPhotosToSet routes overflow batches to the candidate tray', async () => {
+    const result = await setup();
+    // 9-slot landscape (default). Drop 12 files → over capacity → tray.
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`f${i}.jpg`));
+
+    let resultValue: any;
+    await act(async () => {
+      resultValue = await result.current.addPhotosToSet(files, 'set1');
+    });
+
+    expect(resultValue).toEqual({ kind: 'ok', routedTo: 'tray', count: 12 });
+    expect(result.current.session?.sets.set1.photos.length).toBe(0);
+    expect(result.current.session?.candidates?.photos.length).toBe(12);
+  });
+
+  it('addPhotosToSet fills slots when batch fits within remaining capacity', async () => {
+    const result = await setup();
+    const files = Array.from({ length: 5 }, (_, i) => makeFile(`f${i}.jpg`));
+
+    let resultValue: any;
+    await act(async () => {
+      resultValue = await result.current.addPhotosToSet(files, 'set1');
+    });
+
+    expect(resultValue).toEqual({ kind: 'ok', routedTo: 'slot', count: 5 });
+    expect(result.current.session?.sets.set1.photos.length).toBe(5);
+    expect((result.current.session?.candidates?.photos ?? []).length).toBe(0);
+  });
+
+  it('addPhotosToSet returns over-capacity err when set is already over the cap', async () => {
+    const result = await setup();
+    // Force the session into a corrupted state with 11 photos in a 9-slot
+    // capacity (simulates a legacy session or layout switch).
+    await act(async () => {
+      await result.current.addPhotosToSet([makeFile('a.jpg')], 'set1');
+    });
+    // Manually push the over-cap state by addressing the singleton — this
+    // is a TEST-ONLY shortcut for the rare corruption path the guard covers.
+    const session = result.current.currentCompetition!.session;
+    (session.sets.set1.photos as any).push(
+      ...Array.from({ length: 11 }, (_, i) => ({
+        id: `corrupt-${i}`, sessionId: session.id, url: '', filename: 'x', canvasState: {} as any, label: '',
+      })),
+    );
+
+    let errResult: any;
+    await act(async () => {
+      errResult = await result.current.addPhotosToSet([makeFile('y.jpg')], 'set1');
+    });
+    expect(errResult.kind).toBe('err');
+    expect(errResult.reason).toBe('over-capacity');
+  });
+});
+
+describe('useCompetitionSystem — promoteCandidateToSlot capacity clamp (PR #62 review G5 / C1)', () => {
+  it('clamps slotIndex >= capacity to capacity - 1 so swap-on-full fires instead of append', async () => {
+    const result = await setup();
+    // Fill set1 with 9 slot photos.
+    await act(async () => {
+      await result.current.addPhotosToSet(
+        Array.from({ length: 9 }, (_, i) => makeFile(`s${i}.jpg`)),
+        'set1',
+      );
+    });
+    // Add 1 candidate.
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('cand.jpg')]);
+    });
+
+    const slotIdsBefore = result.current.session!.sets.set1.photos.map(p => p.id);
+    const candidateId = result.current.session!.candidates!.photos[0].id;
+
+    // Pass slotIndex = 9 (== capacity) — pre-clamp this APPENDED past
+    // capacity (PR #62 review C1). The clamp must redirect to index 8 so
+    // the swap branch fires instead.
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(candidateId, 'set1', 9);
+    });
+
+    expect(result.current.session!.sets.set1.photos.length).toBe(9);
+    expect(result.current.session!.sets.set1.photos[8].id).toBe(candidateId);
+    // The displaced photo (formerly at index 8) is now back in the tray.
+    expect(result.current.session!.candidates!.photos.map(p => p.id))
+      .toContain(slotIdsBefore[8]);
+  });
+
+  it('clamps negative slotIndex to 0', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('cand.jpg')]);
+    });
+    const candidateId = result.current.session!.candidates!.photos[0].id;
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(candidateId, 'set1', -5);
+    });
+    expect(result.current.session!.sets.set1.photos.map(p => p.id)).toEqual([candidateId]);
+  });
+
+  it('mirrors slot mutation into active mode bucket so mode-switch round-trip preserves it', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('c.jpg')]);
+    });
+    const candidateId = result.current.session!.candidates!.photos[0].id;
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(candidateId, 'set1', 0);
+    });
+    // After promote: setsTrack (active mode bucket) MUST mirror sets.
+    const session = result.current.session!;
+    expect(session.sets.set1.photos.map(p => p.id)).toEqual([candidateId]);
+    expect(session.setsTrack?.set1.photos.map(p => p.id)).toEqual([candidateId]);
+  });
+});
+
+describe('useCompetitionSystem — deleteCandidates and clearAllCandidates (PR #62 review G5 / CRIT-3)', () => {
+  it('deleteCandidates removes specific ids and frees OPFS files', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')]);
+    });
+    const ids = result.current.session!.candidates!.photos.map(p => p.id);
+    const [keepId, deleteId1, deleteId2] = ids;
+
+    await act(async () => {
+      await (result.current as any).deleteCandidates([deleteId1, deleteId2]);
+    });
+
+    expect(result.current.session!.candidates!.photos.map(p => p.id)).toEqual([keepId]);
+    // OPFS file for deleted ids is gone; keepId's file remains.
+    const compId = result.current.currentCompetition!.id;
+    const photosDir = { path: `/competitions/${compId}/photos` } as DirectoryHandle;
+    const remainingFiles = (await storageMock.listDirectory(photosDir)).map(e => e.name);
+    expect(remainingFiles).toContain(keepId);
+    expect(remainingFiles).not.toContain(deleteId1);
+    expect(remainingFiles).not.toContain(deleteId2);
+  });
+
+  it('deleteCandidates is a no-op for ids no longer in the pool', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg')]);
+    });
+    // Try to delete an id that doesn't exist — should not throw or remove anything.
+    await act(async () => {
+      await (result.current as any).deleteCandidates(['ghost-id']);
+    });
+    expect(result.current.session!.candidates!.photos.length).toBe(1);
+  });
+
+  it('deleteCandidates RETHROWS on OPFS partial failure so the cleanup dialog stays open', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('boom.jpg')]);
+    });
+    const id = result.current.session!.candidates!.photos[0].id;
+
+    // Stub deletePhotoFile to throw — exercises the CRIT-3 wiring where
+    // `{ failed }` from the service causes `deleteCandidates` to throw,
+    // which the AppApi cleanup dialog catches to stay open + show Snackbar.
+    const original = storageMock.deletePhotoFile.bind(storageMock);
+    storageMock.deletePhotoFile = (async (dir, fileId) => {
+      if (fileId === id) throw new Error('simulated OPFS error');
+      return original(dir, fileId);
+    }) as typeof storageMock.deletePhotoFile;
+
+    await expect(
+      act(async () => { await (result.current as any).deleteCandidates([id]); })
+    ).rejects.toThrow(/candidateDeletePartialFailure/);
+  });
+
+  it('clearAllCandidates wipes the pool via deleteCandidates', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg')]);
+    });
+    expect(result.current.session!.candidates!.photos.length).toBe(2);
+
+    await act(async () => {
+      await result.current.clearAllCandidates();
+    });
+    expect(result.current.session!.candidates!.photos.length).toBe(0);
+  });
+});
+
+describe('useCompetitionSystem — addPhotosToTurningPoint overflow (PR #62 review G2)', () => {
+  it('routes 25-photo rally turning-point drop to candidates instead of erroring', async () => {
+    const result = await setup();
+    // Switch to turningpoint mode.
+    await act(async () => { await result.current.updateSessionMode('turningpoint'); });
+
+    const files = Array.from({ length: 25 }, (_, i) => makeFile(`f${i}.jpg`));
+    let resultValue: any;
+    await act(async () => {
+      resultValue = await (result.current as any).addPhotosToTurningPoint(files);
+    });
+
+    expect(resultValue).toEqual({ kind: 'ok', routedTo: 'tray', count: 25 });
+    expect(result.current.session!.candidates!.photos.length).toBe(25);
+    expect(result.current.session!.sets.set1.photos.length).toBe(0);
+    expect(result.current.session!.sets.set2.photos.length).toBe(0);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -22,7 +22,15 @@ function ensureChildDir(parent: Entry, name: string, create: boolean): Entry {
   if (parent.kind !== 'dir') throw new Error(`Not a directory`);
   let child = parent.children.get(name);
   if (!child) {
-    if (!create) throw new Error(`Directory missing: ${name}`);
+    if (!create) {
+      // Mirror real OPFS: a missing directory looked up with create:false
+      // throws a DOMException with name 'NotFoundError'. PR #62 review I3
+      // depends on this name to distinguish "already cleaned" from a real
+      // transient error.
+      const err = new Error(`Directory missing: ${name}`);
+      err.name = 'NotFoundError';
+      throw err;
+    }
     child = makeDir();
     parent.children.set(name, child);
   }
@@ -376,5 +384,188 @@ describe('useCompetitionSystem — addPhotosToTurningPoint overflow (PR #62 revi
     expect(result.current.session!.candidates!.photos.length).toBe(25);
     expect(result.current.session!.sets.set1.photos.length).toBe(0);
     expect(result.current.session!.sets.set2.photos.length).toBe(0);
+  });
+});
+
+// PR #62 review I1: pre-fix, the rally turning-point dispatcher discarded the
+// AddPhotosResult of each inner addPhotosToSet call and computed count as
+// `result.toSet1.length + result.toSet2.length`. The fix routes the count
+// through the inner result so the outer caller can never claim more than
+// what actually landed. Under the current `distributeRallyDrop` invariants
+// (total cap = 20, set1 filled first then overflow into set2) the inner err
+// / inner-tray branches are unreachable — distribute itself protects them.
+// The test below pins the aggregation contract on the happy path; the err
+// / inner-tray branches are defense-in-depth for future distribute changes.
+describe('useCompetitionSystem — addPhotosToTurningPoint result aggregation (PR #62 review I1)', () => {
+  it('returns r1.count when only set1 fires (distribute toSet2 is empty)', async () => {
+    const result = await setup();
+    await act(async () => { await result.current.updateSessionMode('turningpoint'); });
+
+    // 8 photos: distribute → toSet1=8 (set1Remaining=10), toSet2=0. Only r1
+    // runs; r2 short-circuits to null. The new aggregation must return
+    // r1.count (8) — pre-fix it returned `toSet1.length + toSet2.length`
+    // which happens to also be 8 here, but the code PATH is different and
+    // a future inner clamp could diverge.
+    const files = Array.from({ length: 8 }, (_, i) => makeFile(`f${i}.jpg`));
+    let aggResult: any;
+    await act(async () => {
+      aggResult = await (result.current as any).addPhotosToTurningPoint(files);
+    });
+
+    expect(aggResult.kind).toBe('ok');
+    expect(aggResult.routedTo).toBe('slot');
+    expect(aggResult.count).toBe(8);
+    expect(result.current.session!.sets.set1.photos.length).toBe(8);
+    expect(result.current.session!.sets.set2.photos.length).toBe(0);
+  });
+
+  it('returns r2.count when only set2 fires (set1 pre-filled to cap)', async () => {
+    const result = await setup();
+    await act(async () => { await result.current.updateSessionMode('turningpoint'); });
+    // Pre-fill set1 to its turning-point cap of 10. Distribute then sends
+    // all subsequent files to set2 (set1Remaining=0). r1 short-circuits to
+    // null; r2 carries the count.
+    await act(async () => {
+      await result.current.addPhotosToSet(
+        Array.from({ length: 10 }, (_, i) => makeFile(`pre${i}.jpg`)),
+        'set1',
+      );
+    });
+
+    let aggResult: any;
+    await act(async () => {
+      aggResult = await (result.current as any).addPhotosToTurningPoint(
+        Array.from({ length: 5 }, (_, i) => makeFile(`new${i}.jpg`)),
+      );
+    });
+
+    expect(aggResult.kind).toBe('ok');
+    expect(aggResult.routedTo).toBe('slot');
+    // The critical regression marker: count comes from r2.count via the
+    // new aggregation, not from raw slice lengths.
+    expect(aggResult.count).toBe(5);
+    expect(result.current.session!.sets.set1.photos.length).toBe(10);
+    expect(result.current.session!.sets.set2.photos.length).toBe(5);
+  });
+});
+
+// PR #62 review I2: pre-fix, the addPhotosToSet over-capacity branch
+// hardcoded an English error message — even after the IMP-5 cleanup-dialog
+// localisation, this banner was still English for Czech users. The fix
+// routes through t() with `errors.setOverCapacity`.
+describe('useCompetitionSystem — over-capacity error is localised (PR #62 review I2)', () => {
+  it('returns a localised over-capacity message instead of hardcoded English', async () => {
+    const result = await setup();
+    // Force corruption: set1 already over the 9-slot landscape cap.
+    const session = result.current.currentCompetition!.session;
+    (session.sets.set1.photos as any).push(
+      ...Array.from({ length: 11 }, (_, i) => ({
+        id: `c-${i}`,
+        sessionId: session.id,
+        url: '',
+        filename: 'x',
+        canvasState: {} as any,
+        label: '',
+      })),
+    );
+
+    let errResult: any;
+    await act(async () => {
+      errResult = await result.current.addPhotosToSet([makeFile('z.jpg')], 'set1');
+    });
+
+    expect(errResult.kind).toBe('err');
+    expect(errResult.reason).toBe('over-capacity');
+    // The mock `t()` echoes `key:params-json`. A localised message must
+    // include the key — a hardcoded English string would NOT, so this is
+    // a direct regression guard.
+    expect(errResult.message).toContain('errors.setOverCapacity');
+    expect(errResult.message).toContain('"current":11');
+    expect(errResult.message).toContain('"cap":9');
+  });
+});
+
+// PR #62 review I6: pre-fix, deleteCandidates returned `Promise<void>` and
+// silently no-op'd when `presentIds.length === 0` (every snapshot id was
+// already promoted to a slot before confirm). The post-export cleanup
+// dialog claimed it freed N photos worth of storage when in fact zero
+// were deleted. The fix returns `{ deleted, skipped }` so the dialog can
+// surface "0 of N deleted — moved to slots".
+describe('useCompetitionSystem — deleteCandidates snapshot-drift result (PR #62 review I6)', () => {
+  it('returns { deleted: 0, skipped: N } when all snapshot ids were already promoted', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg')]);
+    });
+    const snapshotIds = result.current.session!.candidates!.photos.map(p => p.id);
+
+    // Simulate the snapshot-drift case: between dialog-open and confirm,
+    // the user promoted both candidates to slots. Each mutation in its own
+    // `act` so React's render-between-mutations gives the second promote
+    // the post-first-promote state — chaining them in one act leaves the
+    // closure-captured `result.current.session` stale.
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(snapshotIds[0], 'set1', 0);
+    });
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(snapshotIds[1], 'set1', 1);
+    });
+    expect(result.current.session!.candidates!.photos.length).toBe(0);
+
+    let returnValue: { deleted: number; skipped: number } | undefined;
+    await act(async () => {
+      returnValue = await (result.current as any).deleteCandidates(snapshotIds);
+    });
+
+    expect(returnValue).toEqual({ deleted: 0, skipped: 2 });
+    // Both photos are still in slots — promotion was NOT undone by the cleanup.
+    expect(result.current.session!.sets.set1.photos.length).toBe(2);
+  });
+
+  it('returns { deleted: N, skipped: 0 } for a full-success cleanup', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')]);
+    });
+    const ids = result.current.session!.candidates!.photos.map(p => p.id);
+
+    let returnValue: { deleted: number; skipped: number } | undefined;
+    await act(async () => {
+      returnValue = await (result.current as any).deleteCandidates(ids);
+    });
+
+    expect(returnValue).toEqual({ deleted: 3, skipped: 0 });
+    expect(result.current.session!.candidates!.photos.length).toBe(0);
+  });
+
+  it('returns { deleted: 2, skipped: 1 } for a mixed snapshot — 2 still candidates, 1 already promoted', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')]);
+    });
+    const ids = result.current.session!.candidates!.photos.map(p => p.id);
+
+    // Promote one between snapshot and delete.
+    await act(async () => {
+      await result.current.promoteCandidateToSlot(ids[0], 'set1', 0);
+    });
+
+    let returnValue: { deleted: number; skipped: number } | undefined;
+    await act(async () => {
+      returnValue = await (result.current as any).deleteCandidates(ids);
+    });
+
+    expect(returnValue).toEqual({ deleted: 2, skipped: 1 });
+    expect(result.current.session!.sets.set1.photos.length).toBe(1);
+    expect(result.current.session!.candidates!.photos.length).toBe(0);
+  });
+
+  it('returns { deleted: 0, skipped: 0 } for empty input (degenerate case)', async () => {
+    const result = await setup();
+    let returnValue: { deleted: number; skipped: number } | undefined;
+    await act(async () => {
+      returnValue = await (result.current as any).deleteCandidates([]);
+    });
+    expect(returnValue).toEqual({ deleted: 0, skipped: 0 });
   });
 });

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -34,6 +34,7 @@ import { useTheme, alpha } from '@mui/material/styles';
 import { PhotoEditorApi } from './PhotoEditorApi';
 import { useI18n } from '../contexts/I18nContext';
 import { isValidImageFile } from '../utils/imageProcessing';
+import { filterCandidates, countByFlag } from '../utils/candidateFilter';
 import type { ApiPhoto, CandidateFlag } from '../types/api';
 
 export interface CandidateTrayProps {
@@ -74,26 +75,22 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
 
   // Filter rejects out when "Hide rejects" is on. Rejects with the toggle off
   // render at 50% opacity to keep the cull-state visible without forcing a
-  // mode switch.
-  const visiblePhotos = useMemo(() => {
-    if (!hideRejects) return photos;
-    return photos.filter((p) => p.flag !== 'reject');
-  }, [photos, hideRejects]);
+  // mode switch. Logic lives in `utils/candidateFilter` so it stays unit-
+  // testable in isolation (PR #62 review).
+  const visiblePhotos = useMemo(
+    () => filterCandidates(photos, { hideRejects }),
+    [photos, hideRejects],
+  );
 
-  const counts = useMemo(() => {
-    let pick = 0, neutral = 0, reject = 0;
-    for (const p of photos) {
-      if (p.flag === 'pick') pick++;
-      else if (p.flag === 'reject') reject++;
-      else neutral++;
-    }
-    return { pick, neutral, reject, total: photos.length };
-  }, [photos]);
+  const counts = useMemo(() => countByFlag(photos), [photos]);
 
-  // Outer drop zone — accepts native file drops AND slot-photo drags. We
-  // disable react-dropzone's noClick when photos exist; the "Add more" button
-  // becomes the explicit click target in that case.
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  // Outer drop zone — accepts native file drops AND slot-photo drags.
+  // `noClick: true` is required when the tray is populated so MUI Buttons
+  // inside the dropzone (e.g. flag toggles) don't open the file picker on
+  // every click. We expose `open()` and wire it explicitly to the "Add more"
+  // Button below (PR #62 review C2: spreading rootProps onto the Button while
+  // noClick was true made the Button click a no-op).
+  const { getRootProps, getInputProps, isDragActive, open: openFilePicker } = useDropzone({
     accept: {
       'image/jpeg': ['.jpg', '.jpeg'],
       'image/png': ['.png'],
@@ -120,13 +117,23 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
     setDropActive(false);
     const raw = e.dataTransfer.getData('application/x-airq-photo');
     if (!raw) return;
+    let payload: unknown;
     try {
-      const payload = JSON.parse(raw) as { kind: string; setKey?: 'set1' | 'set2'; photoId?: string };
-      if (payload.kind === 'slot' && payload.setKey && payload.photoId) {
-        e.preventDefault();
-        onSlotDroppedIn({ setKey: payload.setKey, photoId: payload.photoId });
-      }
-    } catch {}
+      payload = JSON.parse(raw);
+    } catch (err) {
+      // PR #62 review I5: log instead of `catch {}` so debugging a misbehaving
+      // drag-and-drop doesn't require source patching.
+      console.warn('CandidateTray: malformed drag payload', raw, err);
+      return;
+    }
+    if (!payload || typeof payload !== 'object') return;
+    const p = payload as { kind?: unknown; setKey?: unknown; photoId?: unknown };
+    // Strict literal-union check on setKey (PR #62 review I5).
+    const isValidSet = p.setKey === 'set1' || p.setKey === 'set2';
+    if (p.kind === 'slot' && isValidSet && typeof p.photoId === 'string') {
+      e.preventDefault();
+      onSlotDroppedIn({ setKey: p.setKey as 'set1' | 'set2', photoId: p.photoId });
+    }
   };
 
   const handleThumbDragStart = (e: React.DragEvent, photo: ApiPhoto) => {
@@ -227,17 +234,19 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
         <Tooltip title={t('candidates.addMore')}>
           <span>
             <Button
-              {...(getRootProps() as any)}
+              onClick={(e) => { e.stopPropagation(); openFilePicker(); }}
               size="small"
               variant="outlined"
               startIcon={<AddIcon />}
               sx={{ mr: 1, minHeight: 32 }}
             >
-              <input {...getInputProps()} />
               {t('candidates.addMore')}
             </Button>
           </span>
         </Tooltip>
+        {/* Hidden file input owned by the Paper-level dropzone (rendered once
+            so the `Add more` button + native drop both feed the same picker). */}
+        <input {...getInputProps()} />
         <IconButton size="small" onClick={() => setCollapsed((c) => !c)}>
           {collapsed ? <ExpandMore /> : <ExpandLess />}
         </IconButton>

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -1,0 +1,415 @@
+/**
+ * CandidateTray — slotless workspace pool of photos the user is still
+ * triaging. See docs/CANDIDATE_PHOTOS.md.
+ *
+ * Drag/drop wire format (shared with PhotoGridApi):
+ *   text/plain = JSON.stringify({ kind: 'tray',  photoId })   ← drag source
+ *              | JSON.stringify({ kind: 'slot', setKey, index, photoId }) ← drop target
+ */
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  IconButton,
+  Menu,
+  MenuItem,
+  Divider,
+  Switch,
+  FormControlLabel,
+  Tooltip,
+  Button,
+} from '@mui/material';
+import {
+  ExpandMore,
+  ExpandLess,
+  Star,
+  StarBorder,
+  Block,
+  Close,
+  PhotoLibrary,
+  Add as AddIcon,
+} from '@mui/icons-material';
+import { useDropzone } from 'react-dropzone';
+import { useTheme, alpha } from '@mui/material/styles';
+import { PhotoEditorApi } from './PhotoEditorApi';
+import { useI18n } from '../contexts/I18nContext';
+import { isValidImageFile } from '../utils/imageProcessing';
+import type { ApiPhoto, CandidateFlag } from '../types/api';
+
+export interface CandidateTrayProps {
+  photos: ApiPhoto[];
+  onAddFiles: (files: File[]) => void;
+  onPhotoClick: (photo: ApiPhoto) => void;
+  onSetFlag: (photoId: string, flag: CandidateFlag) => void;
+  onDelete: (photoId: string) => void;
+  onSendToSet: (photoId: string, setKey: 'set1' | 'set2') => void;
+  /**
+   * Called when a slot photo is dropped into the tray. Receives the parsed
+   * dataTransfer payload. If the payload is a slot drop, AppApi demotes it.
+   */
+  onSlotDroppedIn: (payload: { setKey: 'set1' | 'set2'; photoId: string }) => void;
+  /** Hide "Send to Set 2" in the context menu (precision-track single-set mode). */
+  hideSet2?: boolean;
+}
+
+const THUMB_HEIGHT = 96;
+const THUMB_WIDTH = 128;
+
+export const CandidateTray: React.FC<CandidateTrayProps> = ({
+  photos,
+  onAddFiles,
+  onPhotoClick,
+  onSetFlag,
+  onDelete,
+  onSendToSet,
+  onSlotDroppedIn,
+  hideSet2,
+}) => {
+  const theme = useTheme();
+  const { t } = useI18n();
+
+  const [collapsed, setCollapsed] = useState(false);
+  const [hideRejects, setHideRejects] = useState(false);
+  const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; photo: ApiPhoto } | null>(null);
+  const [dropActive, setDropActive] = useState(false);
+
+  // Filter rejects out when "Hide rejects" is on. Rejects with the toggle off
+  // render at 50% opacity to keep the cull-state visible without forcing a
+  // mode switch.
+  const visiblePhotos = useMemo(() => {
+    if (!hideRejects) return photos;
+    return photos.filter((p) => p.flag !== 'reject');
+  }, [photos, hideRejects]);
+
+  const counts = useMemo(() => {
+    let pick = 0, neutral = 0, reject = 0;
+    for (const p of photos) {
+      if (p.flag === 'pick') pick++;
+      else if (p.flag === 'reject') reject++;
+      else neutral++;
+    }
+    return { pick, neutral, reject, total: photos.length };
+  }, [photos]);
+
+  const handleContextMenu = (e: React.MouseEvent<HTMLElement>, photo: ApiPhoto) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setMenuAnchor({ el: e.currentTarget, photo });
+  };
+  const closeMenu = () => setMenuAnchor(null);
+
+  // Outer drop zone — accepts native file drops AND slot-photo drags. We
+  // disable react-dropzone's noClick for the empty-state CTA; in normal mode
+  // (when photos exist) we use a separate "+" button.
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: {
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/png': ['.png'],
+    },
+    noClick: photos.length > 0,
+    onDrop: (accepted) => {
+      const valid = accepted.filter((f) => isValidImageFile(f));
+      if (valid.length > 0) onAddFiles(valid);
+    },
+  });
+
+  // Native HTML5 drag events for slot→tray transfers. react-dropzone owns the
+  // file-drop path; we layer our intra-app slot/tray transfer protocol on top.
+  const handleDragOver = (e: React.DragEvent) => {
+    // Only accept if the drag has our JSON payload — otherwise the user is
+    // dragging a native file and react-dropzone handles it.
+    const hasInternalPayload = e.dataTransfer.types.includes('application/x-airq-photo');
+    if (hasInternalPayload) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDropActive(true);
+    }
+  };
+  const handleDragLeave = () => setDropActive(false);
+  const handleDrop = (e: React.DragEvent) => {
+    setDropActive(false);
+    const raw = e.dataTransfer.getData('application/x-airq-photo');
+    if (!raw) return;
+    try {
+      const payload = JSON.parse(raw) as { kind: string; setKey?: 'set1' | 'set2'; photoId?: string };
+      if (payload.kind === 'slot' && payload.setKey && payload.photoId) {
+        e.preventDefault();
+        onSlotDroppedIn({ setKey: payload.setKey, photoId: payload.photoId });
+      }
+    } catch {}
+  };
+
+  const handleThumbDragStart = (e: React.DragEvent, photo: ApiPhoto) => {
+    const payload = JSON.stringify({ kind: 'tray', photoId: photo.id });
+    e.dataTransfer.setData('application/x-airq-photo', payload);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  // Empty-state hero — when there are no candidates AND no slot photos either,
+  // AppApi hides this component entirely. So whenever we render, we always
+  // have either candidates OR the user is intentionally adding via the "+"
+  // button. The empty branch is only reached after the user deletes all
+  // candidates from a previously-non-empty tray.
+  if (photos.length === 0) {
+    return (
+      <Paper
+        {...(getRootProps() as any)}
+        elevation={1}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        sx={{
+          mb: 2,
+          p: 2,
+          border: '2px dashed',
+          borderColor: isDragActive || dropActive ? 'primary.main' : 'grey.300',
+          borderRadius: 2,
+          bgcolor: isDragActive || dropActive
+            ? alpha(theme.palette.primary.main, 0.06)
+            : 'background.paper',
+          textAlign: 'center',
+          cursor: 'pointer',
+        }}
+      >
+        <input {...getInputProps()} />
+        <PhotoLibrary sx={{ fontSize: 28, color: 'text.secondary', mb: 0.5 }} />
+        <Typography variant="body2" color="text.secondary">
+          {t('candidates.emptyHint')}
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={1}
+      sx={{
+        mb: 2,
+        borderRadius: 2,
+        border: dropActive ? '2px solid' : '1px solid',
+        borderColor: dropActive ? 'primary.main' : 'divider',
+        bgcolor: dropActive ? alpha(theme.palette.primary.main, 0.04) : 'background.paper',
+        transition: 'all 0.15s ease-in-out',
+      }}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* Header */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 2,
+          py: 1,
+          borderBottom: collapsed ? 'none' : '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <PhotoLibrary sx={{ color: 'primary.main', fontSize: 20 }} />
+        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+          {t('candidates.title', { count: counts.total })}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, ml: 1, flexWrap: 'wrap' }}>
+          <CountChip icon={<Star sx={{ fontSize: 14 }} />} count={counts.pick} color="warning" />
+          <CountChip count={counts.neutral} color="default" />
+          <CountChip icon={<Block sx={{ fontSize: 14 }} />} count={counts.reject} color="error" />
+        </Box>
+        <Box sx={{ flex: 1 }} />
+        <FormControlLabel
+          control={
+            <Switch
+              size="small"
+              checked={hideRejects}
+              onChange={(_, v) => setHideRejects(v)}
+            />
+          }
+          label={<Typography variant="caption">{t('candidates.hideRejects')}</Typography>}
+          sx={{ mr: 1 }}
+        />
+        <Tooltip title={t('candidates.addMore')}>
+          <span>
+            <Button
+              {...(getRootProps() as any)}
+              size="small"
+              variant="outlined"
+              startIcon={<AddIcon />}
+              sx={{ mr: 1, minHeight: 32 }}
+            >
+              <input {...getInputProps()} />
+              {t('candidates.addMore')}
+            </Button>
+          </span>
+        </Tooltip>
+        <IconButton size="small" onClick={() => setCollapsed((c) => !c)}>
+          {collapsed ? <ExpandMore /> : <ExpandLess />}
+        </IconButton>
+      </Box>
+
+      {/* Thumb strip */}
+      {!collapsed && (
+        <Box
+          sx={{
+            display: 'flex',
+            gap: 1,
+            p: 1.5,
+            overflowX: 'auto',
+            // Subtle hint that more content scrolls
+            scrollbarGutter: 'stable',
+          }}
+        >
+          {visiblePhotos.map((photo) => (
+            <CandidateThumb
+              key={photo.id}
+              photo={photo}
+              onClick={() => onPhotoClick(photo)}
+              onContextMenu={(e) => handleContextMenu(e, photo)}
+              onDragStart={(e) => handleThumbDragStart(e, photo)}
+            />
+          ))}
+          {visiblePhotos.length === 0 && (
+            <Box sx={{ p: 2, color: 'text.secondary', fontStyle: 'italic' }}>
+              <Typography variant="body2">{t('candidates.allFiltered')}</Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {/* Context menu */}
+      <Menu
+        open={Boolean(menuAnchor)}
+        anchorEl={menuAnchor?.el ?? null}
+        onClose={closeMenu}
+      >
+        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'pick'); closeMenu(); }}>
+          <Star sx={{ fontSize: 18, mr: 1, color: 'warning.main' }} /> {t('candidates.flag.pick')}
+        </MenuItem>
+        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'neutral'); closeMenu(); }}>
+          <StarBorder sx={{ fontSize: 18, mr: 1 }} /> {t('candidates.flag.neutral')}
+        </MenuItem>
+        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'reject'); closeMenu(); }}>
+          <Block sx={{ fontSize: 18, mr: 1, color: 'error.main' }} /> {t('candidates.flag.reject')}
+        </MenuItem>
+        <Divider />
+        <MenuItem onClick={() => { if (menuAnchor) onSendToSet(menuAnchor.photo.id, 'set1'); closeMenu(); }}>
+          {t('candidates.sendToSet1')}
+        </MenuItem>
+        {!hideSet2 && (
+          <MenuItem onClick={() => { if (menuAnchor) onSendToSet(menuAnchor.photo.id, 'set2'); closeMenu(); }}>
+            {t('candidates.sendToSet2')}
+          </MenuItem>
+        )}
+        <Divider />
+        <MenuItem onClick={() => { if (menuAnchor) onDelete(menuAnchor.photo.id); closeMenu(); }} sx={{ color: 'error.main' }}>
+          <Close sx={{ fontSize: 18, mr: 1 }} /> {t('common.delete')}
+        </MenuItem>
+      </Menu>
+    </Paper>
+  );
+};
+
+interface CountChipProps {
+  count: number;
+  icon?: React.ReactNode;
+  color: 'warning' | 'error' | 'default';
+}
+const CountChip: React.FC<CountChipProps> = ({ count, icon, color }) => {
+  const theme = useTheme();
+  const bg =
+    color === 'warning' ? alpha(theme.palette.warning.main, 0.12)
+    : color === 'error' ? alpha(theme.palette.error.main, 0.12)
+    : alpha(theme.palette.text.primary, 0.06);
+  const fg =
+    color === 'warning' ? theme.palette.warning.dark
+    : color === 'error' ? theme.palette.error.dark
+    : theme.palette.text.secondary;
+  return (
+    <Box sx={{
+      display: 'inline-flex', alignItems: 'center', gap: 0.5,
+      px: 0.75, py: 0.25, borderRadius: 1,
+      bgcolor: bg, color: fg, fontSize: '0.75rem', fontWeight: 600
+    }}>
+      {icon}
+      {count}
+    </Box>
+  );
+};
+
+interface CandidateThumbProps {
+  photo: ApiPhoto;
+  onClick: () => void;
+  onContextMenu: (e: React.MouseEvent<HTMLElement>) => void;
+  onDragStart: (e: React.DragEvent) => void;
+}
+const CandidateThumb: React.FC<CandidateThumbProps> = ({ photo, onClick, onContextMenu, onDragStart }) => {
+  const flag: CandidateFlag = (photo.flag as CandidateFlag | undefined) ?? 'neutral';
+  const isReject = flag === 'reject';
+  return (
+    <Box
+      draggable
+      onDragStart={onDragStart}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      sx={{
+        position: 'relative',
+        flex: '0 0 auto',
+        width: THUMB_WIDTH,
+        height: THUMB_HEIGHT,
+        borderRadius: 1,
+        overflow: 'hidden',
+        cursor: 'grab',
+        opacity: isReject ? 0.45 : 1,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
+        transition: 'transform 0.12s, box-shadow 0.12s',
+        '&:hover': {
+          transform: 'scale(1.03)',
+          boxShadow: '0 2px 8px rgba(33,150,243,0.4)',
+        },
+        '&:active': { cursor: 'grabbing' },
+      }}
+    >
+      {/* Re-use PhotoEditorApi in grid size so edits applied to candidate
+          photos render with the same pipeline as slot photos. Label kept
+          empty — tray photos have no slot index. */}
+      <Box sx={{ width: '100%', height: '100%', pointerEvents: 'none' }}>
+        <PhotoEditorApi
+          key={photo.id}
+          photo={photo}
+          label=""
+          onUpdate={() => { /* no-op — modal edits propagate via parent */ }}
+          onRemove={() => { /* delete via context menu */ }}
+          size="grid"
+        />
+      </Box>
+      {/* Flag badge */}
+      {flag === 'pick' && (
+        <BadgeIcon><Star sx={{ fontSize: 14, color: 'warning.dark' }} /></BadgeIcon>
+      )}
+      {flag === 'reject' && (
+        <BadgeIcon color="error"><Block sx={{ fontSize: 14, color: 'common.white' }} /></BadgeIcon>
+      )}
+    </Box>
+  );
+};
+
+const BadgeIcon: React.FC<{ children: React.ReactNode; color?: 'error' }> = ({ children, color }) => (
+  <Box
+    sx={{
+      position: 'absolute',
+      top: 4,
+      right: 4,
+      width: 20,
+      height: 20,
+      borderRadius: '50%',
+      bgcolor: color === 'error' ? 'error.main' : 'common.white',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      boxShadow: '0 1px 2px rgba(0,0,0,0.3)',
+    }}
+  >
+    {children}
+  </Box>
+);

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -23,7 +23,6 @@ import {
   Star,
   StarBorder,
   Block,
-  Close,
   PhotoLibrary,
   Add as AddIcon,
   KeyboardDoubleArrowRight,
@@ -35,6 +34,7 @@ import { PhotoEditorApi } from './PhotoEditorApi';
 import { useI18n } from '../contexts/I18nContext';
 import { isValidImageFile } from '../utils/imageProcessing';
 import { filterCandidates, countByFlag } from '../utils/candidateFilter';
+import { parseDragPayload, serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
 import type { ApiPhoto, CandidateFlag } from '../types/api';
 
 export interface CandidateTrayProps {
@@ -104,8 +104,11 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
 
   // Native HTML5 drag events for slot→tray transfers. react-dropzone owns the
   // file-drop path; we layer our intra-app slot/tray transfer protocol on top.
+  // Parsing + literal-union guard live in `utils/dragPayload.ts` (PR #62
+  // review G3) — formerly duplicated inline between this component and
+  // `PhotoGridApi`.
   const handleDragOver = (e: React.DragEvent) => {
-    const hasInternalPayload = e.dataTransfer.types.includes('application/x-airq-photo');
+    const hasInternalPayload = e.dataTransfer.types.includes(DRAG_PAYLOAD_MIME);
     if (hasInternalPayload) {
       e.preventDefault();
       e.dataTransfer.dropEffect = 'move';
@@ -115,32 +118,35 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
   const handleDragLeave = () => setDropActive(false);
   const handleDrop = (e: React.DragEvent) => {
     setDropActive(false);
-    const raw = e.dataTransfer.getData('application/x-airq-photo');
-    if (!raw) return;
-    let payload: unknown;
-    try {
-      payload = JSON.parse(raw);
-    } catch (err) {
-      // PR #62 review I5: log instead of `catch {}` so debugging a misbehaving
-      // drag-and-drop doesn't require source patching.
-      console.warn('CandidateTray: malformed drag payload', raw, err);
-      return;
-    }
-    if (!payload || typeof payload !== 'object') return;
-    const p = payload as { kind?: unknown; setKey?: unknown; photoId?: unknown };
-    // Strict literal-union check on setKey (PR #62 review I5).
-    const isValidSet = p.setKey === 'set1' || p.setKey === 'set2';
-    if (p.kind === 'slot' && isValidSet && typeof p.photoId === 'string') {
+    const payload = parseDragPayload(e.dataTransfer.getData(DRAG_PAYLOAD_MIME));
+    if (payload?.kind === 'slot') {
       e.preventDefault();
-      onSlotDroppedIn({ setKey: p.setKey as 'set1' | 'set2', photoId: p.photoId });
+      onSlotDroppedIn({ setKey: payload.setKey, photoId: payload.photoId });
     }
   };
 
   const handleThumbDragStart = (e: React.DragEvent, photo: ApiPhoto) => {
-    const payload = JSON.stringify({ kind: 'tray', photoId: photo.id });
-    e.dataTransfer.setData('application/x-airq-photo', payload);
+    e.dataTransfer.setData(
+      DRAG_PAYLOAD_MIME,
+      serializeDragPayload({ kind: 'tray', photoId: photo.id }),
+    );
     e.dataTransfer.effectAllowed = 'move';
   };
+
+  // Compose our slot/tray handlers WITH react-dropzone's internal handlers so
+  // native file drops still work (PR #62 critical review CRIT-2). Previously
+  // the JSX `{...getRootProps()}` spread was followed by explicit
+  // `onDragOver`/`onDrop` props that OVERRODE dropzone's handlers — native
+  // drops were dead despite `t('candidates.emptyHint')` promising they'd work.
+  // Passing handlers through `getRootProps({...})` chains them: our handler
+  // runs first (for the internal `application/x-airq-photo` payload), then
+  // react-dropzone's runs (for native files; idempotent preventDefault is
+  // harmless). See react-dropzone `composeEventHandlers`.
+  const rootProps = getRootProps({
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  });
 
   // Empty-state — shows a wide drop hint. Only reached when slots have photos
   // (AppApi gates the whole tray on `candidates>0 OR slots>0`), so this acts
@@ -152,11 +158,8 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
     const active = isDragActive || dropActive;
     return (
       <Paper
-        {...(getRootProps() as any)}
+        {...(rootProps as any)}
         elevation={1}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
         sx={{
           mb: 2,
           p: 2.5,
@@ -185,6 +188,7 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
 
   return (
     <Paper
+      {...(rootProps as any)}
       elevation={1}
       sx={{
         mb: 2,
@@ -194,9 +198,6 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
         bgcolor: dropActive ? alpha(theme.palette.primary.main, 0.04) : 'background.paper',
         transition: 'all 0.15s ease-in-out',
       }}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
     >
       {/* Header */}
       <Box

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -3,8 +3,8 @@
  * triaging. See docs/CANDIDATE_PHOTOS.md.
  *
  * Drag/drop wire format (shared with PhotoGridApi):
- *   text/plain = JSON.stringify({ kind: 'tray',  photoId })   ← drag source
- *              | JSON.stringify({ kind: 'slot', setKey, index, photoId }) ← drop target
+ *   application/x-airq-photo = JSON.stringify({ kind: 'tray', photoId })   ← drag source
+ *                            | JSON.stringify({ kind: 'slot', setKey, index, photoId }) ← drop target
  */
 import React, { useMemo, useState } from 'react';
 import {
@@ -12,9 +12,6 @@ import {
   Paper,
   Typography,
   IconButton,
-  Menu,
-  MenuItem,
-  Divider,
   Switch,
   FormControlLabel,
   Tooltip,
@@ -29,6 +26,8 @@ import {
   Close,
   PhotoLibrary,
   Add as AddIcon,
+  KeyboardDoubleArrowRight,
+  DeleteOutline,
 } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
 import { useTheme, alpha } from '@mui/material/styles';
@@ -53,8 +52,8 @@ export interface CandidateTrayProps {
   hideSet2?: boolean;
 }
 
-const THUMB_HEIGHT = 96;
-const THUMB_WIDTH = 128;
+const THUMB_WIDTH = 144;
+const THUMB_IMAGE_HEIGHT = 100;
 
 export const CandidateTray: React.FC<CandidateTrayProps> = ({
   photos,
@@ -71,7 +70,6 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
 
   const [collapsed, setCollapsed] = useState(false);
   const [hideRejects, setHideRejects] = useState(false);
-  const [menuAnchor, setMenuAnchor] = useState<{ el: HTMLElement; photo: ApiPhoto } | null>(null);
   const [dropActive, setDropActive] = useState(false);
 
   // Filter rejects out when "Hide rejects" is on. Rejects with the toggle off
@@ -92,16 +90,9 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
     return { pick, neutral, reject, total: photos.length };
   }, [photos]);
 
-  const handleContextMenu = (e: React.MouseEvent<HTMLElement>, photo: ApiPhoto) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setMenuAnchor({ el: e.currentTarget, photo });
-  };
-  const closeMenu = () => setMenuAnchor(null);
-
   // Outer drop zone — accepts native file drops AND slot-photo drags. We
-  // disable react-dropzone's noClick for the empty-state CTA; in normal mode
-  // (when photos exist) we use a separate "+" button.
+  // disable react-dropzone's noClick when photos exist; the "Add more" button
+  // becomes the explicit click target in that case.
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
       'image/jpeg': ['.jpg', '.jpeg'],
@@ -117,8 +108,6 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
   // Native HTML5 drag events for slot→tray transfers. react-dropzone owns the
   // file-drop path; we layer our intra-app slot/tray transfer protocol on top.
   const handleDragOver = (e: React.DragEvent) => {
-    // Only accept if the drag has our JSON payload — otherwise the user is
-    // dragging a native file and react-dropzone handles it.
     const hasInternalPayload = e.dataTransfer.types.includes('application/x-airq-photo');
     if (hasInternalPayload) {
       e.preventDefault();
@@ -146,12 +135,14 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
     e.dataTransfer.effectAllowed = 'move';
   };
 
-  // Empty-state hero — when there are no candidates AND no slot photos either,
-  // AppApi hides this component entirely. So whenever we render, we always
-  // have either candidates OR the user is intentionally adding via the "+"
-  // button. The empty branch is only reached after the user deletes all
-  // candidates from a previously-non-empty tray.
+  // Empty-state — shows a wide drop hint. Only reached when slots have photos
+  // (AppApi gates the whole tray on `candidates>0 OR slots>0`), so this acts
+  // as the "add more to the candidates pool" entry point when slots are full.
+  // Styled distinctly from slot dropzones (warning-tinted border, prominent
+  // label) so the user can tell pool vs print at a glance — first dev-test
+  // feedback 2026-05-12.
   if (photos.length === 0) {
+    const active = isDragActive || dropActive;
     return (
       <Paper
         {...(getRootProps() as any)}
@@ -161,20 +152,24 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
         onDrop={handleDrop}
         sx={{
           mb: 2,
-          p: 2,
+          p: 2.5,
           border: '2px dashed',
-          borderColor: isDragActive || dropActive ? 'primary.main' : 'grey.300',
+          borderColor: active ? 'warning.dark' : 'warning.main',
           borderRadius: 2,
-          bgcolor: isDragActive || dropActive
-            ? alpha(theme.palette.primary.main, 0.06)
-            : 'background.paper',
+          bgcolor: active
+            ? alpha(theme.palette.warning.main, 0.10)
+            : alpha(theme.palette.warning.main, 0.04),
           textAlign: 'center',
           cursor: 'pointer',
+          transition: 'all 0.15s ease-in-out',
         }}
       >
         <input {...getInputProps()} />
-        <PhotoLibrary sx={{ fontSize: 28, color: 'text.secondary', mb: 0.5 }} />
-        <Typography variant="body2" color="text.secondary">
+        <PhotoLibrary sx={{ fontSize: 32, color: 'warning.dark', mb: 0.5 }} />
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, color: 'warning.dark' }}>
+          {t('candidates.poolLabel')}
+        </Typography>
+        <Typography variant="caption" sx={{ display: 'block', color: 'text.secondary', mt: 0.5 }}>
           {t('candidates.emptyHint')}
         </Typography>
       </Paper>
@@ -248,25 +243,51 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
         </IconButton>
       </Box>
 
-      {/* Thumb strip */}
+      {/* Drag-to-slot hint banner — explains the primary action that isn't
+          discoverable from the thumb toolbar alone (first dev-test feedback
+          2026-05-12). Always visible while populated — small enough to stay
+          out of the way. */}
+      {!collapsed && (
+        <Box
+          sx={{
+            px: 2,
+            py: 0.75,
+            bgcolor: alpha(theme.palette.primary.main, 0.06),
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+          }}
+        >
+          <KeyboardDoubleArrowRight sx={{ fontSize: 16, color: 'primary.main' }} />
+          <Typography variant="caption" color="text.secondary">
+            {t('candidates.dragHint')}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Thumb grid — wraps onto multiple rows instead of scrolling
+          horizontally (first dev-test feedback 2026-05-12). */}
       {!collapsed && (
         <Box
           sx={{
             display: 'flex',
-            gap: 1,
+            flexWrap: 'wrap',
+            gap: 1.25,
             p: 1.5,
-            overflowX: 'auto',
-            // Subtle hint that more content scrolls
-            scrollbarGutter: 'stable',
           }}
         >
           {visiblePhotos.map((photo) => (
             <CandidateThumb
               key={photo.id}
               photo={photo}
+              hideSet2={hideSet2}
               onClick={() => onPhotoClick(photo)}
-              onContextMenu={(e) => handleContextMenu(e, photo)}
               onDragStart={(e) => handleThumbDragStart(e, photo)}
+              onSetFlag={(flag) => onSetFlag(photo.id, flag)}
+              onDelete={() => onDelete(photo.id)}
+              onSendToSet={(setKey) => onSendToSet(photo.id, setKey)}
             />
           ))}
           {visiblePhotos.length === 0 && (
@@ -276,36 +297,6 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
           )}
         </Box>
       )}
-
-      {/* Context menu */}
-      <Menu
-        open={Boolean(menuAnchor)}
-        anchorEl={menuAnchor?.el ?? null}
-        onClose={closeMenu}
-      >
-        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'pick'); closeMenu(); }}>
-          <Star sx={{ fontSize: 18, mr: 1, color: 'warning.main' }} /> {t('candidates.flag.pick')}
-        </MenuItem>
-        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'neutral'); closeMenu(); }}>
-          <StarBorder sx={{ fontSize: 18, mr: 1 }} /> {t('candidates.flag.neutral')}
-        </MenuItem>
-        <MenuItem onClick={() => { if (menuAnchor) onSetFlag(menuAnchor.photo.id, 'reject'); closeMenu(); }}>
-          <Block sx={{ fontSize: 18, mr: 1, color: 'error.main' }} /> {t('candidates.flag.reject')}
-        </MenuItem>
-        <Divider />
-        <MenuItem onClick={() => { if (menuAnchor) onSendToSet(menuAnchor.photo.id, 'set1'); closeMenu(); }}>
-          {t('candidates.sendToSet1')}
-        </MenuItem>
-        {!hideSet2 && (
-          <MenuItem onClick={() => { if (menuAnchor) onSendToSet(menuAnchor.photo.id, 'set2'); closeMenu(); }}>
-            {t('candidates.sendToSet2')}
-          </MenuItem>
-        )}
-        <Divider />
-        <MenuItem onClick={() => { if (menuAnchor) onDelete(menuAnchor.photo.id); closeMenu(); }} sx={{ color: 'error.main' }}>
-          <Close sx={{ fontSize: 18, mr: 1 }} /> {t('common.delete')}
-        </MenuItem>
-      </Menu>
     </Paper>
   );
 };
@@ -339,77 +330,178 @@ const CountChip: React.FC<CountChipProps> = ({ count, icon, color }) => {
 
 interface CandidateThumbProps {
   photo: ApiPhoto;
+  hideSet2?: boolean;
   onClick: () => void;
-  onContextMenu: (e: React.MouseEvent<HTMLElement>) => void;
   onDragStart: (e: React.DragEvent) => void;
+  onSetFlag: (flag: CandidateFlag) => void;
+  onDelete: () => void;
+  onSendToSet: (setKey: 'set1' | 'set2') => void;
 }
-const CandidateThumb: React.FC<CandidateThumbProps> = ({ photo, onClick, onContextMenu, onDragStart }) => {
+const CandidateThumb: React.FC<CandidateThumbProps> = ({
+  photo,
+  hideSet2,
+  onClick,
+  onDragStart,
+  onSetFlag,
+  onDelete,
+  onSendToSet,
+}) => {
+  const theme = useTheme();
+  const { t } = useI18n();
   const flag: CandidateFlag = (photo.flag as CandidateFlag | undefined) ?? 'neutral';
+  const isPick = flag === 'pick';
   const isReject = flag === 'reject';
+
+  // Status border colour communicates flag at a glance.
+  const borderColor =
+    isPick ? theme.palette.warning.main
+    : isReject ? theme.palette.error.main
+    : theme.palette.divider;
+
+  // Toolbar button — small, single-purpose. Stops click propagation so
+  // clicking the toolbar doesn't open the editor modal.
+  const tbBtn = (
+    title: string,
+    active: boolean,
+    color: 'warning' | 'error' | 'primary' | 'default',
+    icon: React.ReactNode,
+    onClickFn: () => void,
+  ) => {
+    const palette =
+      color === 'warning' ? theme.palette.warning
+      : color === 'error' ? theme.palette.error
+      : color === 'primary' ? theme.palette.primary
+      : { main: theme.palette.text.secondary, dark: theme.palette.text.primary, light: theme.palette.action.hover, contrastText: theme.palette.text.primary };
+    return (
+      <Tooltip title={title} disableInteractive>
+        <IconButton
+          size="small"
+          onClick={(e) => { e.stopPropagation(); onClickFn(); }}
+          sx={{
+            p: 0.25,
+            borderRadius: 0.75,
+            bgcolor: active ? alpha(palette.main, 0.15) : 'transparent',
+            color: active ? palette.dark : 'text.secondary',
+            '&:hover': {
+              bgcolor: alpha(palette.main, 0.2),
+              color: palette.dark,
+            },
+          }}
+        >
+          {icon}
+        </IconButton>
+      </Tooltip>
+    );
+  };
+
   return (
     <Box
       draggable
       onDragStart={onDragStart}
-      onClick={onClick}
-      onContextMenu={onContextMenu}
       sx={{
-        position: 'relative',
         flex: '0 0 auto',
         width: THUMB_WIDTH,
-        height: THUMB_HEIGHT,
         borderRadius: 1,
         overflow: 'hidden',
+        bgcolor: 'background.paper',
+        border: `2px solid ${borderColor}`,
+        opacity: isReject ? 0.55 : 1,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+        transition: 'transform 0.12s, box-shadow 0.12s, border-color 0.15s',
         cursor: 'grab',
-        opacity: isReject ? 0.45 : 1,
-        boxShadow: '0 1px 3px rgba(0,0,0,0.12)',
-        transition: 'transform 0.12s, box-shadow 0.12s',
         '&:hover': {
-          transform: 'scale(1.03)',
-          boxShadow: '0 2px 8px rgba(33,150,243,0.4)',
+          transform: 'translateY(-1px)',
+          boxShadow: '0 2px 8px rgba(33,150,243,0.35)',
         },
         '&:active': { cursor: 'grabbing' },
       }}
     >
-      {/* Re-use PhotoEditorApi in grid size so edits applied to candidate
-          photos render with the same pipeline as slot photos. Label kept
-          empty — tray photos have no slot index. */}
-      <Box sx={{ width: '100%', height: '100%', pointerEvents: 'none' }}>
-        <PhotoEditorApi
-          key={photo.id}
-          photo={photo}
-          label=""
-          onUpdate={() => { /* no-op — modal edits propagate via parent */ }}
-          onRemove={() => { /* delete via context menu */ }}
-          size="grid"
-        />
+      {/* Image area — click opens the edit modal. pointerEvents on the inner
+          editor are disabled so the parent's drag/click handlers receive
+          events instead. */}
+      <Box
+        onClick={onClick}
+        sx={{
+          width: '100%',
+          height: THUMB_IMAGE_HEIGHT,
+          position: 'relative',
+          cursor: 'pointer',
+        }}
+      >
+        <Box sx={{ width: '100%', height: '100%', pointerEvents: 'none' }}>
+          <PhotoEditorApi
+            key={photo.id}
+            photo={photo}
+            label=""
+            onUpdate={() => { /* persisted via parent's updateCandidatePhotoState */ }}
+            onRemove={() => { /* delete via toolbar */ }}
+            size="grid"
+          />
+        </Box>
       </Box>
-      {/* Flag badge */}
-      {flag === 'pick' && (
-        <BadgeIcon><Star sx={{ fontSize: 14, color: 'warning.dark' }} /></BadgeIcon>
-      )}
-      {flag === 'reject' && (
-        <BadgeIcon color="error"><Block sx={{ fontSize: 14, color: 'common.white' }} /></BadgeIcon>
-      )}
+
+      {/* Always-visible control toolbar. Left-click only — no right-click menu
+          (first dev-test feedback 2026-05-12). Flag toggles act radio-like:
+          clicking the active flag clears it back to neutral. */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 0.25,
+          px: 0.5,
+          py: 0.5,
+          borderTop: `1px solid ${theme.palette.divider}`,
+          bgcolor: alpha(theme.palette.background.default, 0.6),
+        }}
+      >
+        {/* Flag toggles */}
+        <Box sx={{ display: 'flex', gap: 0.25 }}>
+          {tbBtn(
+            t('candidates.flag.pick'),
+            isPick,
+            'warning',
+            isPick ? <Star sx={{ fontSize: 16 }} /> : <StarBorder sx={{ fontSize: 16 }} />,
+            () => onSetFlag(isPick ? 'neutral' : 'pick'),
+          )}
+          {tbBtn(
+            t('candidates.flag.reject'),
+            isReject,
+            'error',
+            <Block sx={{ fontSize: 16 }} />,
+            () => onSetFlag(isReject ? 'neutral' : 'reject'),
+          )}
+        </Box>
+
+        {/* Send to set */}
+        <Box sx={{ display: 'flex', gap: 0.25 }}>
+          {tbBtn(
+            t('candidates.sendToSet1'),
+            false,
+            'primary',
+            <Box sx={{ display: 'flex', alignItems: 'center', fontSize: 11, fontWeight: 700 }}>
+              <KeyboardDoubleArrowRight sx={{ fontSize: 14 }} />1
+            </Box>,
+            () => onSendToSet('set1'),
+          )}
+          {!hideSet2 && tbBtn(
+            t('candidates.sendToSet2'),
+            false,
+            'primary',
+            <Box sx={{ display: 'flex', alignItems: 'center', fontSize: 11, fontWeight: 700 }}>
+              <KeyboardDoubleArrowRight sx={{ fontSize: 14 }} />2
+            </Box>,
+            () => onSendToSet('set2'),
+          )}
+          {tbBtn(
+            t('common.delete'),
+            false,
+            'error',
+            <DeleteOutline sx={{ fontSize: 16 }} />,
+            onDelete,
+          )}
+        </Box>
+      </Box>
     </Box>
   );
 };
-
-const BadgeIcon: React.FC<{ children: React.ReactNode; color?: 'error' }> = ({ children, color }) => (
-  <Box
-    sx={{
-      position: 'absolute',
-      top: 4,
-      right: 4,
-      width: 20,
-      height: 20,
-      borderRadius: '50%',
-      bgcolor: color === 'error' ? 'error.main' : 'common.white',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      boxShadow: '0 1px 2px rgba(0,0,0,0.3)',
-    }}
-  >
-    {children}
-  </Box>
-);

--- a/frontend/photo-helper/src/components/PhotoEditorApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoEditorApi.tsx
@@ -20,7 +20,10 @@ interface PhotoEditorApiProps {
   onUpdate: (canvasState: Photo['canvasState']) => void;
   onRemove: () => void;
   size?: 'grid' | 'large';
-  setKey?: 'set1' | 'set2'; // For PDF generation canvas identification
+  // `'candidates'` is accepted but never reaches PDF generation —
+  // `buildPdfSets` only reads `session.sets.{set1,set2}`. The attribute is
+  // emitted so devtools can tell tray vs slot canvases apart.
+  setKey?: 'set1' | 'set2' | 'candidates'; // For PDF generation canvas identification
   showOriginal?: boolean; // Whether to show original (no effects) or edited version
   circleMode?: boolean; // Whether circle mode is enabled
 }

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -12,6 +12,7 @@ import { useI18n } from '../contexts/I18nContext';
 import { useLayoutMode } from '../contexts/LayoutModeContext';
 import { getImageCache } from '../utils/imageCache';
 import { parseDragPayload, serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
+import { dispatchSlotDrop } from '../utils/slotDropDispatch';
 import type { ApiPhoto, ApiPhotoSet } from '../types/api';
 
 interface PhotoGridApiProps {
@@ -184,31 +185,37 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   const handleDrop = (e: React.DragEvent, dropIndex: number) => {
     e.preventDefault();
 
-    // Check structured payload first — a tray photo dropping in promotes;
-    // a slot photo dropping in is the existing reorder flow.
-    const payload = parseDragPayload(e.dataTransfer.getData(DRAG_PAYLOAD_MIME));
-    if (payload) {
-      if (payload.kind === 'tray' && onCandidateDropped) {
-        onCandidateDropped(payload.photoId, dropIndex);
-        setDraggedIndex(null);
-        setDragOverIndex(null);
-        return;
-      }
-      if (payload.kind === 'slot' && payload.setKey !== setKey) {
-        // Cross-set drops aren't supported in v1 (two-step via tray works).
-        // Surface the rejection so the user knows what happened (PR #62
-        // review I4 — previously silently ignored).
-        if (onCrossSetDropRejected) onCrossSetDropRejected();
-        setDraggedIndex(null);
-        setDragOverIndex(null);
-        return;
-      }
-    }
+    // Dispatch decided by a pure helper (PR #62 review I4) — the component
+    // stays in charge of drag-state resets but no longer holds the branch
+    // logic, which is unit-tested in slotDropDispatch.test.ts.
+    const action = dispatchSlotDrop({
+      payload: parseDragPayload(e.dataTransfer.getData(DRAG_PAYLOAD_MIME)),
+      textPlain: e.dataTransfer.getData('text/plain'),
+      files: Array.from(e.dataTransfer.files),
+      dropIndex,
+      setKey,
+      isValidImageFile,
+    });
 
-    // Legacy in-grid reorder.
-    const dragIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
-    if (Number.isFinite(dragIndex) && dragIndex !== dropIndex && onPhotoMove) {
-      onPhotoMove(dragIndex, dropIndex);
+    switch (action.kind) {
+      case 'promote':
+        if (onCandidateDropped) onCandidateDropped(action.photoId, action.dropIndex);
+        break;
+      case 'cross-set-rejected':
+        if (onCrossSetDropRejected) onCrossSetDropRejected();
+        break;
+      case 'reorder':
+        if (onPhotoMove) onPhotoMove(action.fromIndex, action.toIndex);
+        break;
+      case 'files':
+        // Native OS file drop on an occupied slot — without this branch the
+        // files vanished from the cursor silently because `e.preventDefault()`
+        // already suppressed the dropzone wrapper. Route to smart-drop so it
+        // sends the batch to the candidate tray.
+        if (onFilesDropped) onFilesDropped(action.files);
+        break;
+      case 'none':
+        break;
     }
 
     setDraggedIndex(null);

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -28,6 +28,13 @@ interface PhotoGridApiProps {
    * docs/CANDIDATE_PHOTOS.md "Drag/drop interactions".
    */
   onCandidateDropped?: (candidateId: string, slotIndex: number) => void;
+  /**
+   * Optional hint hook for the (out-of-scope-in-v1) cross-set slot→slot drag.
+   * Fired when a user drops a slot photo from another set onto this grid.
+   * AppApi uses it to nudge the user toward the tray (PR #62 review I4 —
+   * previously silently ignored).
+   */
+  onCrossSetDropRejected?: () => void;
   labelOffset?: number; // Offset for label sequence (e.g., set2 continues from where set1 left off)
   customLabels?: string[]; // Custom labels to use instead of generated ones (for turning point mode)
   /**
@@ -70,6 +77,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   onFilesDropped,
   onPhotoMove,
   onCandidateDropped,
+  onCrossSetDropRejected,
   labelOffset = 0,
   customLabels,
   maxPhotosOverride,
@@ -176,26 +184,41 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
     // a slot photo dropping in is the existing reorder flow.
     const raw = e.dataTransfer.getData('application/x-airq-photo');
     if (raw) {
+      let payload: unknown;
       try {
-        const payload = JSON.parse(raw) as { kind: string; photoId?: string; setKey?: 'set1' | 'set2' };
-        if (payload.kind === 'tray' && payload.photoId && onCandidateDropped) {
-          onCandidateDropped(payload.photoId, dropIndex);
+        payload = JSON.parse(raw);
+      } catch (err) {
+        // PR #62 review I5: log instead of `catch {}` so a malformed payload
+        // is debuggable in devtools.
+        console.warn('PhotoGridApi: malformed drag payload', raw, err);
+        payload = null;
+      }
+      if (payload && typeof payload === 'object') {
+        const p = payload as { kind?: unknown; photoId?: unknown; setKey?: unknown };
+        if (p.kind === 'tray' && typeof p.photoId === 'string' && onCandidateDropped) {
+          onCandidateDropped(p.photoId, dropIndex);
           setDraggedIndex(null);
           setDragOverIndex(null);
           return;
         }
-        if (payload.kind === 'slot' && payload.setKey && payload.setKey !== setKey) {
+        // Strict literal-union check (PR #62 review I5): never index `sets[
+        // payload.setKey]` with an arbitrary string — `__proto__` would crash
+        // downstream consumers.
+        const isValidSet = p.setKey === 'set1' || p.setKey === 'set2';
+        if (p.kind === 'slot' && isValidSet && p.setKey !== setKey) {
           // Cross-set drops aren't supported in v1 (two-step via tray works).
-          // Silently ignore so the user doesn't see a half-applied move.
+          // Surface the rejection so the user knows what happened (PR #62
+          // review I4 — previously silently ignored).
+          if (onCrossSetDropRejected) onCrossSetDropRejected();
           setDraggedIndex(null);
           setDragOverIndex(null);
           return;
         }
-      } catch {}
+      }
     }
 
     // Legacy in-grid reorder.
-    const dragIndex = parseInt(e.dataTransfer.getData('text/plain'));
+    const dragIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
     if (Number.isFinite(dragIndex) && dragIndex !== dropIndex && onPhotoMove) {
       onPhotoMove(dragIndex, dropIndex);
     }

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -11,6 +11,7 @@ import { useLabeling } from '../contexts/LabelingContext';
 import { useI18n } from '../contexts/I18nContext';
 import { useLayoutMode } from '../contexts/LayoutModeContext';
 import { getImageCache } from '../utils/imageCache';
+import { parseDragPayload, serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
 import type { ApiPhoto, ApiPhotoSet } from '../types/api';
 
 interface PhotoGridApiProps {
@@ -143,7 +144,10 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   // Two payload channels:
   //   text/plain                 — legacy in-grid reorder: just the slot index
   //   application/x-airq-photo   — structured payload for tray↔slot transfers.
-  //                                 Shape: { kind: 'slot' | 'tray', ... }.
+  //                                 See `utils/dragPayload.ts` for the parser
+  //                                 and the strict literal-union check on
+  //                                 setKey (PR #62 review G3 — formerly
+  //                                 duplicated inline in two components).
   // Slot drags emit both so the tray can recognise the source. The grid only
   // needs the structured payload on drops that *could* be from the tray.
   const handleDragStart = (e: React.DragEvent, index: number, photoId: string | undefined) => {
@@ -152,8 +156,8 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
     e.dataTransfer.setData('text/plain', index.toString());
     if (photoId) {
       e.dataTransfer.setData(
-        'application/x-airq-photo',
-        JSON.stringify({ kind: 'slot', setKey, index, photoId }),
+        DRAG_PAYLOAD_MIME,
+        serializeDragPayload({ kind: 'slot', setKey, index, photoId }),
       );
     }
 
@@ -182,38 +186,22 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
 
     // Check structured payload first — a tray photo dropping in promotes;
     // a slot photo dropping in is the existing reorder flow.
-    const raw = e.dataTransfer.getData('application/x-airq-photo');
-    if (raw) {
-      let payload: unknown;
-      try {
-        payload = JSON.parse(raw);
-      } catch (err) {
-        // PR #62 review I5: log instead of `catch {}` so a malformed payload
-        // is debuggable in devtools.
-        console.warn('PhotoGridApi: malformed drag payload', raw, err);
-        payload = null;
+    const payload = parseDragPayload(e.dataTransfer.getData(DRAG_PAYLOAD_MIME));
+    if (payload) {
+      if (payload.kind === 'tray' && onCandidateDropped) {
+        onCandidateDropped(payload.photoId, dropIndex);
+        setDraggedIndex(null);
+        setDragOverIndex(null);
+        return;
       }
-      if (payload && typeof payload === 'object') {
-        const p = payload as { kind?: unknown; photoId?: unknown; setKey?: unknown };
-        if (p.kind === 'tray' && typeof p.photoId === 'string' && onCandidateDropped) {
-          onCandidateDropped(p.photoId, dropIndex);
-          setDraggedIndex(null);
-          setDragOverIndex(null);
-          return;
-        }
-        // Strict literal-union check (PR #62 review I5): never index `sets[
-        // payload.setKey]` with an arbitrary string — `__proto__` would crash
-        // downstream consumers.
-        const isValidSet = p.setKey === 'set1' || p.setKey === 'set2';
-        if (p.kind === 'slot' && isValidSet && p.setKey !== setKey) {
-          // Cross-set drops aren't supported in v1 (two-step via tray works).
-          // Surface the rejection so the user knows what happened (PR #62
-          // review I4 — previously silently ignored).
-          if (onCrossSetDropRejected) onCrossSetDropRejected();
-          setDraggedIndex(null);
-          setDragOverIndex(null);
-          return;
-        }
+      if (payload.kind === 'slot' && payload.setKey !== setKey) {
+        // Cross-set drops aren't supported in v1 (two-step via tray works).
+        // Surface the rejection so the user knows what happened (PR #62
+        // review I4 — previously silently ignored).
+        if (onCrossSetDropRejected) onCrossSetDropRejected();
+        setDraggedIndex(null);
+        setDragOverIndex(null);
+        return;
       }
     }
 

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -21,6 +21,13 @@ interface PhotoGridApiProps {
   onPhotoClick?: (photo: ApiPhoto) => void;
   onFilesDropped?: (files: File[]) => void; // For uploading files to empty slots
   onPhotoMove?: (fromIndex: number, toIndex: number) => void; // For drag-and-drop reordering
+  /**
+   * Candidate-tray → slot promotion handler. Receives the candidate's photo
+   * id and the target slot index. The hook layer handles swap-on-occupied
+   * semantics; the grid just decides where to drop. See
+   * docs/CANDIDATE_PHOTOS.md "Drag/drop interactions".
+   */
+  onCandidateDropped?: (candidateId: string, slotIndex: number) => void;
   labelOffset?: number; // Offset for label sequence (e.g., set2 continues from where set1 left off)
   customLabels?: string[]; // Custom labels to use instead of generated ones (for turning point mode)
   /**
@@ -62,6 +69,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   onPhotoClick,
   onFilesDropped,
   onPhotoMove,
+  onCandidateDropped,
   labelOffset = 0,
   customLabels,
   maxPhotosOverride,
@@ -123,11 +131,24 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
 
   
   // Drag and drop handlers
-  const handleDragStart = (e: React.DragEvent, index: number) => {
+  //
+  // Two payload channels:
+  //   text/plain                 — legacy in-grid reorder: just the slot index
+  //   application/x-airq-photo   — structured payload for tray↔slot transfers.
+  //                                 Shape: { kind: 'slot' | 'tray', ... }.
+  // Slot drags emit both so the tray can recognise the source. The grid only
+  // needs the structured payload on drops that *could* be from the tray.
+  const handleDragStart = (e: React.DragEvent, index: number, photoId: string | undefined) => {
     setDraggedIndex(index);
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', index.toString());
-    
+    if (photoId) {
+      e.dataTransfer.setData(
+        'application/x-airq-photo',
+        JSON.stringify({ kind: 'slot', setKey, index, photoId }),
+      );
+    }
+
     // Create custom drag image (optional - use default for now)
     (e.currentTarget as HTMLElement).style.opacity = '0.5';
   };
@@ -150,12 +171,35 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
 
   const handleDrop = (e: React.DragEvent, dropIndex: number) => {
     e.preventDefault();
+
+    // Check structured payload first — a tray photo dropping in promotes;
+    // a slot photo dropping in is the existing reorder flow.
+    const raw = e.dataTransfer.getData('application/x-airq-photo');
+    if (raw) {
+      try {
+        const payload = JSON.parse(raw) as { kind: string; photoId?: string; setKey?: 'set1' | 'set2' };
+        if (payload.kind === 'tray' && payload.photoId && onCandidateDropped) {
+          onCandidateDropped(payload.photoId, dropIndex);
+          setDraggedIndex(null);
+          setDragOverIndex(null);
+          return;
+        }
+        if (payload.kind === 'slot' && payload.setKey && payload.setKey !== setKey) {
+          // Cross-set drops aren't supported in v1 (two-step via tray works).
+          // Silently ignore so the user doesn't see a half-applied move.
+          setDraggedIndex(null);
+          setDragOverIndex(null);
+          return;
+        }
+      } catch {}
+    }
+
+    // Legacy in-grid reorder.
     const dragIndex = parseInt(e.dataTransfer.getData('text/plain'));
-    
-    if (dragIndex !== dropIndex && onPhotoMove) {
+    if (Number.isFinite(dragIndex) && dragIndex !== dropIndex && onPhotoMove) {
       onPhotoMove(dragIndex, dropIndex);
     }
-    
+
     setDraggedIndex(null);
     setDragOverIndex(null);
   };
@@ -207,7 +251,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
             <Paper
               elevation={slot.photo ? 2 : 0}
               draggable={slot.photo ? true : false}
-              onDragStart={slot.photo ? (e) => handleDragStart(e, slot.index) : undefined}
+              onDragStart={slot.photo ? (e) => handleDragStart(e, slot.index, slot.photo?.id) : undefined}
               onDragEnd={slot.photo ? handleDragEnd : undefined}
               onDragOver={(e) => handleDragOver(e, slot.index)}
               onDragLeave={handleDragLeave}

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -24,6 +24,11 @@ interface TurningPointLayoutProps {
   onPhotoUpdate: (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => void;
   onPhotoRemove: (setKey: 'set1' | 'set2', photoId: string) => void;
   onPhotoMove: (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => void;
+  /**
+   * Optional tray → slot promotion handler. AppApi passes one per set key; if
+   * omitted, candidate drops on a slot are ignored (back-compat).
+   */
+  onCandidateDropped?: (setKey: 'set1' | 'set2', candidateId: string, slotIndex: number) => void;
   totalPhotoCount: number;
   /**
    * Precision discipline only uses a single set of up to 9 photos
@@ -48,6 +53,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   error,
   onFilesDropped,
   onInitialFilesDropped,
+  onCandidateDropped,
   onPhotoClick,
   onPhotoUpdate,
   onPhotoRemove,
@@ -110,6 +116,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoClick={(photo) => onPhotoClick(photo, 'set1')}
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set1', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set1', files)}
+                onCandidateDropped={onCandidateDropped ? (id, idx) => onCandidateDropped('set1', id, idx) : undefined}
                 customLabels={turningPointLabels.set1}
                 maxPhotosOverride={rallyMaxPerSet}
                 slotsOverride={set1Grid?.slots}
@@ -133,6 +140,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoClick={(photo) => onPhotoClick(photo, 'set2')}
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set2', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set2', files)}
+                onCandidateDropped={onCandidateDropped ? (id, idx) => onCandidateDropped('set2', id, idx) : undefined}
                 customLabels={turningPointLabels.set2}
                 maxPhotosOverride={rallyMaxPerSet}
                 slotsOverride={set2Grid?.slots}

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -10,7 +10,7 @@ import type {
   CleanupSuggestion,
   StorageStats 
 } from '../types/competition';
-import type { ApiPhotoSession, ApiPhoto, CandidateFlag } from '../types/api';
+import type { ApiPhotoSession, ApiPhoto, CandidateFlag, AddPhotosResult } from '../types/api';
 import { competitionService } from '../services/competitionService';
 import { migrationService } from '../services/migrationService';
 import { useI18n } from '../contexts/I18nContext';
@@ -19,6 +19,7 @@ import { distributeRallyDrop } from '../utils/distributeRallyDrop';
 import { getGridCapacity } from '../utils/getGridCapacity';
 import { parseDiscipline } from '../utils/parseDiscipline';
 import { routeDrop } from '../utils/smartDropRoute';
+import { isPhotoReferencedInSession } from '../utils/sessionRefs';
 import {
   promoteCandidateToSlot as promoteCandidateToSlotPure,
   demoteSlotToCandidate as demoteSlotToCandidatePure,
@@ -55,9 +56,10 @@ export interface UseCompetitionSystemResult {
   // Session operations (proxied to current competition)
   session: ApiPhotoSession | null;
   sessionId: string | null;
-  addPhotosToSet: (files: File[], setKey: 'set1' | 'set2') => Promise<{ routedTo: 'slot' | 'tray'; count: number } | void>;
+  addPhotosToSet: (files: File[], setKey: 'set1' | 'set2') => Promise<AddPhotosResult>;
+  addPhotosToTurningPoint: (files: File[]) => Promise<AddPhotosResult>;
   removePhoto: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
-  updatePhotoState: (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => Promise<void>;
+  updatePhotoState: (setKey: 'set1' | 'set2', photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => Promise<void>;
   updateSetTitle: (setKey: 'set1' | 'set2', title: string) => Promise<void>;
   updateSetTitles: (titles: { set1?: string; set2?: string }) => Promise<void>;
   updateSessionMode: (mode: 'track' | 'turningpoint') => Promise<void>;
@@ -70,7 +72,15 @@ export interface UseCompetitionSystemResult {
   promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
   demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
   setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void>;
-  updateCandidatePhotoState: (photoId: string, canvasState: any) => Promise<void>;
+  updateCandidatePhotoState: (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => Promise<void>;
+  /**
+   * Delete a specific subset of candidate ids — session entries removed AND
+   * their OPFS files freed. Rethrows when any OPFS deletion fails so callers
+   * (e.g. the post-export cleanup dialog) can keep their UI open and surface
+   * the failure. Snapshot-id targeted variant of `clearAllCandidates`
+   * (PR #62 review CRIT-3, IMP-4).
+   */
+  deleteCandidates: (photoIds: string[]) => Promise<void>;
   clearAllCandidates: () => Promise<void>;
   
   // Cleanup & storage
@@ -541,11 +551,12 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     }, { updatePhotos: true });
   }, [updateCurrentCompetition, currentCompetition, filesToPhotos, t]);
 
-  const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2') => {
+  const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2'): Promise<AddPhotosResult> => {
     if (!currentCompetition?.session) {
       console.error('No current competition or session available');
-      setError(t('errors.noActiveCompetition'));
-      return;
+      const message = t('errors.noActiveCompetition');
+      setError(message);
+      return { kind: 'err', reason: 'no-competition', message };
     }
 
     // Smart-drop routing: if the batch fits the remaining slot capacity, fill
@@ -566,13 +577,14 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // tray anyway (remaining = 0), but surfacing the corruption explicitly
     // lets the user know to clean up.
     if (currentSlotCount > slotCapacity) {
-      setError(`This set already has ${currentSlotCount} photos but the cap is now ${slotCapacity}. Please reload the competition or remove photos before adding more.`);
-      return;
+      const message = `This set already has ${currentSlotCount} photos but the cap is now ${slotCapacity}. Please reload the competition or remove photos before adding more.`;
+      setError(message);
+      return { kind: 'err', reason: 'over-capacity', message };
     }
     const route = routeDrop({ files, currentSlotCount, slotCapacity });
     if (route.kind === 'tray') {
       await addPhotosToCandidates(route.files);
-      return { routedTo: 'tray' as const, count: route.files.length };
+      return { kind: 'ok', routedTo: 'tray', count: route.files.length };
     }
 
     await updateCurrentCompetition(session => {
@@ -608,28 +620,17 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       };
     }, { updatePhotos: true });
-    return { routedTo: 'slot' as const, count: route.files.length };
+    return { kind: 'ok', routedTo: 'slot', count: route.files.length };
   }, [updateCurrentCompetition, currentCompetition, t, filesToPhotos, addPhotosToCandidates]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {
     const compId = currentCompetition?.id;
-    // Only schedule the OPFS delete if the id is NOT referenced from the other
-    // mode bucket — `saveSessionPhotos` shares the photos/ dir across buckets,
-    // so deleting a file still listed in `setsTrack`/`setsTurning` would break
-    // the inactive mode (PR #62 review C3).
-    const isReferencedElsewhere = (() => {
-      const s = currentCompetition?.session as any;
-      if (!s) return true;
-      const buckets = [s.setsTrack, s.setsTurning];
-      for (const b of buckets) {
-        if (b?.set1?.photos?.some?.((p: any) => p.id === photoId)) return true;
-        if (b?.set2?.photos?.some?.((p: any) => p.id === photoId)) return true;
-      }
-      if (s.candidates?.photos?.some?.((p: any) => p.id === photoId)) return true;
-      const otherKey = setKey === 'set1' ? 'set2' : 'set1';
-      if (s.sets?.[otherKey]?.photos?.some?.((p: any) => p.id === photoId)) return true;
-      return false;
-    })();
+    // Capture from inside the updater so the check runs against POST-mutation
+    // state. The active mode bucket is mirrored alongside `sets` (PR #62
+    // review IMP-3) so a mode-switch round-trip can't resurrect the photo;
+    // `isPhotoReferencedInSession` then accurately reports whether the OTHER
+    // mode bucket (or candidates, or the other set) still references the id.
+    let referencedElsewhere = true;
     await updateCurrentCompetition(session => {
       const ensuredSets = {
         set1: session.sets?.set1 || { title: '', photos: [] },
@@ -642,23 +643,36 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       }
 
-      return {
+      const nextSets = {
+        ...ensuredSets,
+        [setKey]: {
+          ...ensuredSets[setKey],
+          photos: (ensuredSets[setKey].photos || []).filter(p => p.id !== photoId)
+        }
+      };
+      const next: ApiPhotoSession = {
         ...session,
         version: session.version + 1,
         updatedAt: new Date().toISOString(),
-        sets: {
-          ...ensuredSets,
-          [setKey]: {
-            ...ensuredSets[setKey],
-            photos: (ensuredSets[setKey].photos || []).filter(p => p.id !== photoId)
-          }
-        }
+        sets: nextSets,
       };
+      // Mirror the slot removal into the active mode bucket (PR #62 review
+      // IMP-3) — without this, `setsTrack`/`setsTurning` keep a stale entry,
+      // `isPhotoReferencedInSession` stays truthy, and the OPFS file orphans
+      // after a mode-switch round-trip.
+      const modeKey = session.mode === 'track' ? 'setsTrack' : 'setsTurning';
+      (next as any)[modeKey] = nextSets;
+      referencedElsewhere = isPhotoReferencedInSession(next, photoId);
+      return next;
     }, { updatePhotos: true });
-    if (compId && !isReferencedElsewhere) {
+    if (compId && !referencedElsewhere) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {
+        // Per-photo cleanup is best-effort. The session entry is gone; an
+        // orphan OPFS file is preferable to refusing the UX flow. The
+        // cleanup dialog (CRIT-3) DOES surface failures because it deletes
+        // explicit user-targeted ids; this single-photo path doesn't.
         console.warn('removePhoto: deletePhotosByIds failed:', err);
       }
     }
@@ -671,6 +685,12 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
 
   const removeCandidate = useCallback(async (photoId: string) => {
     const compId = currentCompetition?.id;
+    // Capture POST-mutation reference state. Slots and candidates are
+    // disjoint by construction, but the cross-bucket check is symmetric
+    // with `removePhoto` (PR #62 review IMP-2) — if anything ever breaks
+    // the invariant, this prevents the OPFS file from being deleted while
+    // still referenced from a slot or mode bucket.
+    let referencedElsewhere = true;
     await updateCurrentCompetition(session => {
       const target = session.candidates?.photos?.find(p => p.id === photoId);
       if (typeof target?.url === 'string' && target.url.startsWith('blob:')) {
@@ -678,11 +698,13 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           console.warn(`removeCandidate: revoke failed for ${photoId}:`, err);
         }
       }
-      return removeCandidatePure(session, photoId);
+      const next = removeCandidatePure(session, photoId);
+      referencedElsewhere = isPhotoReferencedInSession(next, photoId);
+      return next;
     }, { updatePhotos: true });
     // Free the OPFS file (PR #62 review C3). `saveSessionPhotos` never prunes,
     // so without an explicit delete the file orphans and storage stats lie.
-    if (compId) {
+    if (compId && !referencedElsewhere) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {
@@ -734,33 +756,63 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     await updateCurrentCompetition(session => setCandidateFlagPure(session, photoId, flag));
   }, [updateCurrentCompetition]);
 
-  const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: any) => {
+  const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     await updateCurrentCompetition(session => updateCandidateCanvasStatePure(session, photoId, canvasState));
   }, [updateCurrentCompetition]);
 
-  const clearAllCandidates = useCallback(async () => {
+  /**
+   * Targeted candidate deletion (PR #62 review CRIT-3, IMP-4). The cleanup
+   * dialog snapshots ids at open time and passes them here — adding more
+   * candidates between dialog-open and confirm doesn't sweep them away.
+   *
+   * Rethrows when any per-id OPFS deletion fails, so the dialog can keep
+   * itself open and surface the partial failure. The `removeCandidate`
+   * single-id path remains best-effort (warning + swallow) because it's
+   * invoked from per-click UI where a per-failure modal would be hostile.
+   */
+  const deleteCandidates = useCallback(async (photoIds: string[]) => {
+    if (photoIds.length === 0) return;
     const compId = currentCompetition?.id;
-    // Snapshot ids BEFORE the state mutation so we still know which OPFS files
-    // to free after the pure helper empties the pool (PR #62 review C3).
-    const idsToDelete = (currentCompetition?.session.candidates?.photos ?? []).map(p => p.id);
+    const idsSet = new Set(photoIds);
+    // Filter to ids that are STILL in the candidate pool — protects against
+    // a race where a candidate was promoted to a slot between dialog-snapshot
+    // and confirm. `isPhotoReferencedInSession` would catch this AFTER the
+    // mutation too, but it's clearer to gate up front.
+    const presentIds = (currentCompetition?.session.candidates?.photos ?? [])
+      .filter(p => idsSet.has(p.id))
+      .map(p => p.id);
+    if (presentIds.length === 0) return;
+    let safeIds: string[] = [];
     await updateCurrentCompetition(session => {
-      for (const p of session.candidates?.photos ?? []) {
-        if (typeof p.url === 'string' && p.url.startsWith('blob:')) {
-          try { URL.revokeObjectURL(p.url); } catch (err) {
-            console.warn(`clearAllCandidates: revoke failed for ${p.id}:`, err);
+      let next = session;
+      for (const id of presentIds) {
+        const target = next.candidates?.photos?.find(p => p.id === id);
+        if (typeof target?.url === 'string' && target.url.startsWith('blob:')) {
+          try { URL.revokeObjectURL(target.url); } catch (err) {
+            console.warn(`deleteCandidates: revoke failed for ${id}:`, err);
           }
         }
+        next = removeCandidatePure(next, id);
       }
-      return clearAllCandidatesPure(session);
+      // Only delete the OPFS files that no other container references —
+      // protects against a promotion racing the delete (PR #62 review IMP-2).
+      safeIds = presentIds.filter(id => !isPhotoReferencedInSession(next, id));
+      return next;
     }, { updatePhotos: true });
-    if (compId && idsToDelete.length > 0) {
-      try {
-        await competitionService.deletePhotosByIds(compId, idsToDelete);
-      } catch (err) {
-        console.warn('clearAllCandidates: deletePhotosByIds failed:', err);
+    if (compId && safeIds.length > 0) {
+      const { failed } = await competitionService.deletePhotosByIds(compId, safeIds);
+      if (failed.length > 0) {
+        throw new Error(
+          t('errors.candidateDeletePartialFailure', { failed: failed.length, total: safeIds.length })
+        );
       }
     }
-  }, [updateCurrentCompetition, currentCompetition]);
+  }, [updateCurrentCompetition, currentCompetition, t]);
+
+  const clearAllCandidates = useCallback(async () => {
+    const ids = (currentCompetition?.session.candidates?.photos ?? []).map(p => p.id);
+    await deleteCandidates(ids);
+  }, [deleteCandidates, currentCompetition]);
 
   const reorderPhotos = useCallback(async (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => {
     await updateCurrentCompetition(session => {
@@ -873,7 +925,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     });
   }, [currentCompetition, updateCurrentCompetition]);
 
-  const updatePhotoState = useCallback(async (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => {
+  const updatePhotoState = useCallback(async (setKey: 'set1' | 'set2', photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     await updateCurrentCompetition(session => {
       // Ensure sets structure is valid
       const ensuredSets = {
@@ -1169,15 +1221,16 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // 10) and set2 (remainder). Per-set capacity is 10 in BOTH orientations
     // (feedback 2026-05-03 — landscape auto-expands from 3×3 to 5×2 at 10).
     // Without this, a 10+ photo drop overflowed set1 invisibly.
-    addPhotosToTurningPoint: (async (files: File[]) => {
+    addPhotosToTurningPoint: async (files: File[]): Promise<AddPhotosResult> => {
       const session = currentCompetition?.session;
       if (!session) {
         // Asymmetric with the overflow branch below, which surfaces via
         // `setError`. Silently dropping 10–18 files because the session is
         // transiently null (initial load, switch-competition in flight) is
         // the exact silent-failure pattern this PR set out to eliminate.
-        setError('No active competition. Create or select one before adding photos.');
-        return;
+        const message = 'No active competition. Create or select one before adding photos.';
+        setError(message);
+        return { kind: 'err', reason: 'no-competition', message };
       }
       const layoutMode = (session as any).layoutMode === 'portrait' ? 'portrait' : 'landscape';
       const set1Count = session.sets?.set1?.photos?.length ?? 0;
@@ -1190,12 +1243,12 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         // surface the toast (PR #62 review I1: previously this was silent
         // and felt like the photos "vanished").
         await addPhotosToCandidates(files);
-        return { routedTo: 'tray' as const, count: files.length };
+        return { kind: 'ok', routedTo: 'tray', count: files.length };
       }
       if (result.toSet1.length) await addPhotosToSet(result.toSet1, 'set1');
       if (result.toSet2.length) await addPhotosToSet(result.toSet2, 'set2');
-      return { routedTo: 'slot' as const, count: result.toSet1.length + result.toSet2.length };
-    }) as any,
+      return { kind: 'ok', routedTo: 'slot', count: result.toSet1.length + result.toSet2.length };
+    },
     refreshSession: (async () => {}) as any,
     applySettingToAll,
     applyLabelPositionToAll,
@@ -1207,6 +1260,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     demoteSlotToCandidate,
     setCandidateFlag,
     updateCandidatePhotoState,
+    deleteCandidates,
     clearAllCandidates,
     
     // Cleanup & storage

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -55,7 +55,7 @@ export interface UseCompetitionSystemResult {
   // Session operations (proxied to current competition)
   session: ApiPhotoSession | null;
   sessionId: string | null;
-  addPhotosToSet: (files: File[], setKey: 'set1' | 'set2') => Promise<void>;
+  addPhotosToSet: (files: File[], setKey: 'set1' | 'set2') => Promise<{ routedTo: 'slot' | 'tray'; count: number } | void>;
   removePhoto: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
   updatePhotoState: (setKey: 'set1' | 'set2', photoId: string, canvasState: any) => Promise<void>;
   updateSetTitle: (setKey: 'set1' | 'set2', title: string) => Promise<void>;
@@ -549,23 +549,21 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     }
 
     // Smart-drop routing: if the batch fits the remaining slot capacity, fill
-    // slots (today's behaviour). Otherwise route the WHOLE batch into the
-    // candidate pool — never silently split between slots and pool. See
-    // `routeDrop` + docs/CANDIDATE_PHOTOS.md "Smart drop heuristic".
+    // slots. Otherwise route the WHOLE batch into the candidate pool — never
+    // silently split. See `routeDrop` + docs/CANDIDATE_PHOTOS.md.
     //
-    // Precision-track has a special-case capacity of 10 in BOTH layouts
-    // because dropping the 10th photo in landscape flips the layout to
-    // portrait (effect in AppApi). `getGridCapacity` returns 9 for
-    // track+landscape since it doesn't know about discipline; we bump it
-    // here so a 10th drop fills the slot instead of routing to candidates.
+    // Capacity strictly follows `getGridCapacity` (= layoutMode). First
+    // dev-test feedback 2026-05-12 removed the precision-track 9→10
+    // auto-layout-flip; without that, bumping capacity to 10 in landscape
+    // would route a 10th drop into a hidden 10th slot. Layout choice is
+    // now fully manual.
     const sess = currentCompetition.session as any;
-    const isPrecisionTrack = isPrecisionDiscipline && sess.mode === 'track';
-    const slotCapacity = isPrecisionTrack ? 10 : getGridCapacity(sess);
+    const slotCapacity = getGridCapacity(sess);
     const currentSlotCount = sess.sets?.[setKey]?.photos?.length ?? 0;
     const route = routeDrop({ files, currentSlotCount, slotCapacity });
     if (route.kind === 'tray') {
       await addPhotosToCandidates(route.files);
-      return;
+      return { routedTo: 'tray' as const, count: route.files.length };
     }
 
     await updateCurrentCompetition(session => {
@@ -601,6 +599,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       };
     }, { updatePhotos: true });
+    return { routedTo: 'slot' as const, count: route.files.length };
   }, [updateCurrentCompetition, currentCompetition, t, filesToPhotos, addPhotosToCandidates]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -560,6 +560,15 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     const sess = currentCompetition.session as any;
     const slotCapacity = getGridCapacity(sess);
     const currentSlotCount = sess.sets?.[setKey]?.photos?.length ?? 0;
+    // Mirror the over-cap guard from usePhotoSessionOPFS (PR #62 review I2):
+    // a legacy session or a layout switch can leave a set already over the
+    // current cap. Without this check the smart-drop routes everything to
+    // tray anyway (remaining = 0), but surfacing the corruption explicitly
+    // lets the user know to clean up.
+    if (currentSlotCount > slotCapacity) {
+      setError(`This set already has ${currentSlotCount} photos but the cap is now ${slotCapacity}. Please reload the competition or remove photos before adding more.`);
+      return;
+    }
     const route = routeDrop({ files, currentSlotCount, slotCapacity });
     if (route.kind === 'tray') {
       await addPhotosToCandidates(route.files);
@@ -603,19 +612,35 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   }, [updateCurrentCompetition, currentCompetition, t, filesToPhotos, addPhotosToCandidates]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {
+    const compId = currentCompetition?.id;
+    // Only schedule the OPFS delete if the id is NOT referenced from the other
+    // mode bucket — `saveSessionPhotos` shares the photos/ dir across buckets,
+    // so deleting a file still listed in `setsTrack`/`setsTurning` would break
+    // the inactive mode (PR #62 review C3).
+    const isReferencedElsewhere = (() => {
+      const s = currentCompetition?.session as any;
+      if (!s) return true;
+      const buckets = [s.setsTrack, s.setsTurning];
+      for (const b of buckets) {
+        if (b?.set1?.photos?.some?.((p: any) => p.id === photoId)) return true;
+        if (b?.set2?.photos?.some?.((p: any) => p.id === photoId)) return true;
+      }
+      if (s.candidates?.photos?.some?.((p: any) => p.id === photoId)) return true;
+      const otherKey = setKey === 'set1' ? 'set2' : 'set1';
+      if (s.sets?.[otherKey]?.photos?.some?.((p: any) => p.id === photoId)) return true;
+      return false;
+    })();
     await updateCurrentCompetition(session => {
-      // Ensure sets structure is valid
       const ensuredSets = {
         set1: session.sets?.set1 || { title: '', photos: [] },
         set2: session.sets?.set2 || { title: '', photos: [] }
       };
-      // Revoke blob URL of the photo being removed (if any) before dropping it
-      try {
-        const photoToRemove = (ensuredSets as any)[setKey]?.photos?.find((p: any) => p.id === photoId);
-        if (photoToRemove && typeof photoToRemove.url === 'string' && photoToRemove.url.startsWith('blob:')) {
-          URL.revokeObjectURL(photoToRemove.url);
+      const photoToRemove = (ensuredSets as any)[setKey]?.photos?.find((p: any) => p.id === photoId);
+      if (photoToRemove && typeof photoToRemove.url === 'string' && photoToRemove.url.startsWith('blob:')) {
+        try { URL.revokeObjectURL(photoToRemove.url); } catch (err) {
+          console.warn(`removePhoto: revoke failed for ${photoId}:`, err);
         }
-      } catch {}
+      }
 
       return {
         ...session,
@@ -630,7 +655,14 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       };
     }, { updatePhotos: true });
-  }, [updateCurrentCompetition]);
+    if (compId && !isReferencedElsewhere) {
+      try {
+        await competitionService.deletePhotosByIds(compId, [photoId]);
+      } catch (err) {
+        console.warn('removePhoto: deletePhotosByIds failed:', err);
+      }
+    }
+  }, [updateCurrentCompetition, currentCompetition]);
 
   // ── Candidate pool operations ─────────────────────────────────────────────
   // All transitions delegate to the pure helpers in `candidateTransitions.ts`
@@ -638,14 +670,26 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   // hook implementations. See docs/CANDIDATE_PHOTOS.md.
 
   const removeCandidate = useCallback(async (photoId: string) => {
+    const compId = currentCompetition?.id;
     await updateCurrentCompetition(session => {
-      try {
-        const target = session.candidates?.photos?.find(p => p.id === photoId);
-        if (target?.url?.startsWith?.('blob:')) URL.revokeObjectURL(target.url);
-      } catch {}
+      const target = session.candidates?.photos?.find(p => p.id === photoId);
+      if (typeof target?.url === 'string' && target.url.startsWith('blob:')) {
+        try { URL.revokeObjectURL(target.url); } catch (err) {
+          console.warn(`removeCandidate: revoke failed for ${photoId}:`, err);
+        }
+      }
       return removeCandidatePure(session, photoId);
     }, { updatePhotos: true });
-  }, [updateCurrentCompetition]);
+    // Free the OPFS file (PR #62 review C3). `saveSessionPhotos` never prunes,
+    // so without an explicit delete the file orphans and storage stats lie.
+    if (compId) {
+      try {
+        await competitionService.deletePhotosByIds(compId, [photoId]);
+      } catch (err) {
+        console.warn('removeCandidate: deletePhotosByIds failed:', err);
+      }
+    }
+  }, [updateCurrentCompetition, currentCompetition]);
 
   const promoteCandidateToSlot = useCallback(async (
     candidateId: string,
@@ -653,7 +697,24 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     slotIndex: number,
   ) => {
     await updateCurrentCompetition(session => {
-      return promoteCandidateToSlotPure(session, candidateId, setKey, slotIndex);
+      // Capacity gate: the pure helper trusts the caller, but `handleSendCandidateToSet`
+      // passes `slotIndex = photos.length` which would silently APPEND past capacity
+      // when the set is full (PR #62 review C1, contract violation vs.
+      // docs/CANDIDATE_PHOTOS.md swap-on-full row). Clamp out-of-range indices to
+      // `capacity - 1` so the helper's swap branch fires instead.
+      const capacity = getGridCapacity(session as any);
+      const slotCount = session.sets[setKey].photos.length;
+      const safeIndex = slotIndex >= capacity
+        ? Math.max(0, capacity - 1)
+        : slotIndex < 0
+          ? 0
+          : slotIndex;
+      // Mirror the slot mutation into the active mode bucket so a subsequent
+      // mode switch doesn't resurrect pre-promotion state from the bucket.
+      const next = promoteCandidateToSlotPure(session, candidateId, setKey, safeIndex);
+      const modeKey = session.mode === 'track' ? 'setsTrack' : 'setsTurning';
+      (next as any)[modeKey] = next.sets;
+      return next;
     }, { updatePhotos: true });
   }, [updateCurrentCompetition]);
 
@@ -662,7 +723,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     photoId: string,
   ) => {
     await updateCurrentCompetition(session => {
-      return demoteSlotToCandidatePure(session, setKey, photoId, 'pick');
+      const next = demoteSlotToCandidatePure(session, setKey, photoId, 'pick');
+      const modeKey = session.mode === 'track' ? 'setsTrack' : 'setsTurning';
+      (next as any)[modeKey] = next.sets;
+      return next;
     }, { updatePhotos: true });
   }, [updateCurrentCompetition]);
 
@@ -675,16 +739,28 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   }, [updateCurrentCompetition]);
 
   const clearAllCandidates = useCallback(async () => {
+    const compId = currentCompetition?.id;
+    // Snapshot ids BEFORE the state mutation so we still know which OPFS files
+    // to free after the pure helper empties the pool (PR #62 review C3).
+    const idsToDelete = (currentCompetition?.session.candidates?.photos ?? []).map(p => p.id);
     await updateCurrentCompetition(session => {
-      // Revoke blob URLs of every removed candidate so we don't leak.
-      try {
-        for (const p of session.candidates?.photos ?? []) {
-          if (p.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url);
+      for (const p of session.candidates?.photos ?? []) {
+        if (typeof p.url === 'string' && p.url.startsWith('blob:')) {
+          try { URL.revokeObjectURL(p.url); } catch (err) {
+            console.warn(`clearAllCandidates: revoke failed for ${p.id}:`, err);
+          }
         }
-      } catch {}
+      }
       return clearAllCandidatesPure(session);
     }, { updatePhotos: true });
-  }, [updateCurrentCompetition]);
+    if (compId && idsToDelete.length > 0) {
+      try {
+        await competitionService.deletePhotosByIds(compId, idsToDelete);
+      } catch (err) {
+        console.warn('clearAllCandidates: deletePhotosByIds failed:', err);
+      }
+    }
+  }, [updateCurrentCompetition, currentCompetition]);
 
   const reorderPhotos = useCallback(async (setKey: 'set1' | 'set2', fromIndex: number, toIndex: number) => {
     await updateCurrentCompetition(session => {
@@ -1109,13 +1185,16 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       const result = distributeRallyDrop({ files, layoutMode, set1Count, set2Count });
       if (!result.ok) {
         // Smart-drop at total-capacity level: rather than erroring on a
-        // 25-photo drop into a 20-cap rally turning-point session, route
-        // the whole batch to candidates so the user can cull from there.
+        // 25-photo drop into a 20-cap rally turning-point session, route the
+        // whole batch to candidates. Return `routedTo: 'tray'` so AppApi can
+        // surface the toast (PR #62 review I1: previously this was silent
+        // and felt like the photos "vanished").
         await addPhotosToCandidates(files);
-        return;
+        return { routedTo: 'tray' as const, count: files.length };
       }
       if (result.toSet1.length) await addPhotosToSet(result.toSet1, 'set1');
       if (result.toSet2.length) await addPhotosToSet(result.toSet2, 'set2');
+      return { routedTo: 'slot' as const, count: result.toSet1.length + result.toSet2.length };
     }) as any,
     refreshSession: (async () => {}) as any,
     applySettingToAll,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -10,7 +10,7 @@ import type {
   CleanupSuggestion,
   StorageStats 
 } from '../types/competition';
-import type { ApiPhotoSession } from '../types/api';
+import type { ApiPhotoSession, ApiPhoto, CandidateFlag } from '../types/api';
 import { competitionService } from '../services/competitionService';
 import { migrationService } from '../services/migrationService';
 import { useI18n } from '../contexts/I18nContext';
@@ -18,6 +18,15 @@ import { applyLabelPositionToAllInSession, applySettingToAllInSession, type Canv
 import { distributeRallyDrop } from '../utils/distributeRallyDrop';
 import { getGridCapacity } from '../utils/getGridCapacity';
 import { parseDiscipline } from '../utils/parseDiscipline';
+import { routeDrop } from '../utils/smartDropRoute';
+import {
+  promoteCandidateToSlot as promoteCandidateToSlotPure,
+  demoteSlotToCandidate as demoteSlotToCandidatePure,
+  setCandidateFlag as setCandidateFlagPure,
+  removeCandidate as removeCandidatePure,
+  clearAllCandidates as clearAllCandidatesPure,
+  updateCandidateCanvasState as updateCandidateCanvasStatePure,
+} from '../utils/candidateTransitions';
 import {
   defaultTrackSetTitles,
   DEFAULT_TRACK_SET1_TITLE_RALLY,
@@ -54,6 +63,15 @@ export interface UseCompetitionSystemResult {
   updateSessionMode: (mode: 'track' | 'turningpoint') => Promise<void>;
   updateLayoutMode: (layoutMode: 'landscape' | 'portrait') => Promise<void>;
   updateSessionCompetitionName: (competitionName: string) => Promise<void>;
+
+  // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
+  addPhotosToCandidates: (files: File[]) => Promise<void>;
+  removeCandidate: (photoId: string) => Promise<void>;
+  promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
+  demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
+  setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void>;
+  updateCandidatePhotoState: (photoId: string, canvasState: any) => Promise<void>;
+  clearAllCandidates: () => Promise<void>;
   
   // Cleanup & storage
   cleanupCandidates: CleanupCandidate[];
@@ -262,6 +280,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           revokeInSet(s.sets);
           revokeInSet(s.setsTrack);
           revokeInSet(s.setsTurning);
+          // Candidate pool URLs are independent of mode buckets — revoke
+          // them on competition transitions too, otherwise we leak one URL
+          // per candidate per switch.
+          try { s.candidates?.photos?.forEach((p: any) => { if (p?.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url); }); } catch {}
         }
       } catch {}
 
@@ -317,6 +339,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           revokeInSet(s.sets);
           revokeInSet(s.setsTrack);
           revokeInSet(s.setsTurning);
+          // Candidate pool URLs are independent of mode buckets — revoke
+          // them on competition transitions too, otherwise we leak one URL
+          // per candidate per switch.
+          try { s.candidates?.photos?.forEach((p: any) => { if (p?.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url); }); } catch {}
         }
       } catch {}
 
@@ -351,6 +377,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           revokeInSet(s.sets);
           revokeInSet(s.setsTrack);
           revokeInSet(s.setsTurning);
+          // Candidate pool URLs are independent of mode buckets — revoke
+          // them on competition transitions too, otherwise we leak one URL
+          // per candidate per switch.
+          try { s.candidates?.photos?.forEach((p: any) => { if (p?.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url); }); } catch {}
         }
       } catch {}
 
@@ -414,12 +444,19 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         ? updatedSession.competition_name.trim()
         : currentCompetition.name;
       
-      // Detect if photos have actually changed (not just metadata)
-      const photosChanged = options?.updatePhotos || 
+      // Detect if photos have actually changed (not just metadata). Includes
+      // the candidate pool so promoting/demoting/adding to the tray triggers
+      // a write — `competitionService.saveSessionPhotos` walks candidates
+      // alongside slots, so the persistence path is symmetric.
+      const origCandIds = (originalSession.candidates?.photos ?? []).map(p => p.id);
+      const nextCandIds = (updatedSession.candidates?.photos ?? []).map(p => p.id);
+      const photosChanged = options?.updatePhotos ||
         originalSession.sets.set1.photos.length !== updatedSession.sets.set1.photos.length ||
         originalSession.sets.set2.photos.length !== updatedSession.sets.set2.photos.length ||
         JSON.stringify(originalSession.sets.set1.photos.map(p => p.id)) !== JSON.stringify(updatedSession.sets.set1.photos.map(p => p.id)) ||
-        JSON.stringify(originalSession.sets.set2.photos.map(p => p.id)) !== JSON.stringify(updatedSession.sets.set2.photos.map(p => p.id));
+        JSON.stringify(originalSession.sets.set2.photos.map(p => p.id)) !== JSON.stringify(updatedSession.sets.set2.photos.map(p => p.id)) ||
+        origCandIds.length !== nextCandIds.length ||
+        JSON.stringify(origCandIds) !== JSON.stringify(nextCandIds);
       
       const updatedCompetition: Competition = {
         ...currentCompetition,
@@ -453,6 +490,57 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     }
   }, [currentCompetition, refreshCompetitions]);
 
+  /**
+   * Build a fresh ApiPhoto from a File. Shared by slot-add and candidate-add
+   * paths so the canvasState/blob-URL/id construction stays in one place.
+   * `flag` is only set on the candidate path.
+   */
+  const filesToPhotos = useCallback((files: File[], sessionIdLocal: string, flag?: CandidateFlag): ApiPhoto[] => {
+    return files.map((file) => ({
+      id: (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+        ? (crypto as any).randomUUID()
+        : `photo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      sessionId: sessionIdLocal,
+      url: URL.createObjectURL(file),
+      filename: file.name,
+      canvasState: {
+        position: { x: 0, y: 0 },
+        scale: 1,
+        brightness: 0,
+        contrast: 1,
+        sharpness: 0,
+        whiteBalance: { temperature: 0, tint: 0, auto: false },
+        labelPosition: 'bottom-left' as const,
+      },
+      label: '',
+      ...(flag !== undefined ? { flag } : {}),
+    }));
+  }, []);
+
+  /**
+   * Append files into the candidate pool. Used directly by the tray dropzone
+   * and indirectly by `addPhotosToSet` via the smart-drop heuristic when a
+   * slot batch exceeds remaining capacity. New candidates start as `neutral`.
+   */
+  const addPhotosToCandidates = useCallback(async (files: File[]) => {
+    if (!currentCompetition?.session) {
+      setError(t('errors.noActiveCompetition'));
+      return;
+    }
+    if (files.length === 0) return;
+    await updateCurrentCompetition(session => {
+      const sessionId = session.id;
+      const newPhotos = filesToPhotos(files, sessionId, 'neutral');
+      const existing = session.candidates?.photos ?? [];
+      return {
+        ...session,
+        version: session.version + 1,
+        updatedAt: new Date().toISOString(),
+        candidates: { photos: [...existing, ...newPhotos] },
+      };
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition, currentCompetition, filesToPhotos, t]);
+
   const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2') => {
     if (!currentCompetition?.session) {
       console.error('No current competition or session available');
@@ -460,25 +548,24 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       return;
     }
 
-    // Defensive capacity ceiling — without this, dropping more files than
-    // the grid can render silently appends them past the last slot and the
-    // user sees a "missing photo" (feedback 2026-04-23 retest of Rally TP).
-    // 10 is the absolute max per set across every (layout × discipline)
-    // combination — using it as the floor lets layout-switch logic in
-    // AppApi do its thing for Precision-track 10-photo drops while still
-    // catching genuine overflow.
-    {
-      const sess = currentCompetition.session as any;
-      const ABSOLUTE_MAX = 10;
-      const current = sess.sets?.[setKey]?.photos?.length ?? 0;
-      if (current + files.length > ABSOLUTE_MAX) {
-        const allowed = Math.max(0, ABSOLUTE_MAX - current);
-        const setLabel = setKey === 'set1' ? '1' : '2';
-        setError(allowed === 0
-          ? t('errors.photoSetFull', { set: setLabel })
-          : t('errors.photoSetCapacityRemaining', { set: setLabel, count: allowed }));
-        return;
-      }
+    // Smart-drop routing: if the batch fits the remaining slot capacity, fill
+    // slots (today's behaviour). Otherwise route the WHOLE batch into the
+    // candidate pool — never silently split between slots and pool. See
+    // `routeDrop` + docs/CANDIDATE_PHOTOS.md "Smart drop heuristic".
+    //
+    // Precision-track has a special-case capacity of 10 in BOTH layouts
+    // because dropping the 10th photo in landscape flips the layout to
+    // portrait (effect in AppApi). `getGridCapacity` returns 9 for
+    // track+landscape since it doesn't know about discipline; we bump it
+    // here so a 10th drop fills the slot instead of routing to candidates.
+    const sess = currentCompetition.session as any;
+    const isPrecisionTrack = isPrecisionDiscipline && sess.mode === 'track';
+    const slotCapacity = isPrecisionTrack ? 10 : getGridCapacity(sess);
+    const currentSlotCount = sess.sets?.[setKey]?.photos?.length ?? 0;
+    const route = routeDrop({ files, currentSlotCount, slotCapacity });
+    if (route.kind === 'tray') {
+      await addPhotosToCandidates(route.files);
+      return;
     }
 
     await updateCurrentCompetition(session => {
@@ -499,26 +586,8 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         throw new Error(`Invalid setKey: ${setKey}`);
       }
 
-      // Convert files to photos (simplified - you'd use proper photo creation logic)
-      const newPhotos = files.map((file) => ({
-        id: (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-          ? (crypto as any).randomUUID()
-          : `photo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        sessionId: session.id,
-        url: URL.createObjectURL(file),
-        filename: file.name,
-        canvasState: {
-          position: { x: 0, y: 0 },
-          scale: 1,
-          brightness: 0,
-          contrast: 1,
-          sharpness: 0,
-          whiteBalance: { temperature: 0, tint: 0, auto: false },
-          labelPosition: 'bottom-left' as const
-        },
-        label: ''
-      }));
-      
+      const newPhotos = filesToPhotos(route.files, session.id);
+
       return {
         ...session,
         version: session.version + 1,
@@ -532,7 +601,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         }
       };
     }, { updatePhotos: true });
-  }, [updateCurrentCompetition, currentCompetition, t]);
+  }, [updateCurrentCompetition, currentCompetition, t, filesToPhotos, addPhotosToCandidates]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {
     await updateCurrentCompetition(session => {
@@ -548,7 +617,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           URL.revokeObjectURL(photoToRemove.url);
         }
       } catch {}
-      
+
       return {
         ...session,
         version: session.version + 1,
@@ -561,6 +630,60 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           }
         }
       };
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition]);
+
+  // ── Candidate pool operations ─────────────────────────────────────────────
+  // All transitions delegate to the pure helpers in `candidateTransitions.ts`
+  // so the branching logic is unit-testable and identical across the two
+  // hook implementations. See docs/CANDIDATE_PHOTOS.md.
+
+  const removeCandidate = useCallback(async (photoId: string) => {
+    await updateCurrentCompetition(session => {
+      try {
+        const target = session.candidates?.photos?.find(p => p.id === photoId);
+        if (target?.url?.startsWith?.('blob:')) URL.revokeObjectURL(target.url);
+      } catch {}
+      return removeCandidatePure(session, photoId);
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition]);
+
+  const promoteCandidateToSlot = useCallback(async (
+    candidateId: string,
+    setKey: 'set1' | 'set2',
+    slotIndex: number,
+  ) => {
+    await updateCurrentCompetition(session => {
+      return promoteCandidateToSlotPure(session, candidateId, setKey, slotIndex);
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition]);
+
+  const demoteSlotToCandidate = useCallback(async (
+    setKey: 'set1' | 'set2',
+    photoId: string,
+  ) => {
+    await updateCurrentCompetition(session => {
+      return demoteSlotToCandidatePure(session, setKey, photoId, 'pick');
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition]);
+
+  const setCandidateFlag = useCallback(async (photoId: string, flag: CandidateFlag) => {
+    await updateCurrentCompetition(session => setCandidateFlagPure(session, photoId, flag));
+  }, [updateCurrentCompetition]);
+
+  const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: any) => {
+    await updateCurrentCompetition(session => updateCandidateCanvasStatePure(session, photoId, canvasState));
+  }, [updateCurrentCompetition]);
+
+  const clearAllCandidates = useCallback(async () => {
+    await updateCurrentCompetition(session => {
+      // Revoke blob URLs of every removed candidate so we don't leak.
+      try {
+        for (const p of session.candidates?.photos ?? []) {
+          if (p.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url);
+        }
+      } catch {}
+      return clearAllCandidatesPure(session);
     }, { updatePhotos: true });
   }, [updateCurrentCompetition]);
 
@@ -986,7 +1109,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       const set2Count = session.sets?.set2?.photos?.length ?? 0;
       const result = distributeRallyDrop({ files, layoutMode, set1Count, set2Count });
       if (!result.ok) {
-        setError(`Cannot add ${files.length} photos. Maximum ${result.maxTotal} photos allowed (${set1Count + set2Count} already added).`);
+        // Smart-drop at total-capacity level: rather than erroring on a
+        // 25-photo drop into a 20-cap rally turning-point session, route
+        // the whole batch to candidates so the user can cull from there.
+        await addPhotosToCandidates(files);
         return;
       }
       if (result.toSet1.length) await addPhotosToSet(result.toSet1, 'set1');
@@ -995,6 +1121,15 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     refreshSession: (async () => {}) as any,
     applySettingToAll,
     applyLabelPositionToAll,
+
+    // Candidate pool surface
+    addPhotosToCandidates,
+    removeCandidate,
+    promoteCandidateToSlot,
+    demoteSlotToCandidate,
+    setCandidateFlag,
+    updateCandidatePhotoState,
+    clearAllCandidates,
     
     // Cleanup & storage
     cleanupCandidates,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -79,8 +79,14 @@ export interface UseCompetitionSystemResult {
    * (e.g. the post-export cleanup dialog) can keep their UI open and surface
    * the failure. Snapshot-id targeted variant of `clearAllCandidates`
    * (PR #62 review CRIT-3, IMP-4).
+   *
+   * Returns `{ deleted, skipped }` so callers can distinguish a real cleanup
+   * from snapshot-drift: when every snapshot id was promoted to a slot
+   * between dialog-open and confirm, `deleted === 0 && skipped === N` and
+   * the dialog should tell the user instead of claiming success silently
+   * (PR #62 review I6).
    */
-  deleteCandidates: (photoIds: string[]) => Promise<void>;
+  deleteCandidates: (photoIds: string[]) => Promise<{ deleted: number; skipped: number }>;
   clearAllCandidates: () => Promise<void>;
   
   // Cleanup & storage
@@ -577,7 +583,9 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // tray anyway (remaining = 0), but surfacing the corruption explicitly
     // lets the user know to clean up.
     if (currentSlotCount > slotCapacity) {
-      const message = `This set already has ${currentSlotCount} photos but the cap is now ${slotCapacity}. Please reload the competition or remove photos before adding more.`;
+      // PR #62 review I2: localised; was hardcoded English even after the
+      // IMP-5 cleanup-dialog fix, so Czech UI users hit an English banner.
+      const message = t('errors.setOverCapacity', { current: currentSlotCount, cap: slotCapacity });
       setError(message);
       return { kind: 'err', reason: 'over-capacity', message };
     }
@@ -770,8 +778,8 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
    * single-id path remains best-effort (warning + swallow) because it's
    * invoked from per-click UI where a per-failure modal would be hostile.
    */
-  const deleteCandidates = useCallback(async (photoIds: string[]) => {
-    if (photoIds.length === 0) return;
+  const deleteCandidates = useCallback(async (photoIds: string[]): Promise<{ deleted: number; skipped: number }> => {
+    if (photoIds.length === 0) return { deleted: 0, skipped: 0 };
     const compId = currentCompetition?.id;
     const idsSet = new Set(photoIds);
     // Filter to ids that are STILL in the candidate pool — protects against
@@ -781,7 +789,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     const presentIds = (currentCompetition?.session.candidates?.photos ?? [])
       .filter(p => idsSet.has(p.id))
       .map(p => p.id);
-    if (presentIds.length === 0) return;
+    // PR #62 review I6: `presentIds.length === 0` was previously a silent
+    // no-op — the cleanup dialog closed with no feedback even though 0 of
+    // N requested photos were deleted. Surface the snapshot-drift count.
+    if (presentIds.length === 0) return { deleted: 0, skipped: photoIds.length };
     let safeIds: string[] = [];
     await updateCurrentCompetition(session => {
       let next = session;
@@ -807,6 +818,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         );
       }
     }
+    return {
+      deleted: presentIds.length,
+      skipped: photoIds.length - presentIds.length,
+    };
   }, [updateCurrentCompetition, currentCompetition, t]);
 
   const clearAllCandidates = useCallback(async () => {
@@ -1228,7 +1243,8 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         // `setError`. Silently dropping 10–18 files because the session is
         // transiently null (initial load, switch-competition in flight) is
         // the exact silent-failure pattern this PR set out to eliminate.
-        const message = 'No active competition. Create or select one before adding photos.';
+        // PR #62 review I2: localised; was hardcoded English.
+        const message = t('errors.noActiveCompetition');
         setError(message);
         return { kind: 'err', reason: 'no-competition', message };
       }
@@ -1245,9 +1261,23 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         await addPhotosToCandidates(files);
         return { kind: 'ok', routedTo: 'tray', count: files.length };
       }
-      if (result.toSet1.length) await addPhotosToSet(result.toSet1, 'set1');
-      if (result.toSet2.length) await addPhotosToSet(result.toSet2, 'set2');
-      return { kind: 'ok', routedTo: 'slot', count: result.toSet1.length + result.toSet2.length };
+      // Inspect inner results so we don't claim `routedTo: 'slot', count: N`
+      // when an inner `addPhotosToSet` actually hit its over-capacity guard
+      // (PR #62 review I1). Previously the discarded inner err meant the
+      // outer caller's smart-drop toast never fired and the user had no
+      // map back from "set1 failed silently, set2 took 8 of 18".
+      const r1 = result.toSet1.length ? await addPhotosToSet(result.toSet1, 'set1') : null;
+      const r2 = result.toSet2.length ? await addPhotosToSet(result.toSet2, 'set2') : null;
+      if (r1?.kind === 'err') return r1;
+      if (r2?.kind === 'err') return r2;
+      const added = (r1?.kind === 'ok' ? r1.count : 0) + (r2?.kind === 'ok' ? r2.count : 0);
+      const r1Tray = r1?.kind === 'ok' && r1.routedTo === 'tray';
+      const r2Tray = r2?.kind === 'ok' && r2.routedTo === 'tray';
+      // If either half overflowed into the tray, the outer caller needs to
+      // know so it can surface the smart-drop toast. Only report 'slot' when
+      // BOTH halves landed in slots.
+      const routedTo: 'slot' | 'tray' = r1Tray || r2Tray ? 'tray' : 'slot';
+      return { kind: 'ok', routedTo, count: added };
     },
     refreshSession: (async () => {}) as any,
     applySettingToAll,

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Photo } from '../types';
-import type { ApiPhoto, ApiPhotoSession } from '../types/api';
+import type { ApiPhoto, ApiPhotoSession, CandidateFlag } from '../types/api';
 import { applyLabelPositionToAllInSession, applySettingToAllInSession, type CanvasSetting, type LabelPosition } from '../utils/canvasStatePatch';
 import { deriveSet1FromSet2, deriveSet2FromSet1 } from '../utils/autoPrefillSetTitle';
 import { getGridCapacity, TURNING_POINT_PER_SET } from '../utils/getGridCapacity';
+import { routeDrop } from '../utils/smartDropRoute';
+import {
+  promoteCandidateToSlot as promoteCandidateToSlotPure,
+  demoteSlotToCandidate as demoteSlotToCandidatePure,
+  setCandidateFlag as setCandidateFlagPure,
+  removeCandidate as removeCandidatePure,
+  clearAllCandidates as clearAllCandidatesPure,
+  updateCandidateCanvasState as updateCandidateCanvasStatePure,
+} from '../utils/candidateTransitions';
 import {
   isStorageAvailable,
   initStorage,
@@ -202,6 +211,66 @@ export function usePhotoSessionOPFS() {
     }
   }, []);
 
+  // Build ApiPhoto from a File, including OPFS save when available. Shared
+  // between slot-add and candidate-add so the persistence semantics stay
+  // identical for both pools.
+  const buildPhotoFromFile = useCallback(async (file: File, flag?: CandidateFlag): Promise<ApiPhoto> => {
+    if (file.size > 20 * 1024 * 1024) throw new Error('Image file too large (max 20MB)');
+    const id = `photo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const photosDir = handlesRef.current.photosDir;
+    let url: string;
+    if (photosDir) {
+      const storage = getStorage();
+      await storage.savePhotoFile(photosDir, id, file);
+      url = await getPhotoURL(id);
+    } else {
+      url = URL.createObjectURL(file);
+      objectURLsRef.current.set(id, url);
+    }
+    return {
+      id,
+      sessionId: session?.id ?? '',
+      url,
+      filename: file.name,
+      canvasState: {
+        position: { x: 0, y: 0 },
+        scale: 1,
+        brightness: 0,
+        contrast: 1,
+        sharpness: 0,
+        whiteBalance: { temperature: 0, tint: 0, auto: false },
+        labelPosition: 'bottom-left',
+      },
+      label: '',
+      ...(flag !== undefined ? { flag } : {}),
+    };
+  }, [session, getPhotoURL]);
+
+  const addPhotosToCandidates = useCallback(async (files: File[]) => {
+    if (!session || files.length === 0) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const newPhotos: ApiPhoto[] = [];
+      for (const file of files) {
+        newPhotos.push(await buildPhotoFromFile(file, 'neutral'));
+      }
+      const existing = session.candidates?.photos ?? [];
+      const next: ApiPhotoSession = {
+        ...session,
+        version: session.version + 1,
+        updatedAt: new Date().toISOString(),
+        candidates: { photos: [...existing, ...newPhotos] },
+      };
+      await persistSession(next);
+      await updateStorageEstimate();
+    } catch (e: any) {
+      setError(e?.message || 'Failed to add candidate photos');
+    } finally {
+      setLoading(false);
+    }
+  }, [session, persistSession, buildPhotoFromFile]);
+
   const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2') => {
     if (!session) return;
     setLoading(true);
@@ -223,7 +292,14 @@ export function usePhotoSessionOPFS() {
       if (current > gridCapacity) {
         throw new Error(`This set already has ${current} photos but the cap is now ${gridCapacity}. Please reload the competition or remove photos before adding more.`);
       }
-      if (current + files.length > gridCapacity) throw new Error(`Can only add ${gridCapacity - current} more photos to this set`);
+      // Smart-drop: instead of erroring on overflow, route the WHOLE batch
+      // into the candidate pool. See docs/CANDIDATE_PHOTOS.md.
+      const route = routeDrop({ files, currentSlotCount: current, slotCapacity: gridCapacity });
+      if (route.kind === 'tray') {
+        setLoading(false);
+        await addPhotosToCandidates(files);
+        return;
+      }
 
       const photosDir = handlesRef.current.photosDir;
       const nowISO = new Date().toISOString();
@@ -292,7 +368,75 @@ export function usePhotoSessionOPFS() {
     } finally {
       setLoading(false);
     }
-  }, [session, persistSession, getPhotoURL]);
+  }, [session, persistSession, getPhotoURL, addPhotosToCandidates]);
+
+  // ── Candidate operations (legacy OPFS hook) ─────────────────────────────
+  // Delegates to the shared pure helpers so the contract stays identical to
+  // `useCompetitionSystem`. This hook isn't consumed today (kept around as a
+  // backup path), but mirroring keeps the interface symmetric — if it gets
+  // wired back in, candidate ops work out of the box.
+
+  const removeCandidate = useCallback(async (photoId: string) => {
+    if (!session) return;
+    try {
+      const target = session.candidates?.photos?.find(p => p.id === photoId);
+      if (target?.url?.startsWith?.('blob:')) URL.revokeObjectURL(target.url);
+      if (handlesRef.current.photosDir) {
+        const storage = getStorage();
+        try { await storage.deletePhotoFile(handlesRef.current.photosDir, photoId); } catch {}
+      }
+      objectURLsRef.current.delete(photoId);
+    } catch {}
+    await persistSession(removeCandidatePure(session, photoId));
+    await updateStorageEstimate();
+  }, [session, persistSession]);
+
+  const promoteCandidateToSlot = useCallback(async (
+    candidateId: string,
+    setKey: 'set1' | 'set2',
+    slotIndex: number,
+  ) => {
+    if (!session) return;
+    const next = promoteCandidateToSlotPure(session, candidateId, setKey, slotIndex);
+    (next as any)[session.mode === 'track' ? 'setsTrack' : 'setsTurning'] = next.sets;
+    await persistSession(next);
+  }, [session, persistSession]);
+
+  const demoteSlotToCandidate = useCallback(async (
+    setKey: 'set1' | 'set2',
+    photoId: string,
+  ) => {
+    if (!session) return;
+    const next = demoteSlotToCandidatePure(session, setKey, photoId, 'pick');
+    (next as any)[session.mode === 'track' ? 'setsTrack' : 'setsTurning'] = next.sets;
+    await persistSession(next);
+  }, [session, persistSession]);
+
+  const setCandidateFlagOp = useCallback(async (photoId: string, flag: CandidateFlag) => {
+    if (!session) return;
+    await persistSession(setCandidateFlagPure(session, photoId, flag));
+  }, [session, persistSession]);
+
+  const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: any) => {
+    if (!session) return;
+    await persistSession(updateCandidateCanvasStatePure(session, photoId, canvasState));
+  }, [session, persistSession]);
+
+  const clearAllCandidates = useCallback(async () => {
+    if (!session) return;
+    try {
+      for (const p of session.candidates?.photos ?? []) {
+        if (p.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url);
+        objectURLsRef.current.delete(p.id);
+        if (handlesRef.current.photosDir) {
+          const storage = getStorage();
+          try { await storage.deletePhotoFile(handlesRef.current.photosDir, p.id); } catch {}
+        }
+      }
+    } catch {}
+    await persistSession(clearAllCandidatesPure(session));
+    await updateStorageEstimate();
+  }, [session, persistSession]);
 
   const removePhoto = useCallback(async (setKey: 'set1' | 'set2', photoId: string) => {
     if (!session) return;
@@ -539,7 +683,9 @@ export function usePhotoSessionOPFS() {
       const set2Count = session.sets.set2.photos.length;
       const total = set1Count + set2Count;
       if (total + files.length > maxTotal) {
-        setError(`Cannot add ${files.length} photos. Maximum ${maxTotal} photos allowed (${total} already added).`);
+        // Smart-drop: instead of erroring, route the WHOLE batch into the
+        // candidate pool. Mirrors useCompetitionSystem's behaviour.
+        await addPhotosToCandidates(files);
         return;
       }
       const filesToSet1: File[] = [];
@@ -552,6 +698,14 @@ export function usePhotoSessionOPFS() {
     updatePhotoState,
     applySettingToAll,
     applyLabelPositionToAll,
+    // Candidate pool operations
+    addPhotosToCandidates,
+    removeCandidate,
+    promoteCandidateToSlot,
+    demoteSlotToCandidate,
+    setCandidateFlag: setCandidateFlagOp,
+    updateCandidatePhotoState,
+    clearAllCandidates,
     updateSetTitle,
     updateSetTitles,
     reorderPhotos,

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -379,15 +379,23 @@ export function usePhotoSessionOPFS() {
 
   const removeCandidate = useCallback(async (photoId: string) => {
     if (!session) return;
-    try {
-      const target = session.candidates?.photos?.find(p => p.id === photoId);
-      if (target?.url?.startsWith?.('blob:')) URL.revokeObjectURL(target.url);
-      if (handlesRef.current.photosDir) {
-        const storage = getStorage();
-        try { await storage.deletePhotoFile(handlesRef.current.photosDir, photoId); } catch {}
+    const target = session.candidates?.photos?.find(p => p.id === photoId);
+    if (target?.url?.startsWith?.('blob:')) {
+      try { URL.revokeObjectURL(target.url); } catch (err) {
+        console.warn(`removeCandidate: revoke failed for ${photoId}:`, err);
       }
-      objectURLsRef.current.delete(photoId);
-    } catch {}
+    }
+    if (handlesRef.current.photosDir) {
+      try {
+        const storage = getStorage();
+        await storage.deletePhotoFile(handlesRef.current.photosDir, photoId);
+      } catch (err) {
+        // Best-effort: orphan file is preferable to refusing the UX flow.
+        // Logged so devtools captures the failure (PR #62 review IMP-1).
+        console.warn(`removeCandidate: OPFS delete failed for ${photoId}:`, err);
+      }
+    }
+    objectURLsRef.current.delete(photoId);
     await persistSession(removeCandidatePure(session, photoId));
     await updateStorageEstimate();
   }, [session, persistSession]);
@@ -425,16 +433,25 @@ export function usePhotoSessionOPFS() {
 
   const clearAllCandidates = useCallback(async () => {
     if (!session) return;
-    try {
-      for (const p of session.candidates?.photos ?? []) {
-        if (p.url?.startsWith?.('blob:')) URL.revokeObjectURL(p.url);
-        objectURLsRef.current.delete(p.id);
-        if (handlesRef.current.photosDir) {
-          const storage = getStorage();
-          try { await storage.deletePhotoFile(handlesRef.current.photosDir, p.id); } catch {}
+    const storage = handlesRef.current.photosDir ? getStorage() : null;
+    for (const p of session.candidates?.photos ?? []) {
+      if (p.url?.startsWith?.('blob:')) {
+        try { URL.revokeObjectURL(p.url); } catch (err) {
+          console.warn(`clearAllCandidates: revoke failed for ${p.id}:`, err);
         }
       }
-    } catch {}
+      objectURLsRef.current.delete(p.id);
+      if (storage && handlesRef.current.photosDir) {
+        try {
+          await storage.deletePhotoFile(handlesRef.current.photosDir, p.id);
+        } catch (err) {
+          // Logged but not rethrown — this hook is the legacy backup path;
+          // production runs the useCompetitionSystem variant which surfaces
+          // partial failures through `deleteCandidates` (PR #62 review IMP-1).
+          console.warn(`clearAllCandidates: OPFS delete failed for ${p.id}:`, err);
+        }
+      }
+    }
     await persistSession(clearAllCandidatesPure(session));
     await updateStorageEstimate();
   }, [session, persistSession]);

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -298,7 +298,7 @@ export function usePhotoSessionOPFS() {
       if (route.kind === 'tray') {
         setLoading(false);
         await addPhotosToCandidates(files);
-        return;
+        return { routedTo: 'tray' as const, count: route.files.length };
       }
 
       const photosDir = handlesRef.current.photosDir;
@@ -363,6 +363,7 @@ export function usePhotoSessionOPFS() {
       (next as any)[modeKey] = next.sets;
       await persistSession(next);
       await updateStorageEstimate();
+      return { routedTo: 'slot' as const, count: newPhotos.length };
     } catch (e: any) {
       setError(e?.message || 'Failed to add photos');
     } finally {

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -279,9 +279,12 @@
   },
   "candidates": {
     "title": "Kandidáti ({{count}})",
+    "poolLabel": "Zásobník kandidátů",
     "addMore": "Přidat další",
     "hideRejects": "Skrýt vyřazené",
-    "emptyHint": "Sem přetáhněte další fotografie, nebo klikněte pro výběr",
+    "emptyHint": "Sem přetáhněte další fotografie — kteroukoli pak přetáhněte do políčka, aby se dostala do tisku",
+    "dragHint": "Přetáhněte miniaturu na prázdné políčko, nebo použijte tlačítka pod každou fotografií.",
+    "smartDropToast": "Přidáno {{count}} fotografií do Kandidátů — přetáhněte kteroukoli do políčka, aby se dostala do tisku.",
     "allFiltered": "Všichni kandidáti jsou skryti filtrem.",
     "flag": {
       "pick": "Označit jako vybrané",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -277,6 +277,26 @@
     "selectNone": "Zrušit výběr",
     "createdOn": "Vytvořeno: {{date}}"
   },
+  "candidates": {
+    "title": "Kandidáti ({{count}})",
+    "addMore": "Přidat další",
+    "hideRejects": "Skrýt vyřazené",
+    "emptyHint": "Sem přetáhněte další fotografie, nebo klikněte pro výběr",
+    "allFiltered": "Všichni kandidáti jsou skryti filtrem.",
+    "flag": {
+      "pick": "Označit jako vybrané",
+      "neutral": "Zrušit označení",
+      "reject": "Označit jako vyřazené"
+    },
+    "sendToSet1": "Přesunout do sady 1",
+    "sendToSet2": "Přesunout do sady 2",
+    "cleanup": {
+      "title": "Smazat nepoužité kandidáty?",
+      "message": "Máte {{count}} kandidátských fotografií, které nejsou v žádné sadě. Smazat je a uvolnit přibližně {{size}} MB úložiště?",
+      "keep": "Ponechat kandidáty",
+      "delete": "Smazat {{count}} kandidátů"
+    }
+  },
   "pdf": {
     "promotional": {
       "line1": "vytvořeno přes",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -285,6 +285,7 @@
     "emptyHint": "Sem přetáhněte další fotografie — kteroukoli pak přetáhněte do políčka, aby se dostala do tisku",
     "dragHint": "Přetáhněte miniaturu na prázdné políčko, nebo použijte tlačítka pod každou fotografií.",
     "smartDropToast": "Přidáno {{count}} fotografií do Kandidátů — přetáhněte kteroukoli do políčka, aby se dostala do tisku.",
+    "crossSetHint": "Přesun mezi sadami jde přes Kandidáty. Přetáhněte fotografii nejprve sem a pak do druhé sady.",
     "allFiltered": "Všichni kandidáti jsou skryti filtrem.",
     "flag": {
       "pick": "Označit jako vybrané",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -262,6 +262,7 @@
     "noActiveCompetition": "Není zvolena žádná aktivní soutěž, do které by šlo přidat fotografie.",
     "photoSetFull": "Sada {{set}} je plná. Nejprve odeberte fotografii.",
     "photoSetCapacityRemaining": "Sada {{set}} přijme už jen {{count}} dalších fotografií.",
+    "setOverCapacity": "Sada už obsahuje {{current}} fotografií, ale aktuální limit je {{cap}}. Načtěte soutěž znovu nebo nejprve odeberte fotografie, než budete přidávat další.",
     "candidateDeletePartialFailure": "Nepodařilo se smazat {{failed}} z {{total}} kandidátských souborů. Mohou stále zabírat úložiště."
   },
   "common": {
@@ -300,7 +301,8 @@
       "message": "Máte {{count}} kandidátských fotografií, které nejsou v žádné sadě. Smazat je a uvolnit přibližně {{size}} MB úložiště?",
       "keep": "Ponechat kandidáty",
       "delete": "Smazat {{count}} kandidátů",
-      "error": "Smazání kandidátů selhalo. Některé soubory mohou stále zabírat úložiště."
+      "error": "Smazání kandidátů selhalo. Některé soubory mohou stále zabírat úložiště.",
+      "allPromoted": "Žádný z {{count}} kandidátů nebyl smazán — všechny byly před potvrzením přesunuty do sad."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -261,7 +261,8 @@
     "shuffleFailed": "Nepodařilo se zamíchat fotografie",
     "noActiveCompetition": "Není zvolena žádná aktivní soutěž, do které by šlo přidat fotografie.",
     "photoSetFull": "Sada {{set}} je plná. Nejprve odeberte fotografii.",
-    "photoSetCapacityRemaining": "Sada {{set}} přijme už jen {{count}} dalších fotografií."
+    "photoSetCapacityRemaining": "Sada {{set}} přijme už jen {{count}} dalších fotografií.",
+    "candidateDeletePartialFailure": "Nepodařilo se smazat {{failed}} z {{total}} kandidátských souborů. Mohou stále zabírat úložiště."
   },
   "common": {
     "loading": "Načítání...",
@@ -298,7 +299,8 @@
       "title": "Smazat nepoužité kandidáty?",
       "message": "Máte {{count}} kandidátských fotografií, které nejsou v žádné sadě. Smazat je a uvolnit přibližně {{size}} MB úložiště?",
       "keep": "Ponechat kandidáty",
-      "delete": "Smazat {{count}} kandidátů"
+      "delete": "Smazat {{count}} kandidátů",
+      "error": "Smazání kandidátů selhalo. Některé soubory mohou stále zabírat úložiště."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -278,6 +278,26 @@
     "selectNone": "Select None",
     "createdOn": "Created: {{date}}"
   },
+  "candidates": {
+    "title": "Candidates ({{count}})",
+    "addMore": "Add more",
+    "hideRejects": "Hide rejected",
+    "emptyHint": "Drop more photos here or click to browse",
+    "allFiltered": "All candidates are hidden by the filter.",
+    "flag": {
+      "pick": "Mark as pick",
+      "neutral": "Clear flag",
+      "reject": "Mark as rejected"
+    },
+    "sendToSet1": "Send to Set 1",
+    "sendToSet2": "Send to Set 2",
+    "cleanup": {
+      "title": "Delete unused candidates?",
+      "message": "You have {{count}} candidate photos that aren't in the final set. Delete them to free ~{{size}} MB of storage?",
+      "keep": "Keep candidates",
+      "delete": "Delete {{count}} candidates"
+    }
+  },
   "pdf": {
     "promotional": {
       "line1": "created using",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -280,9 +280,12 @@
   },
   "candidates": {
     "title": "Candidates ({{count}})",
+    "poolLabel": "Candidate pool",
     "addMore": "Add more",
     "hideRejects": "Hide rejected",
-    "emptyHint": "Drop more photos here or click to browse",
+    "emptyHint": "Drop extra photos here — drag any onto a slot to use it in the print set",
+    "dragHint": "Drag a thumbnail onto an empty slot to add it to the print set, or use the toolbar buttons below each photo.",
+    "smartDropToast": "Added {{count}} photos to Candidates — drag any onto a slot to use them.",
     "allFiltered": "All candidates are hidden by the filter.",
     "flag": {
       "pick": "Mark as pick",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -286,6 +286,7 @@
     "emptyHint": "Drop extra photos here — drag any onto a slot to use it in the print set",
     "dragHint": "Drag a thumbnail onto an empty slot to add it to the print set, or use the toolbar buttons below each photo.",
     "smartDropToast": "Added {{count}} photos to Candidates — drag any onto a slot to use them.",
+    "crossSetHint": "Cross-set moves go via the Candidates tray. Drag the photo there, then drag it into the other set.",
     "allFiltered": "All candidates are hidden by the filter.",
     "flag": {
       "pick": "Mark as pick",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -262,7 +262,8 @@
     "shuffleFailed": "Failed to shuffle photos",
     "noActiveCompetition": "No active competition to add photos to",
     "photoSetFull": "Set {{set}} is full. Remove a photo first.",
-    "photoSetCapacityRemaining": "Set {{set}} can take only {{count}} more photo(s)."
+    "photoSetCapacityRemaining": "Set {{set}} can take only {{count}} more photo(s).",
+    "candidateDeletePartialFailure": "Failed to delete {{failed}} of {{total}} candidate files. They may still occupy storage."
   },
   "common": {
     "loading": "Loading...",
@@ -299,7 +300,8 @@
       "title": "Delete unused candidates?",
       "message": "You have {{count}} candidate photos that aren't in the final set. Delete them to free ~{{size}} MB of storage?",
       "keep": "Keep candidates",
-      "delete": "Delete {{count}} candidates"
+      "delete": "Delete {{count}} candidates",
+      "error": "Failed to delete candidates. Some files may still occupy storage."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -263,6 +263,7 @@
     "noActiveCompetition": "No active competition to add photos to",
     "photoSetFull": "Set {{set}} is full. Remove a photo first.",
     "photoSetCapacityRemaining": "Set {{set}} can take only {{count}} more photo(s).",
+    "setOverCapacity": "This set already has {{current}} photos but the cap is now {{cap}}. Please reload the competition or remove photos before adding more.",
     "candidateDeletePartialFailure": "Failed to delete {{failed}} of {{total}} candidate files. They may still occupy storage."
   },
   "common": {
@@ -301,7 +302,8 @@
       "message": "You have {{count}} candidate photos that aren't in the final set. Delete them to free ~{{size}} MB of storage?",
       "keep": "Keep candidates",
       "delete": "Delete {{count}} candidates",
-      "error": "Failed to delete candidates. Some files may still occupy storage."
+      "error": "Failed to delete candidates. Some files may still occupy storage.",
+      "allPromoted": "None of the {{count}} candidates were deleted — they were moved to slots before confirm."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/services/competitionService.ts
+++ b/frontend/photo-helper/src/services/competitionService.ts
@@ -280,6 +280,44 @@ export class CompetitionService {
     }
   }
 
+  /**
+   * Best-effort deletion of specific photo files from a competition's `photos/`
+   * directory. Used to reclaim OPFS storage for culled candidate photos —
+   * `saveSessionPhotos` deliberately never prunes (to protect non-active mode
+   * buckets), so per-photo deletes must be explicit (PR #62 review C3). Per-id
+   * failures are logged and swallowed: the caller has already removed the id
+   * from the session, so a stuck file would just orphan rather than refuse the
+   * UX flow.
+   */
+  async deletePhotosByIds(competitionId: string, photoIds: string[]): Promise<void> {
+    if (photoIds.length === 0) return;
+    await this.ensureInitialized();
+    let competitionDir: DirectoryHandle;
+    let photosDir: DirectoryHandle;
+    try {
+      competitionDir = await this.storage!.getDirectoryHandle(
+        this.competitionsDir!,
+        competitionId,
+        { create: false }
+      );
+      photosDir = await this.storage!.getDirectoryHandle(
+        competitionDir,
+        'photos',
+        { create: false }
+      );
+    } catch (err) {
+      console.warn(`deletePhotosByIds: cannot open photos dir for ${competitionId}:`, err);
+      return;
+    }
+    for (const id of photoIds) {
+      try {
+        await this.storage!.deletePhotoFile(photosDir, id);
+      } catch (err) {
+        console.warn(`deletePhotosByIds: failed to delete ${id}:`, err);
+      }
+    }
+  }
+
   async deleteCompetition(id: string): Promise<void> {
     await this.ensureInitialized();
 

--- a/frontend/photo-helper/src/services/competitionService.ts
+++ b/frontend/photo-helper/src/services/competitionService.ts
@@ -281,21 +281,23 @@ export class CompetitionService {
   }
 
   /**
-   * Best-effort deletion of specific photo files from a competition's `photos/`
+   * Deletion of specific photo files from a competition's `photos/`
    * directory. Used to reclaim OPFS storage for culled candidate photos —
    * `saveSessionPhotos` deliberately never prunes (to protect non-active mode
-   * buckets), so per-photo deletes must be explicit (PR #62 review C3). Per-id
-   * failures are logged and swallowed: the caller has already removed the id
-   * from the session, so a stuck file would just orphan rather than refuse the
-   * UX flow.
+   * buckets), so per-photo deletes must be explicit (PR #62 review C3).
+   *
+   * Returns `{ failed }` listing ids whose individual delete operation
+   * threw. Callers that surface partial failures to the user (e.g., the
+   * cleanup dialog, see PR #62 review CRIT-3) inspect this list; callers
+   * doing background per-photo cleanup ignore it. A missing competition
+   * directory is treated as success (the files are gone by definition).
    */
-  async deletePhotosByIds(competitionId: string, photoIds: string[]): Promise<void> {
-    if (photoIds.length === 0) return;
+  async deletePhotosByIds(competitionId: string, photoIds: string[]): Promise<{ failed: string[] }> {
+    if (photoIds.length === 0) return { failed: [] };
     await this.ensureInitialized();
-    let competitionDir: DirectoryHandle;
     let photosDir: DirectoryHandle;
     try {
-      competitionDir = await this.storage!.getDirectoryHandle(
+      const competitionDir = await this.storage!.getDirectoryHandle(
         this.competitionsDir!,
         competitionId,
         { create: false }
@@ -306,16 +308,21 @@ export class CompetitionService {
         { create: false }
       );
     } catch (err) {
+      // Competition (or its photos/) doesn't exist — treat as already-cleaned.
+      // Distinct from per-id failure: this is a no-op, not a partial result.
       console.warn(`deletePhotosByIds: cannot open photos dir for ${competitionId}:`, err);
-      return;
+      return { failed: [] };
     }
+    const failed: string[] = [];
     for (const id of photoIds) {
       try {
         await this.storage!.deletePhotoFile(photosDir, id);
       } catch (err) {
         console.warn(`deletePhotosByIds: failed to delete ${id}:`, err);
+        failed.push(id);
       }
     }
+    return { failed };
   }
 
   async deleteCompetition(id: string): Promise<void> {

--- a/frontend/photo-helper/src/services/competitionService.ts
+++ b/frontend/photo-helper/src/services/competitionService.ts
@@ -507,11 +507,18 @@ export class CompetitionService {
       };
     };
 
+    // Candidate pool uses the same URL-stripping pass. The pool is a flat
+    // `{ photos: [] }` shape so it's not symmetric with `{ set1, set2 }` and
+    // can't share the helper above.
+    const clearCandidateUrls = (pool?: { photos: any[] }) =>
+      pool ? { photos: (pool.photos || []).map((p: any) => ({ ...p, url: '' })) } : undefined;
+
     return {
       ...session,
       sets: clearUrls(session.sets) as any,
       ...(session as any).setsTrack ? { setsTrack: clearUrls((session as any).setsTrack) as any } : {},
-      ...(session as any).setsTurning ? { setsTurning: clearUrls((session as any).setsTurning) as any } : {}
+      ...(session as any).setsTurning ? { setsTurning: clearUrls((session as any).setsTurning) as any } : {},
+      ...(session as any).candidates ? { candidates: clearCandidateUrls((session as any).candidates) as any } : {}
     };
   }
 
@@ -529,6 +536,7 @@ export class CompetitionService {
     const activePhotos = collect(session.sets as any);
     const trackPhotos = collect((session as any).setsTrack);
     const turningPhotos = collect((session as any).setsTurning);
+    const candidatePhotos = ((session as any).candidates?.photos as any[]) || [];
 
     // Deduplicate by id while preserving first occurrence with a blob url if available
     const idToPhoto = new Map<string, any>();
@@ -544,7 +552,7 @@ export class CompetitionService {
       }
     };
 
-    [...activePhotos, ...trackPhotos, ...turningPhotos].forEach(pushPhoto);
+    [...activePhotos, ...trackPhotos, ...turningPhotos, ...candidatePhotos].forEach(pushPhoto);
 
     for (const photo of idToPhoto.values()) {
       if (photo.url && photo.url.startsWith('blob:')) {
@@ -593,6 +601,14 @@ export class CompetitionService {
       };
     };
 
+    // Candidates pool — flat array, not the {set1, set2} shape. Reuses the
+    // same blob-load helper as slot photos. Missing pool stays missing
+    // (older sessions on disk have no candidates field).
+    const loadCandidates = async (pool: { photos: any[] } | undefined) => {
+      if (!pool) return undefined;
+      return { photos: await loadPhotoUrls((pool.photos || []) as any) };
+    };
+
     return {
       ...session,
       sets: {
@@ -606,7 +622,8 @@ export class CompetitionService {
         }
       },
       setsTrack: await loadModeSpecificSets(session.setsTrack),
-      setsTurning: await loadModeSpecificSets(session.setsTurning)
+      setsTurning: await loadModeSpecificSets(session.setsTurning),
+      candidates: await loadCandidates((session as any).candidates)
     };
   }
 }

--- a/frontend/photo-helper/src/services/competitionService.ts
+++ b/frontend/photo-helper/src/services/competitionService.ts
@@ -309,9 +309,16 @@ export class CompetitionService {
       );
     } catch (err) {
       // Competition (or its photos/) doesn't exist — treat as already-cleaned.
-      // Distinct from per-id failure: this is a no-op, not a partial result.
-      console.warn(`deletePhotosByIds: cannot open photos dir for ${competitionId}:`, err);
-      return { failed: [] };
+      // ONLY `NotFoundError` qualifies; anything else (transient OPFS error,
+      // lock contention from a concurrent tab, quota, permission) must be
+      // reported back to the caller as a partial failure or orphan files
+      // accumulate while the cleanup dialog claims success (PR #62 review I3).
+      const name = (err as { name?: string } | null)?.name;
+      if (name === 'NotFoundError') {
+        return { failed: [] };
+      }
+      console.error(`deletePhotosByIds: cannot open photos dir for ${competitionId}:`, err);
+      return { failed: photoIds };
     }
     const failed: string[] = [];
     for (const id of photoIds) {

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -6,6 +6,19 @@ import type { Photo } from './index';
 
 export type CandidateFlag = 'pick' | 'neutral' | 'reject';
 
+/**
+ * Result of a photo-add operation (`addPhotosToSet`, `addPhotosToTurningPoint`).
+ * Discriminated union so callers can react specifically to smart-drop routing
+ * vs. error paths without sniffing `result === undefined` (PR #62 review IMP-6).
+ *
+ * The hook still calls `setError` on the `err` arm for the global Alert
+ * banner; the returned result is for callers that want to react more
+ * specifically (toast on tray-routing, dialog on over-capacity, etc.).
+ */
+export type AddPhotosResult =
+  | { kind: 'ok'; routedTo: 'slot' | 'tray'; count: number }
+  | { kind: 'err'; reason: 'no-competition' | 'over-capacity' | 'unknown'; message: string };
+
 export interface ApiPhoto {
   id: string;
   sessionId: string; // Required for image cache and API consistency

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -4,6 +4,8 @@
 
 import type { Photo } from './index';
 
+export type CandidateFlag = 'pick' | 'neutral' | 'reject';
+
 export interface ApiPhoto {
   id: string;
   sessionId: string; // Required for image cache and API consistency
@@ -12,10 +14,20 @@ export interface ApiPhoto {
   canvasState: Photo['canvasState']; // Inherits from main Photo type
   label: string;
   uploadedAt?: string; // Optional for backward compatibility
+  /**
+   * Triage flag — meaningful only while the photo lives in the candidates
+   * pool. Cleared on promotion to a slot, defaulted to `'pick'` on demotion
+   * from a slot back to the tray. See docs/CANDIDATE_PHOTOS.md.
+   */
+  flag?: CandidateFlag;
 }
 
 export interface ApiPhotoSet {
   title: string;
+  photos: ApiPhoto[];
+}
+
+export interface CandidatePool {
   photos: ApiPhoto[];
 }
 
@@ -30,6 +42,12 @@ export interface ApiPhotoSession {
     set1: ApiPhotoSet;
     set2: ApiPhotoSet;
   };
+  /**
+   * Slotless workspace pool of photos the user is still triaging. Photos here
+   * never appear in the PDF; the export logic in `buildPdfSets` reads `sets`
+   * only. Global (not per-mode) — see docs/CANDIDATE_PHOTOS.md "Data model".
+   */
+  candidates?: CandidatePool;
   // Mode-specific photo storage for separate track/turning point collections
   setsTrack?: {
     set1: ApiPhotoSet;

--- a/frontend/photo-helper/src/utils/candidateFilter.ts
+++ b/frontend/photo-helper/src/utils/candidateFilter.ts
@@ -1,0 +1,43 @@
+/**
+ * Candidate-pool view filters. Pure so the rendering path stays testable
+ * without mounting MUI (PR #62 review gap B8). V1 ships only the
+ * `hideRejects` toggle; future pill filters (Picks / Neutral / Rejects)
+ * will add cases to this helper rather than re-implementing the predicates.
+ */
+import type { ApiPhoto } from '../types/api';
+
+export type CandidateFilter = { hideRejects: boolean };
+
+/**
+ * Apply the view filter to the candidate pool.
+ *
+ * Returns the SAME array reference when no filter is active — useful for React
+ * memoization and to skip unnecessary re-renders of the thumb grid.
+ */
+export function filterCandidates(photos: ApiPhoto[], filter: CandidateFilter): ApiPhoto[] {
+  if (!filter.hideRejects) return photos;
+  return photos.filter((p) => p.flag !== 'reject');
+}
+
+/**
+ * Tally counts for the header chips. Centralised so a future filter that
+ * changes the visible set doesn't have to re-implement the count logic.
+ * Counts are computed over ALL photos (not the filtered view) — the header
+ * shows totals regardless of what is hidden.
+ */
+export function countByFlag(photos: ApiPhoto[]): {
+  pick: number;
+  neutral: number;
+  reject: number;
+  total: number;
+} {
+  let pick = 0;
+  let neutral = 0;
+  let reject = 0;
+  for (const p of photos) {
+    if (p.flag === 'pick') pick++;
+    else if (p.flag === 'reject') reject++;
+    else neutral++;
+  }
+  return { pick, neutral, reject, total: photos.length };
+}

--- a/frontend/photo-helper/src/utils/candidateTransitions.ts
+++ b/frontend/photo-helper/src/utils/candidateTransitions.ts
@@ -1,0 +1,148 @@
+/**
+ * Pure session-level transitions for the candidate pool.
+ *
+ * These helpers compute the next session state for promote / demote / swap /
+ * flag operations without touching React, OPFS, or blob URLs. The hooks call
+ * them and then run the result through their normal persistence path, so the
+ * branching logic is unit-testable and stays consistent across the two hook
+ * implementations (`useCompetitionSystem`, `usePhotoSessionOPFS`).
+ *
+ * Contract — see docs/CANDIDATE_PHOTOS.md "Drag/drop interactions":
+ *   - promote: tray → empty slot. Clears flag.
+ *   - swap:    tray → occupied slot. Displaced slot photo enters tray as 'pick'.
+ *   - demote:  slot → tray. Photo enters tray as 'pick' (was good enough to slot).
+ *   - setFlag: tray photo flag transition.
+ */
+
+import type { ApiPhoto, ApiPhotoSession, CandidateFlag } from '../types/api';
+
+type SetKey = 'set1' | 'set2';
+
+const bumpVersion = (s: ApiPhotoSession): ApiPhotoSession => ({
+  ...s,
+  version: s.version + 1,
+  updatedAt: new Date().toISOString(),
+});
+
+const getCandidatePhotos = (s: ApiPhotoSession): ApiPhoto[] =>
+  s.candidates?.photos ?? [];
+
+/**
+ * Promote a candidate photo into a slot. If the slot index is currently
+ * occupied, the existing slot photo is swapped back to the candidate pool as
+ * a 'pick' (it was committed once, so likely a strong fallback).
+ *
+ * If `slotIndex` is past the end of the current array, the photo is appended.
+ * The caller is responsible for ensuring the resulting slot count does not
+ * exceed `getGridCapacity` — typically the slot-renderer prevents drops past
+ * `capacity` and this helper trusts that gate.
+ */
+export function promoteCandidateToSlot(
+  session: ApiPhotoSession,
+  candidateId: string,
+  setKey: SetKey,
+  slotIndex: number,
+): ApiPhotoSession {
+  const candidates = getCandidatePhotos(session);
+  const candidate = candidates.find((p) => p.id === candidateId);
+  if (!candidate) return session;
+
+  const remainingCandidates = candidates.filter((p) => p.id !== candidateId);
+  // Clear flag on entering a slot — flag is a tray-only concept.
+  const { flag: _flag, ...rest } = candidate;
+  const promoted: ApiPhoto = { ...rest };
+
+  const set = session.sets[setKey];
+  const photos = [...set.photos];
+
+  if (slotIndex >= 0 && slotIndex < photos.length) {
+    // Swap: displaced slot photo returns to the tray as 'pick'.
+    const displaced = photos[slotIndex];
+    photos[slotIndex] = promoted;
+    const demoted: ApiPhoto = { ...displaced, flag: 'pick' };
+    return bumpVersion({
+      ...session,
+      sets: { ...session.sets, [setKey]: { ...set, photos } },
+      candidates: { photos: [...remainingCandidates, demoted] },
+    });
+  }
+
+  // Empty slot at the end (or past the end — clamp to append).
+  photos.splice(Math.min(slotIndex, photos.length), 0, promoted);
+  return bumpVersion({
+    ...session,
+    sets: { ...session.sets, [setKey]: { ...set, photos } },
+    candidates: { photos: remainingCandidates },
+  });
+}
+
+/**
+ * Demote a slot photo back to the tray. Default flag is 'pick' — the photo
+ * was committed to a slot once, so it's likely a strong candidate the user
+ * is reconsidering rather than a fresh neutral upload.
+ */
+export function demoteSlotToCandidate(
+  session: ApiPhotoSession,
+  setKey: SetKey,
+  photoId: string,
+  flag: CandidateFlag = 'pick',
+): ApiPhotoSession {
+  const set = session.sets[setKey];
+  const photo = set.photos.find((p) => p.id === photoId);
+  if (!photo) return session;
+
+  const remainingSlotPhotos = set.photos.filter((p) => p.id !== photoId);
+  const demoted: ApiPhoto = { ...photo, flag };
+
+  return bumpVersion({
+    ...session,
+    sets: { ...session.sets, [setKey]: { ...set, photos: remainingSlotPhotos } },
+    candidates: { photos: [...getCandidatePhotos(session), demoted] },
+  });
+}
+
+export function setCandidateFlag(
+  session: ApiPhotoSession,
+  photoId: string,
+  flag: CandidateFlag,
+): ApiPhotoSession {
+  const photos = getCandidatePhotos(session);
+  const idx = photos.findIndex((p) => p.id === photoId);
+  if (idx === -1) return session;
+  const next = [...photos];
+  next[idx] = { ...next[idx], flag };
+  return bumpVersion({ ...session, candidates: { photos: next } });
+}
+
+export function removeCandidate(
+  session: ApiPhotoSession,
+  photoId: string,
+): ApiPhotoSession {
+  const photos = getCandidatePhotos(session);
+  if (!photos.some((p) => p.id === photoId)) return session;
+  return bumpVersion({
+    ...session,
+    candidates: { photos: photos.filter((p) => p.id !== photoId) },
+  });
+}
+
+export function clearAllCandidates(session: ApiPhotoSession): ApiPhotoSession {
+  if (!session.candidates || session.candidates.photos.length === 0) return session;
+  return bumpVersion({ ...session, candidates: { photos: [] } });
+}
+
+export function updateCandidateCanvasState(
+  session: ApiPhotoSession,
+  photoId: string,
+  canvasState: Partial<ApiPhoto['canvasState']>,
+): ApiPhotoSession {
+  const photos = getCandidatePhotos(session);
+  const idx = photos.findIndex((p) => p.id === photoId);
+  if (idx === -1) return session;
+  const next = [...photos];
+  next[idx] = {
+    ...next[idx],
+    canvasState: { ...next[idx].canvasState, ...canvasState },
+  };
+  return bumpVersion({ ...session, candidates: { photos: next } });
+}

--- a/frontend/photo-helper/src/utils/dragPayload.ts
+++ b/frontend/photo-helper/src/utils/dragPayload.ts
@@ -20,6 +20,24 @@ export type DragPayload =
 
 const SET_KEY_UNION: ReadonlyArray<'set1' | 'set2'> = ['set1', 'set2'];
 
+/**
+ * Slot indices and photo IDs must be sane positive integers. The bound of
+ * 1000 is far above any realistic per-set grid (max is 10) but cheap to
+ * check — rejects NaN, Infinity, negative, float, and absurd values.
+ * Without this guard, a hostile payload with `index: NaN` flows into
+ * array indexing in `candidateTransitions.promoteCandidateToSlot` and
+ * downstream pure helpers, where `>=` / `<` comparisons against NaN
+ * silently fall to the append branch (PR #62 review I5).
+ */
+const MAX_REASONABLE_INDEX = 1000;
+function isValidIndex(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 0 && n < MAX_REASONABLE_INDEX;
+}
+
+function isNonEmptyString(s: unknown): s is string {
+  return typeof s === 'string' && s.length > 0;
+}
+
 export function parseDragPayload(raw: string | null | undefined): DragPayload | null {
   if (!raw) return null;
   let parsed: unknown;
@@ -35,7 +53,7 @@ export function parseDragPayload(raw: string | null | undefined): DragPayload | 
   if (!parsed || typeof parsed !== 'object') return null;
   const p = parsed as { kind?: unknown; setKey?: unknown; photoId?: unknown; index?: unknown };
 
-  if (p.kind === 'tray' && typeof p.photoId === 'string') {
+  if (p.kind === 'tray' && isNonEmptyString(p.photoId)) {
     return { kind: 'tray', photoId: p.photoId };
   }
 
@@ -45,8 +63,8 @@ export function parseDragPayload(raw: string | null | undefined): DragPayload | 
   // or crashing downstream code (PR #62 review I5).
   if (
     p.kind === 'slot' &&
-    typeof p.photoId === 'string' &&
-    typeof p.index === 'number' &&
+    isNonEmptyString(p.photoId) &&
+    isValidIndex(p.index) &&
     SET_KEY_UNION.includes(p.setKey as 'set1' | 'set2')
   ) {
     return {

--- a/frontend/photo-helper/src/utils/dragPayload.ts
+++ b/frontend/photo-helper/src/utils/dragPayload.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared parser for the in-app drag payload exchanged between `PhotoGridApi`
+ * and `CandidateTray`. Centralised so the strict literal-union check on
+ * `setKey` (defense against `__proto__`-style prototype pollution via JSON
+ * keys) lives in ONE place rather than being duplicated across both
+ * components — see PR #62 review G3.
+ *
+ * Wire format (MIME `application/x-airq-photo`):
+ *   { kind: 'slot', setKey: 'set1' | 'set2', index: number, photoId: string }
+ *   { kind: 'tray', photoId: string }
+ *
+ * `null` return signals "not a recognised payload": malformed JSON, missing
+ * fields, wrong types, or `setKey` not in the literal union. Callers MUST
+ * fall through to their default (text/plain reorder, or no-op) on null.
+ */
+
+export type DragPayload =
+  | { kind: 'slot'; setKey: 'set1' | 'set2'; photoId: string; index: number }
+  | { kind: 'tray'; photoId: string };
+
+const SET_KEY_UNION: ReadonlyArray<'set1' | 'set2'> = ['set1', 'set2'];
+
+export function parseDragPayload(raw: string | null | undefined): DragPayload | null {
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    // Logged so a misbehaving drag source is debuggable in devtools without
+    // needing to source-patch (PR #62 review I5). Return null so callers
+    // fall through to their non-internal-payload path.
+    console.warn('parseDragPayload: malformed drag payload', raw, err);
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') return null;
+  const p = parsed as { kind?: unknown; setKey?: unknown; photoId?: unknown; index?: unknown };
+
+  if (p.kind === 'tray' && typeof p.photoId === 'string') {
+    return { kind: 'tray', photoId: p.photoId };
+  }
+
+  // Strict literal-union check: must be exactly 'set1' or 'set2', NOT any
+  // arbitrary string. Without this guard, a payload with `setKey: '__proto__'`
+  // would later be used as an index into `session.sets[setKey]`, polluting
+  // or crashing downstream code (PR #62 review I5).
+  if (
+    p.kind === 'slot' &&
+    typeof p.photoId === 'string' &&
+    typeof p.index === 'number' &&
+    SET_KEY_UNION.includes(p.setKey as 'set1' | 'set2')
+  ) {
+    return {
+      kind: 'slot',
+      setKey: p.setKey as 'set1' | 'set2',
+      photoId: p.photoId,
+      index: p.index,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Serialise a drag payload for `dataTransfer.setData`. Counterpart to
+ * `parseDragPayload`; centralising both directions guarantees round-trip
+ * compatibility under refactoring.
+ */
+export function serializeDragPayload(payload: DragPayload): string {
+  return JSON.stringify(payload);
+}
+
+export const DRAG_PAYLOAD_MIME = 'application/x-airq-photo';

--- a/frontend/photo-helper/src/utils/sessionRefs.ts
+++ b/frontend/photo-helper/src/utils/sessionRefs.ts
@@ -1,0 +1,34 @@
+/**
+ * Cross-bucket reference check for a photo id within a session.
+ *
+ * A photo's OPFS file is shared across the active `sets` and the per-mode
+ * buckets (`setsTrack`, `setsTurning`) plus the candidate pool. Deleting the
+ * file from disk while ANY container still references it would break the
+ * inactive mode (or the slot) on next load (PR #62 review IMP-2/3/C3).
+ *
+ * Call this AFTER the source container has been mutated (the photo already
+ * removed from where it's leaving). Returns true if any OTHER container
+ * still references the id and the file must NOT be deleted.
+ *
+ * Slot deletions should mirror the removal into the active mode bucket
+ * (`setsTrack` or `setsTurning`) before calling, otherwise the bucket's
+ * stale reference will keep the check truthy forever and the file orphans
+ * after a mode-switch round-trip.
+ */
+import type { ApiPhotoSession } from '../types/api';
+
+export function isPhotoReferencedInSession(
+  session: ApiPhotoSession,
+  photoId: string,
+): boolean {
+  const s = session as any;
+  const inSet = (set: any) => set?.photos?.some?.((p: any) => p.id === photoId) === true;
+  if (inSet(s.sets?.set1)) return true;
+  if (inSet(s.sets?.set2)) return true;
+  if (inSet(s.setsTrack?.set1)) return true;
+  if (inSet(s.setsTrack?.set2)) return true;
+  if (inSet(s.setsTurning?.set1)) return true;
+  if (inSet(s.setsTurning?.set2)) return true;
+  if (s.candidates?.photos?.some?.((p: any) => p.id === photoId) === true) return true;
+  return false;
+}

--- a/frontend/photo-helper/src/utils/slotDropDispatch.ts
+++ b/frontend/photo-helper/src/utils/slotDropDispatch.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure dispatch for the four possible outcomes of dropping something onto a
+ * `PhotoGridApi` slot:
+ *
+ *   1. tray photo → promote to this slot
+ *   2. slot photo from another set → cross-set drop (rejected with a hint)
+ *   3. integer in `text/plain` → in-grid reorder
+ *   4. native OS file drop → smart-drop forward (occupied slot routes to tray)
+ *
+ * Extracted from `PhotoGridApi.handleDrop` so the dispatch can be unit-tested
+ * without spinning up MUI/contexts/react-dropzone (PR #62 review I4). The
+ * component shell stays in charge of `e.preventDefault()`, drag-state resets,
+ * and invoking the returned callbacks; this helper just decides WHICH
+ * callback should fire.
+ *
+ * The order of checks is load-bearing — keep it identical to the production
+ * dispatch:
+ *   structured payload first (tray / cross-set slot)
+ *   → text/plain reorder (same-set in-grid drag)
+ *   → native file fallthrough (only when neither payload nor reorder matched)
+ *
+ * Returning `{ kind: 'none' }` is a "do nothing" signal — the drop fell
+ * through every branch.
+ */
+
+import type { DragPayload } from './dragPayload';
+
+export type SlotDropAction =
+  | { kind: 'promote'; photoId: string; dropIndex: number }
+  | { kind: 'cross-set-rejected' }
+  | { kind: 'reorder'; fromIndex: number; toIndex: number }
+  | { kind: 'files'; files: File[] }
+  | { kind: 'none' };
+
+export interface SlotDropInput {
+  payload: DragPayload | null;
+  textPlain: string;
+  files: ReadonlyArray<File>;
+  dropIndex: number;
+  setKey: 'set1' | 'set2';
+  isValidImageFile: (file: File) => boolean;
+}
+
+export function dispatchSlotDrop(input: SlotDropInput): SlotDropAction {
+  const { payload, textPlain, files, dropIndex, setKey, isValidImageFile } = input;
+
+  if (payload) {
+    if (payload.kind === 'tray') {
+      return { kind: 'promote', photoId: payload.photoId, dropIndex };
+    }
+    if (payload.kind === 'slot' && payload.setKey !== setKey) {
+      // Cross-set drops aren't supported in v1; two-step via tray works.
+      return { kind: 'cross-set-rejected' };
+    }
+    // payload.kind === 'slot' && payload.setKey === setKey falls through to
+    // the legacy text/plain reorder path (same-set drag emits both formats).
+  }
+
+  const dragIndex = Number.parseInt(textPlain, 10);
+  if (Number.isFinite(dragIndex) && dragIndex !== dropIndex) {
+    return { kind: 'reorder', fromIndex: dragIndex, toIndex: dropIndex };
+  }
+
+  // Native OS file drop onto an occupied slot — neither payload nor reorder
+  // matched. Without this branch, `e.preventDefault()` in the component
+  // already suppressed the dropzone wrapper and the files vanished silently
+  // (PR #62 review I4). Routing to onFilesDropped lets smart-drop send the
+  // batch to the candidate tray (occupied slot → remaining = 0).
+  if (files.length > 0) {
+    const valid = Array.from(files).filter(isValidImageFile);
+    if (valid.length > 0) {
+      return { kind: 'files', files: valid };
+    }
+  }
+
+  return { kind: 'none' };
+}

--- a/frontend/photo-helper/src/utils/smartDropRoute.ts
+++ b/frontend/photo-helper/src/utils/smartDropRoute.ts
@@ -1,0 +1,29 @@
+/**
+ * Smart drop routing — decides whether an incoming batch of files should
+ * fill a target set's empty slots or land in the candidates pool.
+ *
+ * Contract: if the batch fits in the remaining slot capacity, fill slots
+ * (today's behaviour). Otherwise the entire batch routes to candidates —
+ * we never partially fill slots and dump the remainder, because that
+ * silently splits the user's intent and is hard to undo.
+ *
+ * Pure helper so the heuristic stays unit-testable in isolation; see
+ * docs/CANDIDATE_PHOTOS.md "Smart drop heuristic".
+ */
+export type DropRoute =
+  | { kind: 'slot'; files: File[] }
+  | { kind: 'tray'; files: File[] };
+
+export interface SmartDropInput {
+  files: File[];
+  currentSlotCount: number;
+  slotCapacity: number;
+}
+
+export function routeDrop(input: SmartDropInput): DropRoute {
+  const { files, currentSlotCount, slotCapacity } = input;
+  const remaining = Math.max(0, slotCapacity - currentSlotCount);
+  if (files.length === 0) return { kind: 'slot', files: [] };
+  if (files.length <= remaining) return { kind: 'slot', files };
+  return { kind: 'tray', files };
+}

--- a/frontend/photo-helper/vitest.config.ts
+++ b/frontend/photo-helper/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
   },
 })

--- a/frontend/photo-helper/vitest.setup.ts
+++ b/frontend/photo-helper/vitest.setup.ts
@@ -1,0 +1,4 @@
+// Global vitest setup — runs once before any test file. Loads jest-dom's
+// custom matchers (toBeInTheDocument, toHaveTextContent, …) so RTL-based
+// tests can use them without per-file imports.
+import '@testing-library/jest-dom/vitest';

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -179,6 +179,15 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.2.1(vite@7.3.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.1.0
+        version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: 14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.0.3
         version: 25.3.3
@@ -244,6 +253,9 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1178,6 +1190,35 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.1.0':
+    resolution: {integrity: sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.5.2':
+    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tmcw/togeojson@7.1.2':
     resolution: {integrity: sha512-QKnFs9DAuqqBVj4d6c69tV1Dj2TspSBTqffivoN0YoBCVdP/JY1+WaYCJbzU49RkoU5NOSOJ3jtFHCdEUVh21A==}
 
@@ -1526,6 +1567,9 @@ packages:
   '@turf/voronoi@7.3.4':
     resolution: {integrity: sha512-cwKSiDzDHRnA7yafQ1zOhWxRuMzp+fYFFzadCdByBAG1jAD7UlFwKhS1fjNPBNs67Fl5X3LL5ahCLW5gEdFgmg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1791,6 +1835,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1811,6 +1859,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   arr-union@3.1.0:
     resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
@@ -1966,6 +2021,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2089,6 +2148,9 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csscolorparser@1.0.3:
     resolution: {integrity: sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==}
 
@@ -2146,6 +2208,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2167,6 +2233,12 @@ packages:
     engines: {node: '>=8'}
     os: [darwin]
     hasBin: true
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -2648,6 +2720,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -2927,6 +3003,10 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -2982,6 +3062,10 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -3232,6 +3316,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -3296,6 +3384,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@19.2.4:
     resolution: {integrity: sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==}
 
@@ -3333,6 +3424,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3561,6 +3656,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3962,6 +4061,8 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -4916,6 +5017,41 @@ snapshots:
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
       vite: 7.3.2(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.18.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tmcw/togeojson@7.1.2': {}
 
@@ -6043,6 +6179,8 @@ snapshots:
       d3-voronoi: 1.1.2
       tslib: 2.8.1
 
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.0
@@ -6356,6 +6494,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   app-builder-bin@5.0.0-alpha.12: {}
@@ -6406,6 +6546,12 @@ snapshots:
   arc@0.2.0: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   arr-union@3.1.0: {}
 
@@ -6587,6 +6733,11 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -6703,6 +6854,8 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css.escape@1.5.1: {}
+
   csscolorparser@1.0.3: {}
 
   csstype@3.2.3: {}
@@ -6756,6 +6909,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   detect-node@2.1.0:
@@ -6792,6 +6947,10 @@ snapshots:
       smart-buffer: 4.2.0
       verror: 1.10.1
     optional: true
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -7388,6 +7547,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -7622,6 +7783,8 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7724,6 +7887,8 @@ snapshots:
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -7975,6 +8140,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proc-log@5.0.0: {}
 
   progress@2.0.3: {}
@@ -8039,6 +8210,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-is@19.2.4: {}
 
   react-map-gl@8.1.0(mapbox-gl@3.19.1)(maplibre-gl@5.19.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -8075,6 +8248,11 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   require-directory@2.1.1: {}
 
@@ -8313,6 +8491,10 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 


### PR DESCRIPTION
## Summary

Adds a **slotless candidate pool** above the final-print grid so users can:

1. Drop 20–40 candidate photos at once.
2. Edit and triage with pick / neutral / reject flags.
3. Drag the winners into final slots (or use "Send to Set 1/2" from the context menu).
4. Export only slot photos to PDF — same logic as today.

After a successful export, an opt-in cleanup dialog offers to free the unused candidates' storage.

**Smart-drop:** dropping more files than the target set's remaining capacity routes the whole batch into the candidate pool instead of erroring. Small drops still fill slots as today, so existing UX is untouched until the user opts in.

Full contract in [`docs/CANDIDATE_PHOTOS.md`](./docs/CANDIDATE_PHOTOS.md).

## What changed

- **Types** (`api.ts`): optional `candidates: { photos }` on `ApiPhotoSession`; optional `flag: 'pick' | 'neutral' | 'reject'` on `ApiPhoto`.
- **Persistence** (`competitionService.ts`): sanitize / save / load now walk the candidate pool alongside slot photos. `calculatePhotoCount` stays slot-only.
- **Pure helpers**:
  - `utils/smartDropRoute.ts` — the routing heuristic (`> capacity → tray`).
  - `utils/candidateTransitions.ts` — promote / demote / swap / flag / clear, all returning fresh session shapes.
- **Hook surface** (`useCompetitionSystem`, mirrored in `usePhotoSessionOPFS`):
  - `addPhotosToCandidates`, `removeCandidate`, `promoteCandidateToSlot`, `demoteSlotToCandidate`, `setCandidateFlag`, `updateCandidatePhotoState`, `clearAllCandidates`.
  - `addPhotosToSet` now routes through smart-drop instead of erroring on overflow. Precision-track keeps its 9→10 layout-flip behaviour.
- **UI**:
  - New `CandidateTray` component (collapsible, hide-rejected toggle, drag source, drop target).
  - `PhotoGridApi` accepts a structured `application/x-airq-photo` payload for tray↔slot transfers in addition to the existing in-grid reorder.
  - `AppApi` renders the tray above the print layout, wires `onCandidateDropped` per set, exposes a post-export cleanup dialog.
- **Locales**: `candidates.*` keys in `en.json` and `cs.json` (with proper Czech diacritics).

## Test plan

- [x] `pnpm -F @airq/photo-helper test` — 277 passed (26 new, 251 existing).
- [x] `pnpm -F @airq/photo-helper build` — tsc + vite build clean (pre-existing bundle-size warning, tracked in TECH_DEBT.md).
- [ ] Manual smoke (recommended before mark-ready):
  - Drop 30 photos on empty session → all in tray, slots empty.
  - Drag 5 tray thumbs into set1 → labels A–E appear.
  - Drag a slot photo back to tray → label disappears; tray badge shows `★`.
  - Drag a tray thumb onto an occupied slot → swap; old slot photo back in tray.
  - Flag a tray photo as reject → greyed, badge `✗`. Toggle "Hide rejected" → vanishes.
  - Export PDF → only slot photos appear. Dialog offers to delete N candidates.
  - Switch mode track ↔ turningpoint → candidates unchanged; slots swap as today.
  - Refresh page → tray repopulates from OPFS with flags + canvasState intact.

## Out of scope for v1

Compare modal, apply-to-all on candidates, auto-pick suggestions, keyboard shortcuts (P/X/U), per-mode candidate buckets, map-corridors integration. See doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)