### PR TITLE
docs(photo-map-culling): design doc for map-driven photo culling feature

### DIFF
--- a/docs/photo-map-culling/README.md
+++ b/docs/photo-map-culling/README.md
@@ -84,8 +84,6 @@ map-corridors app (decision recorded in [decisions.md](./decisions.md#adr-001-ex
 
 - **HEIC / HEIF support.** iPhone-default format; not supported in v1.
   Documented as a known limitation. ([ADR-006](./decisions.md#adr-006-no-heic-support-in-v1))
-- **Drone XMP / DJI-specific metadata.** Drones not in scope. ([ADR-007](./decisions.md#adr-007-no-drone-xmp-support))
-- **Auto-suggest subject from EXIF heading.** Future enhancement.
 - **Side-by-side compare modal.** Future enhancement.
 - **Time-clustering** ("you took 5 photos in 30s, you probably only need one").
 - **Keyboard shortcuts.**

--- a/docs/photo-map-culling/README.md
+++ b/docs/photo-map-culling/README.md
@@ -1,0 +1,104 @@
+# Photo Map Culling
+
+A map-driven photo culling tool that sits between photo capture and the
+photo editor. Drop a batch of GPS-tagged photos, see them on a map at the
+location they were taken, decide which ones to use, and place a pin at the
+*subject* location (the actual object in the photo). Selections flow
+automatically into both the photo editor (for printing) and the corridor
+checker (for legality / answer sheet generation).
+
+Single biggest workflow win in the competition-prep pipeline.
+
+---
+
+## Status
+
+| | |
+|---|---|
+| Phase | **Design — no code yet** |
+| Branch | `docs/photo-map-culling` |
+| Target app | `frontend/map-corridors` (extended; not a new app) |
+| Depends on | `feat/candidate-photos` merged to `main` |
+| Implementation owner | TBD |
+| Estimated effort (without AI) | ~5–8 working days |
+| First-PR slice | Phase 0 + Phase 1 (types + EXIF pipeline + tests) |
+
+---
+
+## Problem
+
+Today's flow is two unconnected steps:
+
+1. **Cull blind in Explorer.** Organizer shoots 30–100 candidate photos.
+   Picks survivors by filename + thumbnail viewer. No map context. Easy to
+   confuse photos taken near each other.
+2. **Place markers manually.** In map-corridors, organizer clicks the map at
+   each photo's *subject location* by eye. The EXIF already knows roughly
+   where each photo lives — that information is being re-typed by hand.
+
+Both steps are slow, both are error-prone, and they duplicate latent
+geographic information that the camera already captured.
+
+---
+
+## Solution
+
+One tool, one workflow:
+
+```
+        ┌─────────────────────────────────────────────────────┐
+        │ Camera / phone with GPS                             │
+        │ 30–100 photos with EXIF (latitude, longitude, time) │
+        └────────────────────────┬────────────────────────────┘
+                                 │ drag & drop
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│ map-corridors — Photo source mode                                │
+│                                                                  │
+│   • EXIF GPS → dot at capture location                           │
+│   • click dot → thumbnail popup + Include / Skip / Reject        │
+│   • for Include: subject pin appears at capture loc, draggable   │
+│   • drag the pin to where the object actually is                 │
+│   • photos without GPS → dropped along lower map edge by time    │
+│   • assign label (A–T Rally / 1–20 Precision)                    │
+└─────────┬───────────────────────────────────────┬────────────────┘
+          │ chosen photos                         │ same dataset
+          ▼                                       ▼
+┌──────────────────────────────┐    ┌─────────────────────────────────┐
+│ photo-helper (candidate pool)│    │ map-corridors (PhotoMarkers     │
+│  Crop, level, label, PDF     │    │  at subject locations) →        │
+│                              │    │  legality check, answer sheet   │
+└──────────────────────────────┘    └─────────────────────────────────┘
+```
+
+Three apps already share the per-competition OPFS/filesystem directory
+(`competitions/{compId}/`). Adding photos to that directory makes them
+visible everywhere; **no new contract between apps is needed**.
+
+The map tool is not a new app — it's a new **mode** of the existing
+map-corridors app (decision recorded in [decisions.md](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app)).
+
+---
+
+## Out of scope for v1
+
+- **HEIC / HEIF support.** iPhone-default format; not supported in v1.
+  Documented as a known limitation. ([ADR-006](./decisions.md#adr-006-no-heic-support-in-v1))
+- **Drone XMP / DJI-specific metadata.** Drones not in scope. ([ADR-007](./decisions.md#adr-007-no-drone-xmp-support))
+- **Auto-suggest subject from EXIF heading.** Future enhancement.
+- **Side-by-side compare modal.** Future enhancement.
+- **Time-clustering** ("you took 5 photos in 30s, you probably only need one").
+- **Keyboard shortcuts.**
+
+---
+
+## Document map
+
+| File | Purpose |
+|---|---|
+| [README.md](./README.md) | This file. Feature overview + status. |
+| [user-stories.md](./user-stories.md) | What the user wants to do, with acceptance criteria per story. |
+| [decisions.md](./decisions.md) | ADR-style log of every locked design choice and the alternatives considered. |
+| [implementation-plan.md](./implementation-plan.md) | Phased plan with file-level scope, exit criteria, and test focus. |
+
+Read in that order if you're new to the feature.

--- a/docs/photo-map-culling/README.md
+++ b/docs/photo-map-culling/README.md
@@ -7,13 +7,17 @@ location they were taken, decide which ones to use, and place a pin at the
 automatically into both the photo editor (for printing) and the corridor
 checker (for legality / answer sheet generation).
 
-**Implemented as a new "Photo source" mode inside the existing
-`map-corridors` app — not a new app and not an extension of
-`photo-helper`.** That choice (see [ADR-001](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app))
+**Implemented inside the existing `map-corridors` app — not a new app and
+not an extension of `photo-helper`.** That choice (see [ADR-001](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app))
 reuses the map infrastructure already in place (MapLibre + Mapbox via
 `react-map-gl`, token wiring, marker drag, popup, discipline-aware label
 generation, per-competition OPFS dir) instead of duplicating ~3000 LoC
 of map code in a new workspace.
+
+Corridor (KML/GPX) and photo (EXIF) inputs work **side by side** in the
+same view — no mode toggle, no switching. The dropzone routes by file
+extension; the side panel for photos appears when there are photos to
+show. See [ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle).
 
 **Rough workflow time budget (per competition).**
 
@@ -71,9 +75,10 @@ One tool, one workflow:
                                  │ drag & drop
                                  ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│ map-corridors — Photo source mode                                │
+│ map-corridors — single view, corridors + photos coexist          │
 │                                                                  │
-│   • EXIF GPS → dot at capture location                           │
+│   • drop a KML/GPX → corridor renders (today's behaviour)        │
+│   • drop JPEG/PNG → EXIF GPS → dot at capture location           │
 │   • click dot → thumbnail popup + Include / Skip / Reject        │
 │   • for Include: subject pin appears at capture loc, draggable   │
 │   • drag the pin to where the object actually is                 │
@@ -93,8 +98,10 @@ Three apps already share the per-competition OPFS/filesystem directory
 (`competitions/{compId}/`). Adding photos to that directory makes them
 visible everywhere; **no new contract between apps is needed**.
 
-The map tool is not a new app — it's a new **mode** of the existing
-map-corridors app (decision recorded in [decisions.md](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app)).
+The map tool is not a new app — it's an extension of the existing
+map-corridors view (decision recorded in [decisions.md](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app)).
+Corridor checking and photo culling share the same map, the same marker
+array, and the same session file — no mode toggle ([ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle)).
 
 ---
 

--- a/docs/photo-map-culling/README.md
+++ b/docs/photo-map-culling/README.md
@@ -7,7 +7,25 @@ location they were taken, decide which ones to use, and place a pin at the
 automatically into both the photo editor (for printing) and the corridor
 checker (for legality / answer sheet generation).
 
-Single biggest workflow win in the competition-prep pipeline.
+**Implemented as a new "Photo source" mode inside the existing
+`map-corridors` app — not a new app and not an extension of
+`photo-helper`.** That choice (see [ADR-001](./decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app))
+reuses the map infrastructure already in place (MapLibre + Mapbox via
+`react-map-gl`, token wiring, marker drag, popup, discipline-aware label
+generation, per-competition OPFS dir) instead of duplicating ~3000 LoC
+of map code in a new workspace.
+
+**Rough workflow time budget (per competition).**
+
+| Step | Today | After |
+|---|---|---|
+| Cull 30–100 photos | ~2 min/photo (Explorer thumbs + open viewer) | ~15–20 s/photo (drop + click Include) |
+| Place markers in corridor app | ~1 min/photo (re-type by clicking map) | ~10 s/photo (drag pin from capture to subject) |
+| **Total for 60 photos** | **≈ 3 hours** | **≈ 30 minutes** |
+
+These are rough numbers, not measured — point being the order-of-magnitude
+win, not the precise minute count. Single biggest workflow improvement in
+the competition-prep pipeline.
 
 ---
 

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -148,37 +148,96 @@ const tags = await parse(file, {
 
 ---
 
-## ADR-005 — Cross-app handoff via the shared candidate pool
+## ADR-005 — Cross-app handoff via a one-way `map-picks.json` file
 
-**Status:** Accepted
+**Status:** Accepted (revised after design review)
 
 **Context.** Photos selected in the map tool need to appear in
-photo-helper's tray without a manual export/import step.
+photo-helper's candidate tray without a manual export/import step. The
+candidate pool shipped in `feat/candidate-photos` (`ApiPhoto[]` under
+`session.candidates.photos`) is the right *consumer-side* shape. The
+question is who writes to it and how.
 
 **Options.**
 
-1. **Mirror to `session.candidates.photos[]`** on every flag change. The
-   photo-helper tray reads from there as it already does.
-2. **Bespoke handoff format** (e.g., a new `selectedPhotos[]` array in the
-   shared session). photo-helper learns to read both.
-3. **Push at "Send to editor" time** only — batch transfer when user
-   clicks the button.
+1. **Map-corridors writes directly into photo-helper's `session.json`'s
+   `candidates.photos[]`** on every flag change.
+2. **Map-corridors writes a separate `map-picks.json`** with the minimal
+   fields it owns (`photoId`, `filename`, `flag`, `gps`, optional `label`).
+   Photo-helper's competition-load hook reads it on init and on
+   `visibilitychange`, projects each entry into a full `ApiPhoto` with
+   default `canvasState`, and merges into the candidate pool.
+3. **Push at "Send to editor" time** only — batch transfer on click.
 
-**Decision.** Option 1. The candidate pool shipped in
-`feat/candidate-photos` already models exactly this concept (photos in
-selection, with `pick` / `neutral` / `reject` flag). Reuse it.
+**Decision.** Option 2.
+
+**Why Option 1 was rejected after review.**
+
+- `ApiPhoto` is *photo-helper-specific*: it requires `sessionId`, `url`,
+  `label`, and a fully-populated `canvasState` with brightness, contrast,
+  whitebalance, labelPosition, circle, etc. Map-corridors does not own
+  those concepts. Writing them forces map-corridors to fabricate defaults
+  that only photo-helper's hook should own. If photo-helper later adds a
+  required `canvasState` field, the map writer silently produces invalid
+  records.
+- Writing `session.json` directly means map-corridors must round-trip the
+  *entire* photo-helper schema (`mode`, `setsTrack`/`setsTurning`,
+  `version`, `updatedAt`, `competition_name`). Any unknown field added to
+  photo-helper's schema is at risk of being dropped on the next map
+  write.
+- In web mode, the user can open `/photo-helper/` and `/map-corridors/`
+  in two tabs of the same browser; they share the OPFS root. Two
+  concurrent writers to `session.json` with debounce → unbounded
+  read-modify-write race. `@airq/shared-storage` exposes no lock API.
 
 **Consequences.**
 
-- Every flag change in the map tool triggers a debounced write to the
-  photo-helper session JSON. The two writers (map-corridors session +
-  photo-helper session) share the same `competitions/{compId}/` dir and
-  the same `@airq/shared-storage` abstraction; sequential read-modify-write
-  with retry is sufficient (single-window apps).
-- "Send to editor" becomes a pure navigation, not a data transfer — see
+- New file: `competitions/{compId}/map-picks.json`. Schema:
+
+  ```ts
+  type MapPicksFile = {
+    version: 1;
+    updatedAt: string;            // ISO
+    picks: MapPickEntry[];
+  };
+  type MapPickEntry = {
+    photoId: string;              // namespaced — see below
+    filename: string;
+    flag: 'pick' | 'neutral' | 'reject';
+    gps?: {
+      capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string };
+      subjectAt?: { lng: number; lat: number };
+    };
+    label?: PhotoLabel;
+  };
+  ```
+
+- **One writer, one reader per file.** Map-corridors writes
+  `map-picks.json`; photo-helper reads it. Photo-helper never writes
+  back. No file-level lock needed.
+- Photo-helper gets a new lightweight hook `useMapPicksSync`
+  (~50 LoC) that:
+  1. On competition load, reads `map-picks.json`; for each entry not
+     already represented by `photoId` in `session.candidates.photos`,
+     creates an `ApiPhoto` with default `canvasState` and pushes it.
+  2. On `visibilitychange` (tab regained focus), re-reads and merges.
+- "Send to editor" remains a pure navigation; see
   [ADR-009](#adr-009-send-to-editor-navigates-only).
-- Photo-helper does not need any changes to consume the photos — they
-  arrive shaped exactly as the existing candidate pool expects.
+- The earlier framing "photo-helper requires zero code changes" is
+  rescinded. The addition is small but real.
+
+**Photo ID namespace.** Photos imported by map-corridors use a `pm-`
+prefix in their `photoId` (e.g., `pm-1736283921-x9k3`). Photos created
+or dropped directly in photo-helper continue to use today's scheme
+(`photo-${ts}-${rand}` or `crypto.randomUUID()`). This guarantees no
+collision when both apps write into the same
+`competitions/{compId}/photos/` directory, and lets photo-helper's hook
+identify map-origin photos at a glance.
+
+**Future-proofing.** If a third producer ever needs to write picks
+(e.g., a CLI batch tool), `map-picks.json` is the protocol; the file
+owner is the *current* producer, not "the map app forever". The photoID
+namespace makes multi-producer coexistence possible later.
 
 ---
 
@@ -229,9 +288,14 @@ draggable subject pin start?
 
 **Consequences.**
 
-- For photos where the user is OK with capture ≈ subject (rare but
-  possible), zero clicks are needed beyond Include.
+- An aviation photographer flying past a landmark usually captures and
+  subject locations that differ by hundreds of meters — so in practice
+  almost every pick triggers one drag. The "default at capture point"
+  is not a no-drag shortcut; it's a *legible* starting state that
+  makes the dashed-line/ghost-marker UI obvious without a tutorial.
 - The dashed-line indicator only appears once the user drags.
+- Any default other than capture point (e.g., map center) would force
+  every pick to be dragged from a position with no semantic meaning.
 
 ---
 
@@ -262,9 +326,9 @@ Precision?
 
 **Options.**
 
-1. **Navigate only.** Photos already live in the candidate pool (see
-   [ADR-005](#adr-005-cross-app-handoff-via-shared-candidate-pool));
-   button just switches apps.
+1. **Navigate only.** Photos are already represented in `map-picks.json`
+   (see [ADR-005](#adr-005-cross-app-handoff-via-a-one-way-map-picksjson-file));
+   the button just switches apps and photo-helper's hook reads the file.
 2. **Navigate + auto-fill slots.** Promote N picks into the print grid
    slots automatically.
 3. **Navigate + open the candidate tray expanded.**
@@ -274,10 +338,19 @@ job; auto-filling would couple two concerns and hide which photo went where.
 
 **Consequences.**
 
-- The map tool never writes to `session.sets`; only to
-  `session.candidates`.
-- photo-helper opens normally and the user drags from tray to slots as
-  today.
+- The map tool never writes to `session.sets`; it only writes
+  `map-picks.json` (and its own `corridors-session.json` for marker
+  state).
+- photo-helper opens normally; the new `useMapPicksSync` hook
+  pre-populates the candidate tray on load.
+- **Navigation must flush pending writes.** `map-picks.json` writes are
+  debounced (see Phase 8). If the user toggles a flag and immediately
+  clicks "Send to editor", the renderer is torn down by the
+  Electron `loadURL` (or web `window.location.href` set) before the
+  debounce fires — the last toggle is lost. Implementation requirement:
+  on click, `await flushPendingMapPicks()` *before* the navigation call.
+  Equivalently, hook into `beforeunload` / `pagehide` to flush
+  synchronously. Both belt and suspenders are cheap.
 
 ---
 
@@ -334,47 +407,71 @@ parse on every load). Separate files load lazily into popups via
 
 ---
 
-## ADR-012 — No-GPS photo placement strategy: lower viewport edge, capture-time order
+## ADR-012 — No-GPS photo placement: off-map tray pinned to map corner
 
-**Status:** Accepted
+**Status:** Accepted (revised after design review)
 
-**Context.** Some photos arrive without GPS. They still need to be visible
-on the map so the user can drag them to position. Three options:
+**Context.** Some photos arrive without GPS. They still need to be
+visible so the user can drag them to position. The earlier v1 strategy
+(viewport-anchored lower-edge placement) was rejected on review:
 
-**Options.**
+- Markers placed at viewport-anchored lng/lat lie about what
+  `PhotoMarker.lng/lat` means (it should be the subject location, not a
+  fake screen-projected coord).
+- Map pan/zoom does not rearrange the placements, so a no-GPS marker
+  can end up off-screen with no way to find it without the side panel —
+  defeating the "see them on the map" benefit.
+- Multiple no-GPS markers in the same competition pile up at unrelated
+  lng/lat values that have no semantic meaning.
+- The original ADR self-flagged "if it feels off, v2 can pin them to
+  current viewport" — the design owner expected to redo it. Don't ship
+  the version you expect to redo.
 
-1. **Center of the corridor route midpoint** (if corridor loaded) or map
-   center (if not).
-2. **Along the lower edge of the visible map viewport**, ordered
-   left-to-right by EXIF `DateTimeOriginal`.
-3. **Stacked at a fixed off-map "tray" position** like a UI element pinned
-   to the map corner.
+**Options reconsidered.**
 
-**Decision.** Option 2.
+1. **Lower viewport edge, viewport-anchored.** Rejected, above.
+2. **Stacked at corridor route midpoint or map center.** Pile-up problem.
+3. **Off-map tray pinned to a map corner** (e.g., bottom-left dock).
+   Tray holds thumbnails ordered by capture time, each draggable directly
+   *onto* the map.
+
+**Decision.** Option 3.
 
 **Reasoning.**
 
-- Predictable regardless of whether a corridor is loaded.
-- Each photo gets a distinct position; no pile-up that would prevent
-  grabbing.
-- Visible immediately without scrolling.
-- Capture-time ordering is meaningful — neighbouring photos in time are
-  often neighbouring photos on the ground.
+- The semantic is honest: a thumbnail in the tray means "no decided
+  location", not "located at fake-coord-x".
+- Drag-and-drop affordance is clearer than "find the orange dot and
+  drag it".
+- The right-side photo list panel (US-12) covers discoverability; the
+  on-map tray covers the "drag from here onto the map" affordance.
+- `PhotoMarker.lng/lat` only exists for *placed* photos. A no-GPS photo
+  doesn't get a `PhotoMarker` until placed — it lives in
+  `session.candidates` only.
 
 **Consequences.**
 
-- Markers are rendered with viewport-anchored coordinates initially. When
-  the user drags one, it converts to a normal map-anchored pin.
-- "Needs placement" visual: orange/yellow + `?` glyph, no dashed line back
-  to a capture point (no capture point exists).
-- Spacing ~80 px between markers; wrap to a row above if too many to fit
-  in viewport width.
-- Map pan/zoom **does not** rearrange the no-GPS markers — they stay where
-  they were placed (initial viewport coords). User pans to find them if
-  needed. (Trade-off: simple to implement; if it feels off, v2 can pin them
-  to current viewport.)
-- They are also listed in the right-side panel under "No GPS" for
-  discoverability.
+- Drag-end on the map (anywhere) for an in-tray photo → create
+  `PhotoMarker` at the drop coordinate, flag = `pick`, remove from tray.
+- Tray is collapsed/expanded via header click; state persists in
+  `corridors-session.json` field `noGpsTrayOpen: boolean`.
+- Photos in the tray are *not* `PhotoMarker[]` entries — they are
+  candidate-pool entries with no `subjectAt`. This keeps the marker
+  type clean.
+- The earlier proposed `needsPlacement` flag on `PhotoMarker` is
+  removed — no `PhotoMarker` without coordinates exists at all.
+- Drag from tray fires a custom HTML5 drag event with the photoId; the
+  map's drop handler reads the projected lng/lat from the event
+  (`map.unproject([clientX, clientY])`) and creates the marker.
+
+**Edge cases.**
+
+- Tray empties → header dims but tray remains visible. Once empty,
+  collapse to a chevron icon to free map area.
+- User imports more no-GPS photos later → they append to the tray,
+  sorted by capture time.
+- User drags a placed pin back to the tray? Out of scope v1 (single
+  direction: tray → map). Demotion uses the existing Reject flag.
 
 ---
 
@@ -406,12 +503,12 @@ corrupted file, etc.). What's the recovery story?
 
 ---
 
-## ADR-014 — Import throughput: main-thread, throttled at 8 concurrent
+## ADR-014 — Import throughput: main-thread, batched at 8 concurrent
 
 **Status:** Accepted
 
 **Context.** 100 photos × (EXIF read + thumb generation + blob save) is
-non-trivial work. Web Workers would parallelize cleanly but add
+non-trivial work. Web Workers would parallelize CPU cleanly but add
 complexity.
 
 **Options.**
@@ -422,17 +519,53 @@ complexity.
 
 **Decision.** Option 2 for v1.
 
-**Reasoning.** 100 photos at ~150 ms each (typical EXIF + canvas
-downscale) = ~15 s wall-clock, batched 8 wide = ~2 s on modern hardware.
-That's tolerable for a one-time per-competition operation. Worker pool can
-come if it proves slow on real data.
+**Reasoning (honest version).** Per photo: ~30 ms EXIF parse (mostly
+I/O, parallelizes freely) + ~80 ms canvas decode + downscale + JPEG
+encode (CPU, single-threaded JS event loop). For 100 photos: I/O fully
+overlapped, CPU sequential at ~80 ms × 100 ≈ **8 s wall-clock**.
+Batching 8 wide changes peak memory (and bursty I/O), not wall-clock —
+`Promise.all` does not multi-core JavaScript compute. That's tolerable
+for a one-time per-competition operation, with a progress bar to make
+it tolerable to look at.
 
 **Consequences.**
 
-- A progress bar shows N of M during the operation.
-- The UI is responsive but not fully idle — canvas work blocks for tens
-  of ms per photo. Acceptable for v1.
-- If a future profile shows > 30 s on real batches, revisit with workers.
+- Progress bar shows N of M during the operation.
+- UI is responsive between photo bursts but pulses every ~80 ms while
+  a photo is decoding. Acceptable for v1.
+- Concurrency of 8 caps peak in-flight decoded `ImageBitmap`s to
+  protect memory (8 × ~50 MB decoded pixels = ~400 MB peak).
+- If real-world batches exceed 30 s, revisit with `OffscreenCanvas` in
+  a Worker pool — only `OffscreenCanvas` actually lets canvas work
+  multi-thread.
+
+---
+
+## Visual state matrix — flag × GPS presence
+
+This table enumerates every visual state a photo can be in, to keep the
+UI specification and the Phase 4/5 test plans aligned.
+
+| GPS | Flag = `pick`   | Flag = `neutral`     | Flag = `reject`        |
+|---|---|---|---|
+| **With GPS** | Subject pin at `lng/lat`; ghost capture marker + dashed line iff drag has occurred | Small grey capture dot | Red `×` at capture, 40% opacity, hidden when "Hide rejects" is on |
+| **No GPS** | Subject pin at user-dropped `lng/lat`; no capture ghost or dashed line | Thumbnail in the off-map tray ([ADR-012](#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)) | Thumbnail in the off-map tray with a red overlay; same "Hide rejects" filter applies |
+
+The `neutral`-with-GPS state is the on-import default for every photo
+that has GPS. The `neutral`-no-GPS state is "still in the tray, awaiting
+placement". A click on Skip in the popup for a *placed* photo demotes
+its `pick` back to `neutral` and removes the subject pin (keeping the
+capture dot if GPS exists; sending it back to the tray if not).
+
+Click semantics per state:
+
+| Visual | Click action | Right-click |
+|---|---|---|
+| Capture dot (GPS / neutral) | Open popup with thumb + Include/Skip/Reject | Quick label submenu |
+| Subject pin (pick) | Open popup with thumb + label picker + Demote/Reject | Quick label submenu |
+| Red × (reject) | Open popup with Restore | — |
+| Tray thumb (no-GPS / neutral) | Open popup with Reject | Reject |
+| Tray thumb (no-GPS / reject) | Open popup with Restore | Restore |
 
 ---
 
@@ -446,3 +579,91 @@ These are recorded so they're not re-debated during v1 review.
 - **Manual EXIF correction** (overriding GPS for individual photos).
 - **HEIC support.** Revisit if user demand emerges (ADR-006).
 - **Web Workers for import.** ADR-014.
+
+---
+
+## ADR-015 — Apply EXIF orientation via `createImageBitmap`, not manual rotation
+
+**Status:** Accepted
+
+**Context.** Photos can be stored with two conflicting conventions:
+
+- **Already-rotated pixels with `Orientation = 1`** — modern phones,
+  most JPEGs exported from HEIC, social-media output. The image is
+  upright as-is.
+- **Sideways pixels with `Orientation = 6/8`** — older cameras, some
+  raw camera dumps. The image must be rotated for display.
+
+If we manually rotate based on the EXIF Orientation tag, half the
+photos will be double-rotated.
+
+**Decision.** Use `createImageBitmap(file, { imageOrientation: 'from-image' })`
+to decode. The browser handles both conventions per the HTML spec —
+it reads the Orientation tag and produces an upright `ImageBitmap`. We
+then `drawImage` the result onto the thumbnail canvas without any
+manual rotation logic.
+
+**Consequences.**
+
+- `generateThumb` does not need an `orientation` parameter.
+- Test fixtures must include both conventions: one phone-pre-rotated
+  (`Orientation = 1`, already-rotated pixels) and one camera-sideways
+  (`Orientation = 6`).
+- `extractExif` still reads the Orientation tag (for completeness in
+  the data model), but no consumer in v1 uses it.
+- Browser support: shipped in all evergreen browsers since 2021.
+  Electron's Chromium is current; web users on ancient browsers are
+  out of scope.
+
+---
+
+## ADR-016 — Marker rendering split: GeoJSON layer for static dots, individual `<Marker>` for picks
+
+**Status:** Accepted
+
+**Context.** `react-map-gl/mapbox` `<Marker>` is a React-component-
+per-marker pattern. Each instance is a DOM node plus a `move` listener.
+At 50+ markers, pan/zoom performance starts to degrade noticeably; at
+100 it's unacceptable. A competition can easily produce 100 photos.
+
+**Options.**
+
+1. **One `<Marker>` per photo.** Simple, but 100+ markers tank pan
+   performance.
+2. **All markers in a single Mapbox GeoJSON source with `circle` and
+   `symbol` layers.** Fast at any count, but loses individual React
+   component lifecycles — interactions go through `queryRenderedFeatures`.
+3. **Split.** Static markers (capture dots, ghost markers, rejected
+   dots, dashed lines) → GeoJSON layers. Draggable subject pins →
+   individual `<Marker>` components.
+
+**Decision.** Option 3.
+
+**Reasoning.** The vast majority of markers in a session are
+non-draggable (capture dots and rejected markers). Picks are a
+minority (typically 9–20 out of 30–100). Splitting along the
+draggable/static line gives:
+
+- Performant pan/zoom at any photo count.
+- Rich drag UX for the photos that need it.
+- Clean separation of concerns: layer composition for visualization,
+  React component for interaction.
+
+**Consequences.**
+
+- New components: `CaptureDotsLayer`, `DashedLinesLayer`,
+  `RejectedDotsLayer`, `SubjectPin`.
+- Click handling on layers goes through
+  `map.on('click', 'photo-capture-dots', handler)` +
+  `queryRenderedFeatures`.
+- Dashed lines redraw on **drag-end** (not drag-tick) via source-data
+  update.
+- The "Hide rejects" toggle (US-13) becomes a Mapbox paint filter —
+  fast, no DOM churn.
+- Phase 4 of the implementation plan is rescoped accordingly.
+
+**Note on library naming.** The codebase imports from
+`react-map-gl/mapbox` (Mapbox GL), not `maplibre-gl`. Earlier doc
+references to "MapLibre" were imprecise — the existing infrastructure
+uses Mapbox GL via react-map-gl. MapLibre is also in the deps for
+non-Mapbox tile providers but isn't the React-binding entry point.

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -171,24 +171,12 @@ question is who writes to it and how.
 
 **Decision.** Option 2.
 
-**Why Option 1 was rejected after review.**
-
-- `ApiPhoto` is *photo-helper-specific*: it requires `sessionId`, `url`,
-  `label`, and a fully-populated `canvasState` with brightness, contrast,
-  whitebalance, labelPosition, circle, etc. Map-corridors does not own
-  those concepts. Writing them forces map-corridors to fabricate defaults
-  that only photo-helper's hook should own. If photo-helper later adds a
-  required `canvasState` field, the map writer silently produces invalid
-  records.
-- Writing `session.json` directly means map-corridors must round-trip the
-  *entire* photo-helper schema (`mode`, `setsTrack`/`setsTurning`,
-  `version`, `updatedAt`, `competition_name`). Any unknown field added to
-  photo-helper's schema is at risk of being dropped on the next map
-  write.
-- In web mode, the user can open `/photo-helper/` and `/map-corridors/`
-  in two tabs of the same browser; they share the OPFS root. Two
-  concurrent writers to `session.json` with debounce → unbounded
-  read-modify-write race. `@airq/shared-storage` exposes no lock API.
+**Why Option 1 was rejected.** `ApiPhoto` requires fields map-corridors
+doesn't own (`canvasState`, `sessionId`, `url`); direct writing would
+couple the writer to photo-helper's full session schema and race in
+two-tab web mode (shared OPFS, no lock primitive in `@airq/shared-storage`).
+A consumer-side projection is cheaper and keeps both apps' schemas
+independent.
 
 **Consequences.**
 
@@ -197,12 +185,14 @@ question is who writes to it and how.
   ```ts
   type MapPicksFile = {
     version: 1;
+    competitionId: string;        // self-identifying — survives dir moves
     updatedAt: string;            // ISO
     picks: MapPickEntry[];
   };
   type MapPickEntry = {
     photoId: string;              // namespaced — see below
     filename: string;
+    contentHash: string;          // SHA-1, for dedup on re-import (ADR-020)
     flag: 'pick' | 'neutral' | 'reject';
     gps?: {
       capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string };
@@ -345,12 +335,16 @@ job; auto-filling would couple two concerns and hide which photo went where.
   pre-populates the candidate tray on load.
 - **Navigation must flush pending writes.** `map-picks.json` writes are
   debounced (see Phase 8). If the user toggles a flag and immediately
-  clicks "Send to editor", the renderer is torn down by the
-  Electron `loadURL` (or web `window.location.href` set) before the
-  debounce fires — the last toggle is lost. Implementation requirement:
-  on click, `await flushPendingMapPicks()` *before* the navigation call.
-  Equivalently, hook into `beforeunload` / `pagehide` to flush
-  synchronously. Both belt and suspenders are cheap.
+  clicks "Send to editor", the renderer is torn down before the debounce
+  fires — the last toggle is lost. Implementation requirement: on click,
+  `await flushPendingMapPicks()` *before* the navigation call. This is
+  the only reliable path on web (OPFS writes are async; neither
+  `pagehide` nor `beforeunload` can await them). On Electron the
+  same await suffices because IPC is sequential per channel.
+- A `pagehide` listener triggers the same flush as a defence against
+  tab close / back-button. The flush is best-effort there — if it
+  doesn't complete before the page is frozen, the next session sees
+  state from the last successful write.
 
 ---
 
@@ -412,30 +406,14 @@ parse on every load). Separate files load lazily into popups via
 **Status:** Accepted (revised after design review)
 
 **Context.** Some photos arrive without GPS. They still need to be
-visible so the user can drag them to position. The earlier v1 strategy
-(viewport-anchored lower-edge placement) was rejected on review:
+visible so the user can drag them to position. An earlier v1 design
+(viewport-anchored lower-edge placement) was rejected because markers
+anchored to fake screen-projected coords would drift off-screen on pan
+and lie about what `PhotoMarker.lng/lat` means.
 
-- Markers placed at viewport-anchored lng/lat lie about what
-  `PhotoMarker.lng/lat` means (it should be the subject location, not a
-  fake screen-projected coord).
-- Map pan/zoom does not rearrange the placements, so a no-GPS marker
-  can end up off-screen with no way to find it without the side panel —
-  defeating the "see them on the map" benefit.
-- Multiple no-GPS markers in the same competition pile up at unrelated
-  lng/lat values that have no semantic meaning.
-- The original ADR self-flagged "if it feels off, v2 can pin them to
-  current viewport" — the design owner expected to redo it. Don't ship
-  the version you expect to redo.
-
-**Options reconsidered.**
-
-1. **Lower viewport edge, viewport-anchored.** Rejected, above.
-2. **Stacked at corridor route midpoint or map center.** Pile-up problem.
-3. **Off-map tray pinned to a map corner** (e.g., bottom-left dock).
-   Tray holds thumbnails ordered by capture time, each draggable directly
-   *onto* the map.
-
-**Decision.** Option 3.
+**Decision.** Off-map tray pinned to a map corner (bottom-left), holding
+thumbnails ordered by capture time, each draggable directly *onto* the
+map.
 
 **Reasoning.**
 
@@ -519,14 +497,12 @@ complexity.
 
 **Decision.** Option 2 for v1.
 
-**Reasoning (honest version).** Per photo: ~30 ms EXIF parse (mostly
-I/O, parallelizes freely) + ~80 ms canvas decode + downscale + JPEG
-encode (CPU, single-threaded JS event loop). For 100 photos: I/O fully
-overlapped, CPU sequential at ~80 ms × 100 ≈ **8 s wall-clock**.
-Batching 8 wide changes peak memory (and bursty I/O), not wall-clock —
-`Promise.all` does not multi-core JavaScript compute. That's tolerable
-for a one-time per-competition operation, with a progress bar to make
-it tolerable to look at.
+**Reasoning.** Per photo: ~30 ms EXIF parse (mostly I/O, parallelizes
+freely) + ~80 ms canvas decode + downscale + JPEG encode (CPU,
+single-threaded). For 100 photos: I/O overlapped, CPU sequential at
+~80 ms × 100 ≈ **8 s wall-clock**. Batching at 8 wide caps peak memory,
+not wall-clock — `Promise.all` doesn't multi-core JS compute. A progress
+bar makes 8 s tolerable.
 
 **Consequences.**
 
@@ -538,47 +514,6 @@ it tolerable to look at.
 - If real-world batches exceed 30 s, revisit with `OffscreenCanvas` in
   a Worker pool — only `OffscreenCanvas` actually lets canvas work
   multi-thread.
-
----
-
-## Visual state matrix — flag × GPS presence
-
-This table enumerates every visual state a photo can be in, to keep the
-UI specification and the Phase 4/5 test plans aligned.
-
-| GPS | Flag = `pick`   | Flag = `neutral`     | Flag = `reject`        |
-|---|---|---|---|
-| **With GPS** | Subject pin at `lng/lat`; ghost capture marker + dashed line iff drag has occurred | Small grey capture dot | Red `×` at capture, 40% opacity, hidden when "Hide rejects" is on |
-| **No GPS** | Subject pin at user-dropped `lng/lat`; no capture ghost or dashed line | Thumbnail in the off-map tray ([ADR-012](#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)) | Thumbnail in the off-map tray with a red overlay; same "Hide rejects" filter applies |
-
-The `neutral`-with-GPS state is the on-import default for every photo
-that has GPS. The `neutral`-no-GPS state is "still in the tray, awaiting
-placement". A click on Skip in the popup for a *placed* photo demotes
-its `pick` back to `neutral` and removes the subject pin (keeping the
-capture dot if GPS exists; sending it back to the tray if not).
-
-Click semantics per state:
-
-| Visual | Click action | Right-click |
-|---|---|---|
-| Capture dot (GPS / neutral) | Open popup with thumb + Include/Skip/Reject | Quick label submenu |
-| Subject pin (pick) | Open popup with thumb + label picker + Demote/Reject | Quick label submenu |
-| Red × (reject) | Open popup with Restore | — |
-| Tray thumb (no-GPS / neutral) | Open popup with Reject | Reject |
-| Tray thumb (no-GPS / reject) | Open popup with Restore | Restore |
-
----
-
-## Decisions explicitly deferred to v2
-
-These are recorded so they're not re-debated during v1 review.
-
-- **Side-by-side compare modal.** Out of scope.
-- **Time-cluster suggestion** ("photos taken within 30 s — pick best").
-- **Keyboard shortcuts** (I/S/R, ←/→).
-- **Manual EXIF correction** (overriding GPS for individual photos).
-- **HEIC support.** Revisit if user demand emerges (ADR-006).
-- **Web Workers for import.** ADR-014.
 
 ---
 
@@ -656,14 +591,214 @@ draggable/static line gives:
 - Click handling on layers goes through
   `map.on('click', 'photo-capture-dots', handler)` +
   `queryRenderedFeatures`.
-- Dashed lines redraw on **drag-end** (not drag-tick) via source-data
-  update.
 - The "Hide rejects" toggle (US-13) becomes a Mapbox paint filter —
   fast, no DOM churn.
 - Phase 4 of the implementation plan is rescoped accordingly.
 
-**Note on library naming.** The codebase imports from
-`react-map-gl/mapbox` (Mapbox GL), not `maplibre-gl`. Earlier doc
-references to "MapLibre" were imprecise — the existing infrastructure
-uses Mapbox GL via react-map-gl. MapLibre is also in the deps for
-non-Mapbox tile providers but isn't the React-binding entry point.
+**Note on library naming.** Photo layers use whichever map engine
+`MapProviderView` is mounted on (currently `mapbox-gl` via
+`react-map-gl/mapbox` — confirmed at `MapProviderView.tsx` line 2).
+The workspace also ships `maplibre-gl` and `@vis.gl/react-maplibre`
+for non-Mapbox tile providers; if a future engine swap lands, GeoJSON
+`circle` / `line` paint expressions are spec-compatible across both
+renderers. **The new GeoJSON layers are purely additive** — existing
+KML-clicked corridor markers continue to render as individual
+`<Marker>` components unchanged, so the corridor flow has no
+regression surface.
+
+---
+
+## ADR-017 — `flag` lives in `map-picks.json` only, denormalized to GeoJSON properties at render time
+
+**Status:** Accepted
+
+**Context.** The visual `flag` (`pick` / `neutral` / `reject`) needs to
+be (a) persisted so it survives reload, and (b) available to the Mapbox
+paint expressions on the static-dot GeoJSON layers so the right colour
+renders without a per-feature DOM update.
+
+The naive choice would be: store `flag` on `PhotoMarker` (in
+`corridors-session.json`) *and* on `MapPickEntry` (in `map-picks.json`).
+That duplicates the data, and every flag toggle writes both files.
+`corridors-session.json` includes markers + geojson + leftSegments + …
+— at 100 photos it can be hundreds of KB. Writing the whole blob on
+every keystroke is a write storm.
+
+**Decision.** `flag` lives **only** in `map-picks.json`. `PhotoMarker`
+does **not** carry a flag field.
+
+For rendering, App.tsx maintains an in-memory `Map<photoId, flag>` fed
+by the latest `map-picks.json` state, and **denormalizes** the flag
+into the GeoJSON feature properties when building the source data
+passed to `CaptureDotsLayer` / `RejectedDotsLayer`. The Mapbox paint
+expression matches on `feature.properties.flag` exactly as it would
+have if the flag were persisted on the marker.
+
+**Consequences.**
+
+- One write per flag toggle (just `map-picks.json`).
+- Source data for static layers is rebuilt when the in-memory flag map
+  changes, which is cheap (a Map lookup per feature) and only fires
+  when something the user did changed state.
+- `PhotoMarker` stays minimal: `id`, `lng`, `lat`, `name`, `label?`,
+  `capturedAt?`, `photoId?`. No state-machine field.
+- Photos without an entry in `map-picks.json` default to flag `neutral`
+  at render time.
+- Removes the consistency invariant that a duplicated `flag` field
+  would otherwise force the code to maintain by hand.
+
+---
+
+## ADR-018 — OPFS quota: hard pre-flight gate, soft warning band
+
+**Status:** Accepted
+
+**Context.** A 100-photo competition is ~500 MB of original blobs +
+~5 MB of thumbs. Web browsers grant OPFS quota of roughly 60% of free
+disk with no warning before eviction. Once eviction starts, partial
+deletes leave a session that points at gone files. Today's only
+mechanism is the `isStorageLow` warning, which fires *after* the user
+has already imported.
+
+**Options.**
+
+1. Warn only (today's behaviour). User can blunder past it and lose data.
+2. **Hard pre-flight gate**: before a bulk import, sum estimated bytes
+   and call `getStorageEstimate()`. If `usage + estimated > 0.8 * quota`,
+   block the drop with a modal that shows the deficit. If `usage +
+   estimated > 0.5 * quota`, warn but allow.
+3. Throttle: split the import into smaller batches and check after each.
+
+**Decision.** Option 2. Hard pre-flight gate at 0.8 of quota; soft
+warning band at 0.5.
+
+**Consequences.**
+
+- New helper `await checkQuotaForImport(estimatedBytes): { ok: true } | { ok: false; deficitBytes; usage; quota }`.
+- The modal at the blocked state offers two actions: "Free space"
+  (links to the existing storage-management UI) and "Cancel".
+- The warning state is a non-blocking toast with the bytes/quota
+  delta visible.
+- Per-photo size estimate uses `file.size + 25 KB` (the thumb).
+  Slightly over-estimates so we don't push past quota under
+  measurement error.
+- Electron filesystem has no quota; the gate is a no-op there but the
+  same code path runs (it just always returns `{ ok: true }` for
+  Electron's storage backend).
+
+---
+
+## ADR-019 — `useMapPicksSync` upsert semantics, delete propagation
+
+**Status:** Accepted
+
+**Context.** Round 1 spec'd `useMapPicksSync` as "for each entry not
+already in `existingPhotoIds`, push into the candidate pool". That
+covers the *initial* import case but breaks for:
+
+- A photo flag changes in map-corridors after photo-helper has already
+  loaded the entry. The hook re-reads `map-picks.json` on
+  `visibilitychange` but `existingPhotoIds.has(photoId)` is true, so
+  nothing happens. Photo-helper's tray shows a stale flag.
+- A photo is deleted in map-corridors (entry removed from `map-picks.json`).
+  Photo-helper still has it in its candidate pool — no clean-up.
+
+**Decision.** Upsert + delete.
+
+- **On read:** for every entry in `map-picks.json`:
+  - If `photoId` not in pool → insert (today's behaviour).
+  - If `photoId` in pool and origin is map (`pm-` prefix) → **update**
+    the flag and any other map-owned fields. Do not touch
+    `canvasState`, `label`, or any photo-helper-owned fields.
+- **On read:** for every `pm-`-prefixed `photoId` *in* the pool but
+  *not* in `map-picks.json` → **remove from the pool** (clean-up).
+  Photos without the `pm-` prefix (photo-helper-originated) are
+  untouched.
+
+**Consequences.**
+
+- Flag changes propagate within one focus cycle.
+- Deletes propagate cleanly.
+- The `pm-` namespace becomes load-bearing for "is it safe to remove?"
+  decisions — the prefix is the policy boundary.
+- The hook is still ~50 LoC; just an upsert + a set-difference instead
+  of a one-shot insert.
+
+---
+
+## ADR-020 — Photo re-import: skip duplicates by content hash
+
+**Status:** Accepted
+
+**Context.** User drops a folder of photos, then later drops the same
+folder again (perhaps after re-organising files outside the app, or
+re-dragging the wrong set). What happens?
+
+**Options.**
+
+1. **Overwrite** by `photoId` — but photoIds are generated fresh on
+   import, so a re-import produces new IDs. Doesn't help.
+2. **Detect duplicate by filename + size** — fast but fragile (same
+   filename can wrap different content; size is a weak signal).
+3. **Detect duplicate by content hash** (SHA-1 of the file bytes) —
+   robust; cost is one file read per imported photo, parallel with
+   EXIF parse.
+4. **Always import as new** with fresh photoId — disk fills, user
+   confusion at duplicate thumbs.
+
+**Decision.** Option 3. Compute a content hash during import and key
+deduplication on it.
+
+**Consequences.**
+
+- `MapPickEntry` gains a `contentHash: string` field for fast
+  duplicate checks across batches.
+- On import: for each file, compute SHA-1; if `contentHash` matches an
+  existing `MapPickEntry`, skip with toast "N photos already imported,
+  M new".
+- Hash compute is ~10 ms per 5 MB JPEG via `crypto.subtle.digest` —
+  fully overlapped with EXIF + thumb work.
+- The toast offers an "Import as duplicate anyway" override for the
+  edge case where the same content is needed twice (rare).
+
+---
+
+## Visual state matrix — flag × GPS presence
+
+This table enumerates every visual state a photo can be in, to keep the
+UI specification and the Phase 4/5 test plans aligned.
+
+| GPS | Flag = `pick`   | Flag = `neutral`     | Flag = `reject`        |
+|---|---|---|---|
+| **With GPS** | Subject pin at `lng/lat`; ghost capture marker + dashed line iff drag has occurred | Small grey capture dot | Red `×` at capture, 40% opacity, hidden when "Hide rejects" is on |
+| **No GPS** | Subject pin at user-dropped `lng/lat`; no capture ghost or dashed line | Thumbnail in the off-map tray ([ADR-012](#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)) | Thumbnail in the off-map tray with a red overlay; same "Hide rejects" filter applies |
+
+The `neutral`-with-GPS state is the on-import default for every photo
+that has GPS. The `neutral`-no-GPS state is "still in the tray, awaiting
+placement". A click on Skip in the popup for a *placed* photo demotes
+its `pick` back to `neutral` and removes the subject pin (keeping the
+capture dot if GPS exists; sending it back to the tray if not).
+
+Click semantics per state:
+
+| Visual | Click action | Right-click |
+|---|---|---|
+| Capture dot (GPS / neutral) | Open popup with thumb + Include/Skip/Reject | Quick label submenu |
+| Subject pin (pick) | Open popup with thumb + label picker + Demote/Reject | Quick label submenu |
+| Red × (reject) | Open popup with Restore | — |
+| Tray thumb (no-GPS / neutral) | Open popup with Reject | Reject |
+| Tray thumb (no-GPS / reject) | Open popup with Restore | Restore |
+
+---
+
+## Decisions explicitly deferred to v2
+
+These are recorded so they're not re-debated during v1 review.
+
+- **Side-by-side compare modal.** Out of scope.
+- **Time-cluster suggestion** ("photos taken within 30 s — pick best").
+- **Keyboard shortcuts** (I/S/R, ←/→).
+- **Manual EXIF correction** (overriding GPS for individual photos).
+- **HEIC support.** Revisit if user demand emerges (ADR-006).
+- **Web Workers for import.** ADR-014.
+

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -35,7 +35,7 @@ wiring, a new launcher tile, a new icon, and a new build target.
 
 - map-corridors becomes "the map app", not strictly "the corridor app". The
   user-facing label `Photo Placement` / `Umístění fotek` already fits both
-  flows (see [ADR-011](#adr-011-no-rename-photo-placement--umístění-fotek-stays)).
+  flows (see [ADR-010](#adr-010-no-rename-photo-placement--umístění-fotek-stays)).
 - A new `Photo source` mode toggle ships in the map-corridors header.
 - The internal package name `@airq/map-corridors` is **not** renamed —
   doing so would touch every workspace dependency, the desktop launcher's
@@ -133,7 +133,7 @@ map-corridors (already carries MapLibre + Mapbox + react-map-gl).
 import { gps, parse } from 'exifr/dist/lite.esm.mjs';
 const gpsCoords = await gps(file);
 const tags = await parse(file, {
-  pick: ['DateTimeOriginal', 'GPSAltitude', 'GPSImgDirection', 'Orientation'],
+  pick: ['DateTimeOriginal', 'GPSAltitude', 'Orientation'],
 });
 ```
 
@@ -176,7 +176,7 @@ selection, with `pick` / `neutral` / `reject` flag). Reuse it.
   the same `@airq/shared-storage` abstraction; sequential read-modify-write
   with retry is sufficient (single-window apps).
 - "Send to editor" becomes a pure navigation, not a data transfer — see
-  [ADR-010](#adr-010-send-to-editor-navigates-only).
+  [ADR-009](#adr-009-send-to-editor-navigates-only).
 - Photo-helper does not need any changes to consume the photos — they
   arrive shaped exactly as the existing candidate pool expects.
 
@@ -210,25 +210,7 @@ this user base; the 600 KB cost is not justified by usage.
 
 ---
 
-## ADR-007 — No drone XMP support
-
-**Status:** Accepted
-
-**Context.** Drone photos (DJI especially) embed gimbal yaw / pitch in XMP
-metadata, which could be used to auto-suggest subject offset direction.
-
-**Decision.** Drones are not part of the competition photography workflow.
-Not supported. The `capturedAt.heading` field exists in the data model for
-future-proofing only; nothing reads it in v1.
-
-**Consequences.**
-
-- No XMP parsing added to the EXIF pipeline.
-- No bearing arrow on map markers in v1.
-
----
-
-## ADR-008 — Default subject pin position: at the capture point
+## ADR-007 — Default subject pin position: at the capture point
 
 **Status:** Accepted
 
@@ -253,7 +235,7 @@ draggable subject pin start?
 
 ---
 
-## ADR-009 — Discipline support: both Rally and Precision
+## ADR-008 — Discipline support: both Rally and Precision
 
 **Status:** Accepted
 
@@ -272,7 +254,7 @@ Precision?
 
 ---
 
-## ADR-010 — "Send to editor" navigates only
+## ADR-009 — "Send to editor" navigates only
 
 **Status:** Accepted
 
@@ -299,7 +281,7 @@ job; auto-filling would couple two concerns and hide which photo went where.
 
 ---
 
-## ADR-011 — No rename. "Photo Placement" / "Umístění fotek" stays
+## ADR-010 — No rename. "Photo Placement" / "Umístění fotek" stays
 
 **Status:** Accepted
 
@@ -319,7 +301,7 @@ package name `@airq/map-corridors`. No rename.
 
 ---
 
-## ADR-012 — Thumbnail storage in `photos/thumbs/`
+## ADR-011 — Thumbnail storage in `photos/thumbs/`
 
 **Status:** Accepted
 
@@ -352,7 +334,7 @@ parse on every load). Separate files load lazily into popups via
 
 ---
 
-## ADR-013 — No-GPS photo placement strategy: lower viewport edge, capture-time order
+## ADR-012 — No-GPS photo placement strategy: lower viewport edge, capture-time order
 
 **Status:** Accepted
 
@@ -396,7 +378,7 @@ on the map so the user can drag them to position. Three options:
 
 ---
 
-## ADR-014 — Atomic per-photo import (no partial-batch state)
+## ADR-013 — Atomic per-photo import (no partial-batch state)
 
 **Status:** Accepted
 
@@ -424,7 +406,7 @@ corrupted file, etc.). What's the recovery story?
 
 ---
 
-## ADR-015 — Import throughput: main-thread, throttled at 8 concurrent
+## ADR-014 — Import throughput: main-thread, throttled at 8 concurrent
 
 **Status:** Accepted
 
@@ -460,10 +442,7 @@ These are recorded so they're not re-debated during v1 review.
 
 - **Side-by-side compare modal.** Out of scope.
 - **Time-cluster suggestion** ("photos taken within 30 s — pick best").
-- **Auto-suggest subject from heading.** Needs `capturedAt.heading` data,
-  which is captured but not consumed in v1.
 - **Keyboard shortcuts** (I/S/R, ←/→).
 - **Manual EXIF correction** (overriding GPS for individual photos).
 - **HEIC support.** Revisit if user demand emerges (ADR-006).
-- **Drone XMP / gimbal yaw.** ADR-007.
-- **Web Workers for import.** ADR-015.
+- **Web Workers for import.** ADR-014.

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -22,8 +22,9 @@ wiring, a new launcher tile, a new icon, and a new build target.
 
 **Options.**
 
-1. **Extend `map-corridors`** with a new "Photo source" mode. Single mode
-   toggle in the existing UI.
+1. **Extend `map-corridors`** so its dropzone and marker layer accept
+   both KML/GPX (corridor) and JPEG/PNG (photos), side by side in the
+   same view (see [ADR-021](#adr-021--implicit-dropzone-routing-no-mode-toggle)).
 2. **Extend `photo-helper`** with a map tab. Pulls MapLibre into a canvas
    editor that today has zero map dependencies.
 3. **New sub-app** `photo-scout` (or similar). Standalone Vite package +
@@ -36,7 +37,8 @@ wiring, a new launcher tile, a new icon, and a new build target.
 - map-corridors becomes "the map app", not strictly "the corridor app". The
   user-facing label `Photo Placement` / `Umístění fotek` already fits both
   flows (see [ADR-010](#adr-010-no-rename-photo-placement--umístění-fotek-stays)).
-- A new `Photo source` mode toggle ships in the map-corridors header.
+- The dropzone, marker layers, and side panel all support photo inputs
+  alongside the existing corridor inputs — no mode toggle ([ADR-021](#adr-021--implicit-dropzone-routing-no-mode-toggle)).
 - The internal package name `@airq/map-corridors` is **not** renamed —
   doing so would touch every workspace dependency, the desktop launcher's
   protocol handler, and the build pipeline for ~zero user benefit.
@@ -46,7 +48,7 @@ wiring, a new launcher tile, a new icon, and a new build target.
 
 ## ADR-002 — Explicit mode toggle
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-021](#adr-021--implicit-dropzone-routing-no-mode-toggle)
 
 **Context.** The dropzone needs to accept either KML/GPX (corridor mode) or
 JPEG/PNG (photo mode). It could auto-route by file MIME type silently, or
@@ -60,15 +62,11 @@ expose an explicit mode toggle.
    map header. The toggle disambiguates UX (panels, tooltips, defaults) that
    depend on which source the user is working with.
 
-**Decision.** Option 2 for v1.
+**Decision.** Option 2 for v1. — **Superseded.** See ADR-021 — the user wants
+corridor and photo to work together without switching, which makes the toggle
+a friction point rather than a clarification.
 
-**Consequences.**
-
-- One chip pair in the map header: `Corridor` / `Photo`.
-- The right-side panel content varies by mode (photo list in photo mode;
-  nothing or corridor info in corridor mode).
-- Toggle state persists in the corridor session JSON.
-- v2 may revisit auto-routing once we see which mode dominates.
+**Consequences.** (no longer in effect)
 
 ---
 
@@ -293,8 +291,8 @@ draggable subject pin start?
 
 **Status:** Accepted
 
-**Context.** Should photo mode be enabled only for Rally, or both Rally and
-Precision?
+**Context.** Should photo culling be enabled only for Rally, or both Rally
+and Precision?
 
 **Decision.** Both. Label generation is already discipline-aware
 (`@airq/shared-discipline`); reuse it as-is.
@@ -760,6 +758,59 @@ deduplication on it.
   fully overlapped with EXIF + thumb work.
 - The toast offers an "Import as duplicate anyway" override for the
   edge case where the same content is needed twice (rare).
+
+---
+
+## ADR-021 — Implicit dropzone routing (no mode toggle)
+
+**Status:** Accepted (supersedes [ADR-002](#adr-002--explicit-mode-toggle))
+
+**Context.** ADR-002 introduced an explicit `Corridor / Photo` mode toggle.
+On reflection, the toggle conflicts with the actual user mental model:
+corridor checking and photo culling are part of one workflow ("place
+markers inside the corridor"), not two separate apps inside the same app.
+Forcing the user to pick a mode before they can drop a file is friction
+without information gain — the file extension already disambiguates.
+
+The data model in [ADR-003](#adr-003--photomarker-keeps-single-canonical-position--optional-capturedat)
+and the simultaneous-rendering criterion in [US-9](./user-stories.md#us-9--corridor-and-photo-work-coexist-on-one-map)
+already say corridor markers and EXIF-derived photo markers coexist on the
+same `markers[]` array. The toggle adds nothing to that coexistence; it
+only gates which dropzone handler runs on the next drop.
+
+**Options.**
+
+1. **Implicit routing** — single dropzone accepts everything; file type
+   determines which pipeline runs. No mode UI.
+2. **Keep the toggle** (ADR-002 as-is).
+3. **Auto-select toggle by recent activity** — toggle exists but switches
+   itself based on the last dropped file type.
+
+**Decision.** Option 1.
+
+**Consequences.**
+
+- No `Corridor / Photo` chip in the map header.
+- No `sourceMode: 'corridor' | 'photo'` field on `CorridorsSession`. No
+  `setSourceMode` setter.
+- The dropzone accepts both `.kml`/`.gpx` and `.jpg`/`.jpeg`/`.png`.
+  Routing happens after drop, by file extension (with MIME-type fallback
+  for safety). Mixed-batch drops are supported — KMLs go to the corridor
+  parser, JPEGs to `importPhotoFiles`.
+- The photo list side panel appears when there is ≥ 1 imported photo, and
+  hides when there are none. Corridor-related controls stay always-visible
+  (they're already part of map-corridors' baseline UI). No conditional
+  panel toggling based on a mode.
+- The HEIC reject error toast ([ADR-006](#adr-006--no-heic-support-in-v1))
+  fires on drop regardless of any prior file activity.
+- Wrong-file-type messaging changes: instead of "KML in photo mode, switch
+  sources" (a mode-aware message), it's just "Unsupported file: foo.bin"
+  for genuinely unsupported types — KML in any state is welcome, JPEG in
+  any state is welcome.
+- One fewer commit in Phase 3 (no toggle component); the photo dropzone
+  routing folds into the existing dropzone handler.
+- `noGpsTrayOpen` is unaffected — its visibility is data-driven (open iff
+  the no-GPS bucket is non-empty by default), not mode-driven.
 
 ---
 

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -1,0 +1,469 @@
+# Architecture Decision Records — Photo Map Culling
+
+Each ADR captures one locked design decision. Status is **Accepted** unless
+otherwise noted. Format follows the lightweight ADR template (context →
+options → decision → consequences).
+
+When implementation reveals an ADR is wrong, update its status to
+**Superseded** and add a new ADR underneath rather than rewriting history.
+
+---
+
+## ADR-001 — Extend map-corridors rather than build a new app
+
+**Status:** Accepted
+
+**Context.** The new tool needs a map, photo-on-map markers, drag, popup,
+discipline-aware label generation, KML/GPX awareness, OPFS persistence, and
+a competition-aware launcher entry. map-corridors already has every one of
+those. photo-helper has none. A third app would mean a fourth workspace
+package, a second copy of `react-map-gl` + MapLibre + Mapbox + token
+wiring, a new launcher tile, a new icon, and a new build target.
+
+**Options.**
+
+1. **Extend `map-corridors`** with a new "Photo source" mode. Single mode
+   toggle in the existing UI.
+2. **Extend `photo-helper`** with a map tab. Pulls MapLibre into a canvas
+   editor that today has zero map dependencies.
+3. **New sub-app** `photo-scout` (or similar). Standalone Vite package +
+   launcher tile.
+
+**Decision.** Option 1. Extend `map-corridors`.
+
+**Consequences.**
+
+- map-corridors becomes "the map app", not strictly "the corridor app". The
+  user-facing label `Photo Placement` / `Umístění fotek` already fits both
+  flows (see [ADR-011](#adr-011-no-rename-photo-placement--umístění-fotek-stays)).
+- A new `Photo source` mode toggle ships in the map-corridors header.
+- The internal package name `@airq/map-corridors` is **not** renamed —
+  doing so would touch every workspace dependency, the desktop launcher's
+  protocol handler, and the build pipeline for ~zero user benefit.
+- Subsequent ADRs assume Option 1 as the baseline.
+
+---
+
+## ADR-002 — Explicit mode toggle
+
+**Status:** Accepted
+
+**Context.** The dropzone needs to accept either KML/GPX (corridor mode) or
+JPEG/PNG (photo mode). It could auto-route by file MIME type silently, or
+expose an explicit mode toggle.
+
+**Options.**
+
+1. **Implicit routing** — sniff file type on drop, branch internally. No
+   visible UI for the mode.
+2. **Explicit mode toggle** — segmented control / chip at the top of the
+   map header. The toggle disambiguates UX (panels, tooltips, defaults) that
+   depend on which source the user is working with.
+
+**Decision.** Option 2 for v1.
+
+**Consequences.**
+
+- One chip pair in the map header: `Corridor` / `Photo`.
+- The right-side panel content varies by mode (photo list in photo mode;
+  nothing or corridor info in corridor mode).
+- Toggle state persists in the corridor session JSON.
+- v2 may revisit auto-routing once we see which mode dominates.
+
+---
+
+## ADR-003 — PhotoMarker keeps single canonical position + optional `capturedAt`
+
+**Status:** Accepted
+
+**Context.** Two coordinates per photo:
+1. **Capture location** — where the camera was when the photo was taken
+   (from EXIF GPS).
+2. **Subject location** — where the *object* in the photo actually is
+   (user-placed, the legally-relevant coordinate for corridor checks).
+
+The data model could be:
+
+**Options.**
+
+1. **Single `lng/lat` field, optional `capturedAt: { lng, lat, … }`
+   metadata.** The single field always means "subject location". For
+   EXIF-imported photos, `capturedAt` is populated; the subject starts at
+   the same coordinates and may diverge after drag.
+2. **Two equal fields:** `subject: { lng, lat }` and `captured: { lng, lat }`,
+   both required for EXIF photos.
+3. **Discriminated union** of `KmlMarker` (one position) and `PhotoMarker`
+   (two positions).
+
+**Decision.** Option 1.
+
+**Consequences.**
+
+- Zero migration of existing logic in `MapProviderView`, the corridor
+  legality check, or the answer-sheet exporter — they all read `lng/lat`
+  unchanged, which still means "subject".
+- `capturedAt` is opt-in metadata. KML/GPX-clicked markers leave it
+  undefined.
+- The dashed-line + ghost-marker UI key is `marker.capturedAt !== undefined
+  && marker.capturedAt.lng !== marker.lng` (or lat).
+- See full type in [implementation-plan.md → Phase 0](./implementation-plan.md#phase-0--foundation-types--dependencies).
+
+---
+
+## ADR-004 — EXIF library: `exifr` (lite build)
+
+**Status:** Accepted
+
+**Context.** Browser-side EXIF extraction from JPEG. Need GPS lat/lng,
+timestamp, orientation, optionally altitude. Bundle size matters for
+map-corridors (already carries MapLibre + Mapbox + react-map-gl).
+
+**Options.**
+
+| Library | Min+gz | GPS API | HEIC | Maintained |
+|---|---|---|---|---|
+| `exifr` (lite) | ~9 KB | `gps()` helper | yes | yes |
+| `piexifjs` | ~20 KB | manual DMS → DD | no | yes |
+| `exif-js` | ~14 KB | manual | no | abandoned 2019 |
+| `browser-image-compression` (with EXIF preserve) | ~50 KB | indirect | partial | yes |
+
+**Decision.** `exifr` lite build. Import only what's used:
+
+```ts
+import { gps, parse } from 'exifr/dist/lite.esm.mjs';
+const gpsCoords = await gps(file);
+const tags = await parse(file, {
+  pick: ['DateTimeOriginal', 'GPSAltitude', 'GPSImgDirection', 'Orientation'],
+});
+```
+
+**Consequences.**
+
+- Adds ~9 KB gzipped to map-corridors bundle.
+- HEIC tag extraction works but display does not — see
+  [ADR-006](#adr-006-no-heic-support-in-v1).
+- Tree-shake verified via Vite build report after install.
+- Library is added to `frontend/map-corridors/package.json` with an exact
+  pinned version (no caret), per the global dependency-pinning rule.
+
+---
+
+## ADR-005 — Cross-app handoff via the shared candidate pool
+
+**Status:** Accepted
+
+**Context.** Photos selected in the map tool need to appear in
+photo-helper's tray without a manual export/import step.
+
+**Options.**
+
+1. **Mirror to `session.candidates.photos[]`** on every flag change. The
+   photo-helper tray reads from there as it already does.
+2. **Bespoke handoff format** (e.g., a new `selectedPhotos[]` array in the
+   shared session). photo-helper learns to read both.
+3. **Push at "Send to editor" time** only — batch transfer when user
+   clicks the button.
+
+**Decision.** Option 1. The candidate pool shipped in
+`feat/candidate-photos` already models exactly this concept (photos in
+selection, with `pick` / `neutral` / `reject` flag). Reuse it.
+
+**Consequences.**
+
+- Every flag change in the map tool triggers a debounced write to the
+  photo-helper session JSON. The two writers (map-corridors session +
+  photo-helper session) share the same `competitions/{compId}/` dir and
+  the same `@airq/shared-storage` abstraction; sequential read-modify-write
+  with retry is sufficient (single-window apps).
+- "Send to editor" becomes a pure navigation, not a data transfer — see
+  [ADR-010](#adr-010-send-to-editor-navigates-only).
+- Photo-helper does not need any changes to consume the photos — they
+  arrive shaped exactly as the existing candidate pool expects.
+
+---
+
+## ADR-006 — No HEIC support in v1
+
+**Status:** Accepted
+
+**Context.** iPhones default to HEIC/HEIF capture. EXIF parsing works fine
+with `exifr` for HEIC. **Display** of HEIC in non-Safari browsers requires
+a decoder (`heic2any` ≈ 600 KB) or extraction of the embedded JPEG
+thumbnail.
+
+**Options.**
+
+1. **Ship HEIC support** via `heic2any` or thumbnail extraction.
+2. **No HEIC support in v1.** Document as known limitation. Reject HEIC
+   files at import time with a friendly error.
+
+**Decision.** Option 2. User-confirmed: iPhone capture is not expected for
+this user base; the 600 KB cost is not justified by usage.
+
+**Consequences.**
+
+- Drag-dropping a `.heic` / `.heif` file shows a toast: "HEIC not supported.
+  Please convert to JPEG (iPhone: Settings → Camera → Formats → Most
+  Compatible)."
+- en + cs locales include this message.
+- A future ADR will revisit if user feedback shows demand.
+
+---
+
+## ADR-007 — No drone XMP support
+
+**Status:** Accepted
+
+**Context.** Drone photos (DJI especially) embed gimbal yaw / pitch in XMP
+metadata, which could be used to auto-suggest subject offset direction.
+
+**Decision.** Drones are not part of the competition photography workflow.
+Not supported. The `capturedAt.heading` field exists in the data model for
+future-proofing only; nothing reads it in v1.
+
+**Consequences.**
+
+- No XMP parsing added to the EXIF pipeline.
+- No bearing arrow on map markers in v1.
+
+---
+
+## ADR-008 — Default subject pin position: at the capture point
+
+**Status:** Accepted
+
+**Context.** When a user clicks Include on a photo, where should the
+draggable subject pin start?
+
+**Options.**
+
+1. **At the capture point.** Pin and ghost marker overlap; dashed line is
+   zero-length until user drags.
+2. **Centered on the map.** Forces an explicit drag-to-place gesture.
+3. **At a small offset from capture** (e.g., 50 m north). Hint that
+   subject is somewhere nearby.
+
+**Decision.** Option 1. User-confirmed.
+
+**Consequences.**
+
+- For photos where the user is OK with capture ≈ subject (rare but
+  possible), zero clicks are needed beyond Include.
+- The dashed-line indicator only appears once the user drags.
+
+---
+
+## ADR-009 — Discipline support: both Rally and Precision
+
+**Status:** Accepted
+
+**Context.** Should photo mode be enabled only for Rally, or both Rally and
+Precision?
+
+**Decision.** Both. Label generation is already discipline-aware
+(`@airq/shared-discipline`); reuse it as-is.
+
+**Consequences.**
+
+- Rally photos get labels A–T (max 20).
+- Precision photos get labels 1–20 (max 20).
+- The label picker renders the correct alphabet based on the active
+  competition's `discipline`.
+
+---
+
+## ADR-010 — "Send to editor" navigates only
+
+**Status:** Accepted
+
+**Context.** When the user clicks "Send to editor (N picks)", what happens?
+
+**Options.**
+
+1. **Navigate only.** Photos already live in the candidate pool (see
+   [ADR-005](#adr-005-cross-app-handoff-via-shared-candidate-pool));
+   button just switches apps.
+2. **Navigate + auto-fill slots.** Promote N picks into the print grid
+   slots automatically.
+3. **Navigate + open the candidate tray expanded.**
+
+**Decision.** Option 1. User-confirmed. Slot assignment is the editor's
+job; auto-filling would couple two concerns and hide which photo went where.
+
+**Consequences.**
+
+- The map tool never writes to `session.sets`; only to
+  `session.candidates`.
+- photo-helper opens normally and the user drags from tray to slots as
+  today.
+
+---
+
+## ADR-011 — No rename. "Photo Placement" / "Umístění fotek" stays
+
+**Status:** Accepted
+
+**Context.** Once map-corridors hosts both KML-driven and photo-driven
+flows, the original name "MapCorridors" feels narrow. The desktop launcher
+already labels this app **Photo Placement** / **Umístění fotek** (per
+`TODO.md` — Done 2026-03-27).
+
+**Decision.** Keep the existing user-facing label. Keep the internal
+package name `@airq/map-corridors`. No rename.
+
+**Consequences.**
+
+- No churn in workspace deps, launcher entries, protocol handlers.
+- "Photo Placement" semantically covers both KML-corridor placement and
+  EXIF-photo placement.
+
+---
+
+## ADR-012 — Thumbnail storage in `photos/thumbs/`
+
+**Status:** Accepted
+
+**Context.** Map popups need fast preview. Original photos are 4–10 MB
+each; loading 50 of them for popups is unacceptable. A pre-computed
+thumbnail per photo solves it.
+
+**Options.**
+
+1. **Inline data URL in PhotoMarker.** Persisted in `corridors-session.json`.
+2. **Separate `photos/thumbs/{photoId}.jpg` directory** in the competition
+   dir, alongside the original photos.
+
+**Decision.** Option 2.
+
+**Reasoning.** Inline data URLs balloon the session JSON (a 50 KB JPEG
+becomes ~67 KB base64 per photo; 100 photos × 67 KB = 6.7 MB JSON to
+parse on every load). Separate files load lazily into popups via
+`storage.getPhotoBlob()` and benefit from any caching layer.
+
+**Consequences.**
+
+- New subdirectory `competitions/{compId}/photos/thumbs/` materializes on
+  first import.
+- Thumb is generated once at import via canvas + `pica` downscale to
+  ~200×150 JPEG quality 0.7. Approximate size: 15–25 KB each.
+- Storage adds ~2 MB per competition for 100 photos (negligible).
+- Thumb generation is part of the import pipeline; failure to generate a
+  thumb degrades to "show filename" but does not block import.
+
+---
+
+## ADR-013 — No-GPS photo placement strategy: lower viewport edge, capture-time order
+
+**Status:** Accepted
+
+**Context.** Some photos arrive without GPS. They still need to be visible
+on the map so the user can drag them to position. Three options:
+
+**Options.**
+
+1. **Center of the corridor route midpoint** (if corridor loaded) or map
+   center (if not).
+2. **Along the lower edge of the visible map viewport**, ordered
+   left-to-right by EXIF `DateTimeOriginal`.
+3. **Stacked at a fixed off-map "tray" position** like a UI element pinned
+   to the map corner.
+
+**Decision.** Option 2.
+
+**Reasoning.**
+
+- Predictable regardless of whether a corridor is loaded.
+- Each photo gets a distinct position; no pile-up that would prevent
+  grabbing.
+- Visible immediately without scrolling.
+- Capture-time ordering is meaningful — neighbouring photos in time are
+  often neighbouring photos on the ground.
+
+**Consequences.**
+
+- Markers are rendered with viewport-anchored coordinates initially. When
+  the user drags one, it converts to a normal map-anchored pin.
+- "Needs placement" visual: orange/yellow + `?` glyph, no dashed line back
+  to a capture point (no capture point exists).
+- Spacing ~80 px between markers; wrap to a row above if too many to fit
+  in viewport width.
+- Map pan/zoom **does not** rearrange the no-GPS markers — they stay where
+  they were placed (initial viewport coords). User pans to find them if
+  needed. (Trade-off: simple to implement; if it feels off, v2 can pin them
+  to current viewport.)
+- They are also listed in the right-side panel under "No GPS" for
+  discoverability.
+
+---
+
+## ADR-014 — Atomic per-photo import (no partial-batch state)
+
+**Status:** Accepted
+
+**Context.** A 50-photo import might fail mid-way (storage error,
+corrupted file, etc.). What's the recovery story?
+
+**Options.**
+
+1. **All-or-nothing batch.** Roll back all writes if any fails.
+2. **Per-photo atomic.** Each photo's import is independent: EXIF →
+   thumbnail → blob save → marker creation. If photo 23 fails, photos 1–22
+   are kept; photo 23 reports in an error list.
+
+**Decision.** Option 2.
+
+**Consequences.**
+
+- Import returns a result shape `{ ok: PhotoMarker[]; failed: { file: string; reason: string }[] }`.
+- A toast surfaces the failure count after import: "47 imported, 3
+  failed (see details)".
+- A details modal lists failure reasons (e.g., "RIMG0172.JPG: invalid
+  JPEG").
+- Failed files do not pollute storage with half-written blobs (the save
+  step is the last step in the per-photo pipeline).
+
+---
+
+## ADR-015 — Import throughput: main-thread, throttled at 8 concurrent
+
+**Status:** Accepted
+
+**Context.** 100 photos × (EXIF read + thumb generation + blob save) is
+non-trivial work. Web Workers would parallelize cleanly but add
+complexity.
+
+**Options.**
+
+1. **Web Worker pool.** Send each file to a worker for EXIF + decode +
+   thumb; main thread does storage writes.
+2. **Main-thread with `Promise.all` over batches of 8.**
+
+**Decision.** Option 2 for v1.
+
+**Reasoning.** 100 photos at ~150 ms each (typical EXIF + canvas
+downscale) = ~15 s wall-clock, batched 8 wide = ~2 s on modern hardware.
+That's tolerable for a one-time per-competition operation. Worker pool can
+come if it proves slow on real data.
+
+**Consequences.**
+
+- A progress bar shows N of M during the operation.
+- The UI is responsive but not fully idle — canvas work blocks for tens
+  of ms per photo. Acceptable for v1.
+- If a future profile shows > 30 s on real batches, revisit with workers.
+
+---
+
+## Decisions explicitly deferred to v2
+
+These are recorded so they're not re-debated during v1 review.
+
+- **Side-by-side compare modal.** Out of scope.
+- **Time-cluster suggestion** ("photos taken within 30 s — pick best").
+- **Auto-suggest subject from heading.** Needs `capturedAt.heading` data,
+  which is captured but not consumed in v1.
+- **Keyboard shortcuts** (I/S/R, ←/→).
+- **Manual EXIF correction** (overriding GPS for individual photos).
+- **HEIC support.** Revisit if user demand emerges (ADR-006).
+- **Drone XMP / gimbal yaw.** ADR-007.
+- **Web Workers for import.** ADR-015.

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -107,11 +107,11 @@ change.
   the default `pnpm test` so CI is not forced to install a Chromium
   download. Pin exact versions if/when adopted.
 - `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` — extend
-  `CorridorsSession` with `sourceMode: 'corridor' | 'photo'` (default
-  `'corridor'`) and `noGpsTrayOpen: boolean` (default `true`). Expose
-  `setSourceMode` and `setNoGpsTrayOpen` setters from the hook,
-  mirroring the existing `setMarkers` pattern. **Note on the existing
-  `version` field**: it is a per-mutation write counter
+  `CorridorsSession` with `noGpsTrayOpen: boolean` (default `true`).
+  Expose `setNoGpsTrayOpen` setter from the hook, mirroring the existing
+  `setMarkers` pattern. **No `sourceMode` field** — see [ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle):
+  corridor and photo coexist by default, no mode persisted. **Note on the
+  existing `version` field**: it is a per-mutation write counter
   (`session.version + 1` on every persist), not a schema version.
   Backwards compatibility for pre-feature sessions relies on
   `sanitizePhotoMarkers` (extended above) ignoring missing fields,
@@ -267,29 +267,37 @@ helper.
 
 ---
 
-## Phase 3 — Mode toggle + photo dropzone in map-corridors
+## Phase 3 — Photo dropzone routing in map-corridors
 
-**Scope.** Add the visible `Corridor / Photo` chip to the map header. Wire
-the dropzone to accept JPEG/PNG in photo mode. Run `importPhotoFiles` and
-write to storage. Persist mode in corridor session JSON.
+**Scope.** Extend the existing dropzone to also accept JPEG/PNG. Route
+each dropped file by extension: KML/GPX → existing corridor parser; JPEG/
+PNG → `importPhotoFiles`. Run the import pipeline, write blobs/thumbs to
+storage, mirror picks to `map-picks.json`. No mode UI (see [ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle)).
 
 **Files touched.**
 
-- `frontend/map-corridors/src/components/SourceModeToggle.tsx` *(new)* —
-  MUI `ToggleButtonGroup` with two options. Persists to session.
-- `frontend/map-corridors/src/App.tsx` — mount toggle, branch dropzone
-  behaviour.
-- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` — add
-  `sourceMode: 'corridor' | 'photo'` field to `CorridorsSession`.
-- `frontend/map-corridors/src/locales/en.json` + `cs.json` — strings.
+- `frontend/map-corridors/src/App.tsx` — extend dropzone `accept` to
+  include image MIME types and `.jpg`/`.jpeg`/`.png` extensions. Add
+  per-file routing branch in the drop handler: `parsers/detect.ts` for
+  KML/GPX, `importPhotoFiles` for images. Mixed-batch drops are split
+  by extension and each branch runs independently.
+- `frontend/map-corridors/src/locales/en.json` + `cs.json` — strings
+  for the unsupported-file toast ("Unsupported file: {name}") and import
+  progress.
 
 **Exit criteria.**
 
-- Toggle renders correctly in light theme (matches existing chrome).
-- Dropping a `.kml` file in photo mode shows a friendly toast: "KML is for
-  Corridor mode — switch sources to import a corridor."
-- Dropping `.jpg` in photo mode → import pipeline runs, progress visible.
-- Mode survives reload.
+- Dropping a `.kml` continues to work exactly as it does today (no
+  regression on the corridor flow).
+- Dropping a `.jpg` triggers `importPhotoFiles`; progress visible for
+  batches > 10.
+- Dropping a mixed batch (1 KML + 30 JPEGs) parses the KML and imports
+  the photos in parallel — both end states reflected on the map.
+- Dropping an unsupported file (`.txt`, `.bin`) surfaces a toast naming
+  the file. No silent failures.
+- No mode chip rendered. The header looks identical to today's
+  map-corridors chrome aside from any panel-presence reactions from
+  Phase 6 (right-side photo list when there are photos).
 
 ---
 
@@ -316,8 +324,9 @@ remain individual `<Marker>` components.
 - `frontend/map-corridors/src/map/photoLayers/SubjectPin.tsx` *(new)* —
   individual draggable `<Marker>` per pick.
 - `frontend/map-corridors/src/map/MapProviderView.tsx` — mount these
-  layers in photo mode; preserve existing corridor-marker rendering for
-  KML/GPX flow.
+  layers whenever the markers array contains photo-derived entries
+  (`marker.photoId !== undefined`); existing corridor-marker rendering
+  for KML/GPX flow is unchanged and runs in parallel.
 
 **Paint expressions (sketch).**
 
@@ -443,8 +452,9 @@ flag. Two-way sync with the map.
 - `frontend/map-corridors/src/components/PhotoListPanel.tsx` *(new)*.
   MUI list grouped by `pick` / `neutral` / `reject` / `no-gps`. Group
   headers show counts; collapsible.
-- `frontend/map-corridors/src/App.tsx` — mount panel in photo mode;
-  hidden in corridor mode.
+- `frontend/map-corridors/src/App.tsx` — mount panel iff the markers
+  array contains at least one photo-derived entry (`marker.photoId !==
+  undefined`); auto-hides when there are no photos.
 
 **Acceptance (manual).**
 
@@ -671,8 +681,9 @@ edge cases. Move PR out of draft.
 
 1. Open desktop launcher, create a new competition "Smoke Test", select
    discipline Rally.
-2. Open Photo Placement → switch to Photo source mode.
-3. Drop 30 JPEGs with GPS → 30 dots appear, map fits bounds.
+2. Open Photo Placement.
+3. Drop 30 JPEGs with GPS → 30 dots appear, map fits bounds, photo
+   side panel appears.
 4. Drop 5 more JPEGs without GPS → 5 orange `?` markers along bottom.
 5. Click a GPS dot → popup with thumb. Click Include → becomes pin at
    capture point. Drag pin 100 m away → dashed line + ghost marker
@@ -693,10 +704,10 @@ edge cases. Move PR out of draft.
 14. Drop a `.heic` file → friendly error toast.
 15. Drop a corrupt `.jpg` → it appears in the failure list, import does
     not abort.
-16. Fresh install, no Mapbox token configured → photo mode surfaces
-    the token-config CTA prominently. After dismissing, photo mode
-    still works with the OSM fallback (or shows a clear "configure
-    a map provider" empty state if no fallback ships).
+16. Fresh install, no Mapbox token configured → after dropping photos,
+    the token-config CTA surfaces prominently. After dismissing, photo
+    rendering still works with the OSM fallback (or shows a clear
+    "configure a map provider" empty state if no fallback ships).
 17. Re-import the same folder a second time → "N photos already
     imported, M new" toast; no duplicate thumbs in the right-side panel.
 
@@ -767,7 +778,7 @@ propagation).
 |---|---|---|
 | `exifr` bundle larger than expected | MED | Phase 0 measures actual contribution and records in PR. Soft target ≤ 15 KB gz; if > 25 KB, switch to a manual GPS-only parser (~5 lines). |
 | `pica` added but bloats map-corridors bundle | LOW | v1 starts without `pica` — plain canvas downscale to 200×150 is adequate for popup thumbs. Only add if Phase 1 measurement shows visible quality regression. |
-| Mapbox token not configured on first app open | MED | Photo source mode is useless without a map. Surface the token-config CTA prominently when entering photo mode without a token. Fallback to OpenStreetMap raster tile (no token needed) — see [Open question](#open-implementation-questions). |
+| Mapbox token not configured on first app open | MED | Photo culling is useless without a map. Surface the token-config CTA prominently when the user has imported photos but no token is set. Fallback to OpenStreetMap raster tile (no token needed) — see [Open question](#open-implementation-questions). |
 | User accidentally clicks "Send to editor" with 0 picks | LOW | Button disabled when picks = 0. |
 | Coordinate precision at high zoom (sub-meter) | LOW | float64 throughout. The existing `dragMovedPxRef` click-vs-drag threshold of 8 px (≈ 1.2 m at zoom 19) is shared by all marker types in `MapProviderView`; do not lower it globally. If photo-mode subject pins prove to misclassify drag-as-click, add a per-marker threshold prop rather than changing the default. |
 | Browser drag-and-drop quirks on Windows | LOW | Already exercised by existing dropzone code. Reuse `react-dropzone`. |

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -1,0 +1,586 @@
+# Implementation Plan — Photo Map Culling
+
+This plan turns the decisions in [decisions.md](./decisions.md) into ordered
+phases with file-level scope. Each phase has explicit exit criteria so it
+can be reviewed and merged on its own (or all phases can ship as one PR —
+see [Delivery shape](#delivery-shape)).
+
+The plan assumes `feat/candidate-photos` has merged to `main` before
+implementation starts — the candidate pool is the handoff foundation
+([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool)).
+
+---
+
+## Delivery shape
+
+**Recommended:** one feature branch `feat/photo-map-culling`, ordered
+commits per phase, **draft** PR opened after Phase 1. Mark ready for review
+when Phase 9 completes. Squash on merge.
+
+The first commit-worthy slice is **Phase 0 + Phase 1** (types + EXIF
+pipeline + unit tests). Pure data side, zero UI risk, validates the
+foundation. Subsequent phases layer UI on a proven base.
+
+---
+
+## Pre-flight checklist
+
+Before opening the branch:
+
+- [ ] `feat/candidate-photos` is merged to `main`.
+- [ ] The candidate pool's persistence works end-to-end (manual smoke).
+- [ ] `frontend/photo-helper/src/types/api.ts` defines `CandidatePool`
+      and `ApiPhoto.flag` as expected.
+- [ ] `exifr` latest version checked on npm; note exact version for the
+      install (no caret, per global dependency-pinning rule).
+- [ ] Sample test photos available: 1× JPEG with GPS, 1× JPEG without GPS,
+      1× JPEG with bad orientation, 1× HEIC (for the reject path),
+      1× corrupt JPEG.
+
+---
+
+## Phase 0 — Foundation: types + dependencies
+
+**Scope.** Add the new types and install the EXIF library. No behaviour
+change.
+
+**Files touched.**
+
+- `frontend/map-corridors/src/types/markers.ts` — extend `PhotoMarker`:
+  ```ts
+  export type PhotoMarker = {
+    id: string;
+    lng: number;
+    lat: number;
+    name: string;
+    label?: PhotoLabel;
+    capturedAt?: {
+      lng: number;
+      lat: number;
+      altitude?: number;
+      heading?: number;
+      timestamp?: string;
+    };
+    photoId?: string;
+    needsPlacement?: boolean;
+  };
+  ```
+- `frontend/photo-helper/src/types/api.ts` — extend `ApiPhoto`:
+  ```ts
+  export interface ApiPhoto {
+    // ...existing fields
+    gps?: {
+      capturedAt?: { lng: number; lat: number; altitude?: number; heading?: number };
+      subjectAt?: { lng: number; lat: number };
+      timestamp?: string;
+    };
+  }
+  ```
+- `frontend/map-corridors/package.json` — add `exifr` (exact version).
+- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` —
+  bump session JSON schema version + add migration shim that defaults the
+  new fields to `undefined` on load.
+
+**Exit criteria.**
+
+- TypeScript compiles in both `map-corridors` and `photo-helper`.
+- `pnpm --filter @airq/map-corridors build` and
+  `pnpm --filter @airq/photo-helper build` succeed.
+- Existing corridor session JSONs from before the change load without
+  errors (schema migration path exercised).
+
+**Test focus.**
+
+- Unit test: load a v1 corridors-session.json (without new fields) →
+  PhotoMarker array reads fine, `capturedAt` is undefined.
+
+---
+
+## Phase 1 — EXIF + thumbnail pipeline (pure module)
+
+**Scope.** A standalone module that takes File objects and produces
+`{ photoId, exifGps, thumbnailBlob, originalBlob, failed }`. Pure
+domain logic — no UI, no map, no storage. Fully unit-testable.
+
+**New files.**
+
+- `frontend/map-corridors/src/photoImport/extractExif.ts`
+  ```ts
+  export type ExifData = {
+    capturedAt?: { lng: number; lat: number; altitude?: number; heading?: number };
+    timestamp?: string;
+    orientation?: number;
+  };
+  export async function extractExif(file: File): Promise<ExifData>;
+  ```
+- `frontend/map-corridors/src/photoImport/generateThumb.ts`
+  ```ts
+  export async function generateThumb(
+    file: File,
+    opts?: { maxWidth?: number; maxHeight?: number; quality?: number; orientation?: number }
+  ): Promise<Blob>;
+  ```
+  Uses canvas + `pica` (already in workspace via photo-helper; verify
+  tree-shake). Honours the EXIF orientation tag so the popup shows
+  upright.
+- `frontend/map-corridors/src/photoImport/types.ts`
+  ```ts
+  export type ImportedPhoto = {
+    photoId: string;
+    file: File;
+    thumbnail: Blob;
+    exif: ExifData;
+  };
+  export type ImportResult = {
+    ok: ImportedPhoto[];
+    failed: { filename: string; reason: string }[];
+  };
+  ```
+- `frontend/map-corridors/src/photoImport/importPhotoFiles.ts`
+  ```ts
+  export async function importPhotoFiles(
+    files: File[],
+    opts?: { concurrency?: number; onProgress?: (done: number, total: number) => void }
+  ): Promise<ImportResult>;
+  ```
+  Orchestrates: filter HEIC (reject with reason), filter non-image MIME
+  types, generate `photoId`, run extractExif + generateThumb per file with
+  `Promise.all` in batches of 8 ([ADR-015](./decisions.md#adr-015-import-throughput-main-thread-throttled-at-8-concurrent)).
+
+**Exit criteria.**
+
+- 95%+ unit test coverage on the pipeline.
+- All edge cases covered: GPS present, GPS absent, GPS `(0,0)` (treated as
+  absent), bad orientation tag (canvas correction verified), HEIC rejected
+  with reason, corrupt JPEG → failure list.
+- Mock fixture set checked into `frontend/map-corridors/test/fixtures/`.
+
+**Test focus.**
+
+```
+extractExif.test.ts
+  ✓ extracts lat/lng from JPEG with GPS
+  ✓ returns capturedAt: undefined for JPEG without GPS
+  ✓ treats (0,0) GPS as absent
+  ✓ returns timestamp from DateTimeOriginal in ISO format
+  ✓ returns orientation tag
+
+generateThumb.test.ts
+  ✓ produces JPEG at most 200×150 px
+  ✓ rotates 90/180/270 based on orientation tag
+  ✓ quality 0.7 produces < 30 KB for typical 4 MP input
+
+importPhotoFiles.test.ts
+  ✓ runs in parallel batches of 8
+  ✓ surfaces per-file progress
+  ✓ collects failures without aborting the batch
+  ✓ rejects HEIC at the top
+  ✓ rejects non-image MIME types
+```
+
+---
+
+## Phase 2 — Storage layer: thumbnails + photo blob writes
+
+**Scope.** Wire the import result into the shared storage abstraction.
+Write blobs and thumbs into `competitions/{compId}/photos/` and
+`competitions/{compId}/photos/thumbs/`. Surface a `getPhotoThumbBlob`
+helper.
+
+**Files touched.**
+
+- `frontend/shared-storage/src/types.ts` — add to `StorageInterface`:
+  ```ts
+  savePhotoThumb(photosDir: DirectoryHandle, photoId: string, blob: Blob): Promise<void>;
+  getPhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<Blob | null>;
+  deletePhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<void>;
+  ```
+  These call into `getDirectoryHandle('thumbs', { create: true })` and
+  operate on files named `{photoId}.jpg`.
+- `frontend/shared-storage/src/opfsStorage.ts` — implement.
+- `frontend/shared-storage/src/electronStorage.ts` — implement via the
+  existing IPC channels, adding a new `storage-save-thumb` etc. handler in
+  `frontend/desktop/main.js`.
+- `frontend/desktop/preload.js` — expose the new IPC.
+
+**Exit criteria.**
+
+- Round-trip test: write thumb → read thumb → matches.
+- `competitions/{compId}/photos/thumbs/` directory materializes on first
+  thumb save.
+- Deleting a photo also deletes its thumb (existing
+  `deleteSessionDir` already nukes the parent; verify thumb cleanup on
+  individual `deletePhotoFile`).
+
+---
+
+## Phase 3 — Mode toggle + photo dropzone in map-corridors
+
+**Scope.** Add the visible `Corridor / Photo` chip to the map header. Wire
+the dropzone to accept JPEG/PNG in photo mode. Run `importPhotoFiles` and
+write to storage. Persist mode in corridor session JSON.
+
+**Files touched.**
+
+- `frontend/map-corridors/src/components/SourceModeToggle.tsx` *(new)* —
+  MUI `ToggleButtonGroup` with two options. Persists to session.
+- `frontend/map-corridors/src/App.tsx` — mount toggle, branch dropzone
+  behaviour.
+- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` — add
+  `sourceMode: 'corridor' | 'photo'` field to `CorridorsSession`.
+- `frontend/map-corridors/src/locales/en.json` + `cs.json` — strings.
+
+**Exit criteria.**
+
+- Toggle renders correctly in light theme (matches existing chrome).
+- Dropping a `.kml` file in photo mode shows a friendly toast: "KML is for
+  Corridor mode — switch sources to import a corridor."
+- Dropping `.jpg` in photo mode → import pipeline runs, progress visible.
+- Mode survives reload.
+
+---
+
+## Phase 4 — Marker rendering: capture/subject distinction
+
+**Scope.** Extend `MapProviderView` to render capture-vs-subject markers
+correctly. Three marker visual states ([decisions.md §UI](./decisions.md)):
+
+- **Capture-only** (no flag yet): small grey dot at `capturedAt`.
+- **Picked** (flag = `pick`): coloured pin at `lng/lat`, ghost marker at
+  `capturedAt` with dashed line between (when they differ).
+- **Rejected** (flag = `reject`): red ✗ with 40% opacity.
+- **Needs placement** (no GPS): orange `?` glyph at viewport-anchored coord.
+
+**Files touched.**
+
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — extend marker
+  rendering loop (currently lines 332-375). Add a helper:
+  ```tsx
+  function renderPhotoMarker(marker: PhotoMarker): ReactNode {
+    if (marker.needsPlacement) return <NeedsPlacementMarker {...} />;
+    const hasCapture = marker.capturedAt !== undefined;
+    const flag = lookupFlag(marker.id);
+    if (flag === 'reject') return <RejectedDot ... />;
+    if (flag === 'pick') return (
+      <>
+        <SubjectPin draggable onDragEnd={...} />
+        {hasCapture && capturedDiffers(marker) && (
+          <>
+            <CaptureGhostMarker />
+            <DashedLine from={marker.capturedAt} to={marker} />
+          </>
+        )}
+      </>
+    );
+    return <CaptureDot />;
+  }
+  ```
+- `frontend/map-corridors/src/map/markers/` *(new directory)* — small
+  presentational components: `CaptureDot`, `CaptureGhostMarker`,
+  `SubjectPin`, `RejectedDot`, `NeedsPlacementMarker`, `DashedLine`
+  (rendered via a tiny GeoJSON layer).
+
+**Exit criteria.**
+
+- All four visual states render correctly with sample data.
+- Dragging a `SubjectPin` updates `marker.lng/lat` (not `capturedAt`).
+- Dashed line redraws on every drag tick (or on drag-end, depending on
+  performance).
+- Clicking a marker still opens the popup (Phase 5).
+
+---
+
+## Phase 5 — Photo popup with thumbnail and actions
+
+**Scope.** Replace / extend the existing marker popup. Show thumbnail,
+filename, timestamp, label picker, and the three action buttons.
+
+**Files touched.**
+
+- `frontend/map-corridors/src/components/PhotoMarkerPopup.tsx` *(new)* —
+  pulls thumbnail via `storage.getPhotoThumb`, renders MUI card UI.
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — wire the popup
+  for photo-mode markers (existing popup unchanged for corridor markers).
+- `frontend/map-corridors/src/locales/*.json` — action labels.
+
+**Acceptance (manual).**
+
+- Hover capture dot → small 80×60 tooltip preview.
+- Click capture dot → popup with 200×150 thumb + filename + timestamp +
+  Include / Skip / Reject.
+- Click Include on a no-flag photo → becomes pick, popup closes (or
+  refreshes to show the label picker).
+- Esc closes the popup.
+
+---
+
+## Phase 6 — No-GPS placement strategy
+
+**Scope.** Implement [ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy):
+photos without GPS arrive in a row along the bottom of the viewport,
+ordered by capture time.
+
+**New / touched files.**
+
+- `frontend/map-corridors/src/photoImport/placeNoGpsPhotos.ts` *(new)*:
+  ```ts
+  export function placeNoGpsPhotos(
+    photos: ImportedPhoto[],
+    viewport: { bounds: [[number, number], [number, number]]; width: number; height: number },
+    opts?: { spacingPx?: number; bottomMarginPx?: number }
+  ): Array<{ photoId: string; lng: number; lat: number }>;
+  ```
+  Pure function. Sorts by `exif.timestamp` (fallback: filename
+  alphabetical). Computes lng/lat for each photo from the viewport bounds
+  + a screen-space offset (so they appear ~`bottomMarginPx` from the
+  bottom edge, `spacingPx` apart horizontally). Wraps to a second row
+  above if total width exceeds viewport width.
+- `frontend/map-corridors/src/App.tsx` — call `placeNoGpsPhotos` for
+  photos that come back from `importPhotoFiles` with no `exif.capturedAt`,
+  set `marker.needsPlacement = true`, and place at the computed coords.
+  Then add to `markers[]` as PhotoMarkers.
+
+**Exit criteria.**
+
+- Drop a batch of 5 photos with no GPS → all visible along the bottom of
+  the map, ordered by capture time.
+- Each marker is independently draggable; on first drag, `needsPlacement`
+  flips to `false` and the marker behaves like a normal subject pin.
+- Side panel "No GPS" section lists the same photos with a `?` indicator.
+
+---
+
+## Phase 7 — Right-side photo list panel
+
+**Scope.** A panel beside the map listing all imported photos, grouped by
+flag. Two-way sync with the map.
+
+**New / touched files.**
+
+- `frontend/map-corridors/src/components/PhotoListPanel.tsx` *(new)*.
+  MUI list grouped by `pick` / `neutral` / `reject` / `no-gps`. Group
+  headers show counts; collapsible.
+- `frontend/map-corridors/src/App.tsx` — mount panel in photo mode;
+  hidden in corridor mode.
+
+**Acceptance (manual).**
+
+- All photos appear in their correct group.
+- Clicking an item → map flies to the photo's marker and opens its popup.
+- Group counts update live as flags change.
+- Panel collapses to a drawer on narrow screens.
+
+---
+
+## Phase 8 — Cross-app handoff: candidate pool mirror
+
+**Scope.** Implement [ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool).
+Every flag change in the map tool writes to
+`session.candidates.photos[]` in the photo-helper session JSON.
+
+**New / touched files.**
+
+- `frontend/map-corridors/src/handoff/candidatePoolMirror.ts` *(new)*:
+  ```ts
+  export async function syncToCandidatePool(
+    storage: StorageInterface,
+    competitionDir: DirectoryHandle,
+    markers: PhotoMarker[],
+    flags: Record<string, CandidateFlag>
+  ): Promise<void>;
+  ```
+  Reads photo-helper's `session.json`, replaces `candidates.photos` with
+  the photo-mode selection, writes back. Debounced; idempotent.
+- `frontend/map-corridors/src/App.tsx` — call `syncToCandidatePool` on
+  every flag change (debounced 300 ms).
+
+**Exit criteria.**
+
+- Set a flag in map tool → open photo-helper after debounce flush →
+  candidate tray reflects the flag.
+- Set a flag in photo-helper → photo-helper writes back to its own
+  session; map tool reads back on next focus (or via a periodic poll —
+  TBD; simplest is "stale until user toggles").
+- No corrupted JSON under rapid flag changes (debounce + sequential
+  write).
+- Photo IDs match between the two sessions (same `photoId` key).
+
+---
+
+## Phase 9 — Send-to-editor button
+
+**Scope.** A button at the bottom of the photo list panel: "Send to editor
+(N picks)". Navigates only ([ADR-010](./decisions.md#adr-010-send-to-editor-navigates-only)).
+
+**Files touched.**
+
+- `frontend/map-corridors/src/components/PhotoListPanel.tsx` — button.
+- `frontend/desktop/preload.js` — already exposes `navigateToApp`.
+- `frontend/map-corridors/src/App.tsx` — wire `onClick` to
+  `electronAPI?.navigateToApp('photo-helper', { competitionId })` for
+  Electron, or `window.location.href = '/photo-helper/?competitionId=…'`
+  for web.
+
+**Exit criteria.**
+
+- Button disabled when 0 picks; live count in label.
+- Click → app switches; candidate tray pre-populated.
+
+---
+
+## Phase 10 — Locales (en + cs) + a11y polish
+
+**Scope.** All visible strings localized. Czech uses proper diacritics.
+
+**Files touched.**
+
+- `frontend/map-corridors/src/locales/en.json`
+- `frontend/map-corridors/src/locales/cs.json`
+
+**Keys to add (illustrative):**
+
+```
+photo.source.modeToggle.corridor    "Corridor (KML/GPX)" / "Trať (KML/GPX)"
+photo.source.modeToggle.photo       "Photo (EXIF GPS)"   / "Fotky (EXIF GPS)"
+photo.import.dropHere               "Drop photos here, or"
+photo.import.addButton              "Add photos"
+photo.import.progress               "Importing {{done}} of {{total}}…"
+photo.import.heicRejected           "HEIC not supported. Convert to JPEG."
+photo.action.include                "Include" / "Vybrat"
+photo.action.skip                   "Skip" / "Přeskočit"
+photo.action.reject                 "Reject" / "Zamítnout"
+photo.hideRejects                   "Hide rejects" / "Skrýt zamítnuté"
+photo.list.groupPicks               "Picks" / "Vybrané"
+photo.list.groupNeutral             "Neutral" / "Neutrální"
+photo.list.groupRejects             "Rejects" / "Zamítnuté"
+photo.list.groupNoGps               "No GPS" / "Bez GPS"
+photo.sendToEditor                  "Send to editor ({{count}})" / "Otevřít v editoru ({{count}})"
+photo.needsPlacement                "Drag to place" / "Přetáhněte na pozici"
+```
+
+**Exit criteria.**
+
+- All strings rendered via `t()`.
+- No hard-coded English in the new components.
+- Czech text uses proper diacritics (verified by reviewer).
+- Keyboard navigation: Tab through the popup actions; Esc closes popup.
+- Focus visible on all interactive elements.
+
+---
+
+## Phase 11 — Manual smoke + bug bash + PR
+
+**Scope.** End-to-end manual run-through against a real photo batch. Fix
+edge cases. Move PR out of draft.
+
+**Smoke script.**
+
+1. Open desktop launcher, create a new competition "Smoke Test", select
+   discipline Rally.
+2. Open Photo Placement → switch to Photo source mode.
+3. Drop 30 JPEGs with GPS → 30 dots appear, map fits bounds.
+4. Drop 5 more JPEGs without GPS → 5 orange `?` markers along bottom.
+5. Click a GPS dot → popup with thumb. Click Include → becomes pin at
+   capture point. Drag pin 100 m away → dashed line + ghost marker
+   appear.
+6. Assign label A.
+7. Click a no-GPS marker → drag to corridor → orange disappears, becomes
+   normal pin.
+8. Reject 3 photos. Toggle "Hide rejects" → red dots disappear.
+9. Open right-side panel → verify counts: 1 pick / 4 neutral / 3 rejects /
+   4 no-GPS.
+10. Click "Send to editor (1)" → photo-helper opens, candidate tray
+    contains the 1 pick.
+11. Drag tray photo into slot A → label persists.
+12. Return to Photo Placement → photo is still flagged pick, in slot A in
+    photo-helper. Drag it back to tray in photo-helper → flag becomes
+    pick in map tool after reload (or via mirror).
+13. Reload the app entirely → all state survives.
+14. Drop a `.heic` file → friendly error toast.
+15. Drop a corrupt `.jpg` → it appears in the failure list, import does
+    not abort.
+
+**PR description checklist.**
+
+- Decision links to each ADR.
+- Screenshots / GIFs of the four marker states.
+- Test plan checked items.
+- Known limitations (HEIC, drone, etc.).
+
+---
+
+## Test plan summary
+
+### Unit (Vitest)
+
+- `extractExif.test.ts` — GPS, no-GPS, (0,0), bad orientation, HEIC reject,
+  corrupt input.
+- `generateThumb.test.ts` — size, orientation correction, quality.
+- `importPhotoFiles.test.ts` — concurrency, progress, failure isolation.
+- `placeNoGpsPhotos.test.ts` — ordering, spacing, wrap, viewport math.
+- `candidatePoolMirror.test.ts` — read-modify-write idempotency, flag
+  propagation, debounce semantics.
+- `photoMarker.persistence.test.ts` — round-trip through
+  `corridors-session.json` with `capturedAt`, `photoId`, `needsPlacement`.
+
+### Integration (manual; recorded in PR)
+
+- Smoke script above.
+
+### Cross-app contract test
+
+- Write a test that boots both photo-helper and map-corridors in a
+  shared OPFS context, sets flag in map, asserts photo-helper sees it.
+  (Optional v1 — manual smoke is acceptable initial coverage.)
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `exifr` tree-shake doesn't kick in → 30 KB+ added | Verify via Vite build report after Phase 0. Fall back to inline canvas EXIF parser if size unacceptable. |
+| `pica` not available from map-corridors (workspace boundary) | Import directly; or add `pica` to map-corridors `dependencies` (it's already in photo-helper). Cost is duplicate dep declaration only — same file ends up bundled once. |
+| Concurrent writes to `session.json` (map and photo-helper open in two windows) | v1 assumes single-window apps (Electron is). Document the assumption. Add file-level write retry with stat check. |
+| OPFS quota at high photo counts | Existing `isStorageLow` warning fires. New "Many photos (N, ~N MB)" warning in photo mode after 50 photos. |
+| User accidentally clicks "Send to editor" with 0 picks | Button disabled when picks = 0. |
+| Coordinate precision loss when dragging at high zoom | MapLibre returns float64; we store float64. No issue. |
+| Browser drag-and-drop API quirks on Windows | Already exercised by existing dropzone code in photo-helper / map-corridors. Reuse the same dropzone library (react-dropzone). |
+
+---
+
+## Rollback plan
+
+If a serious issue surfaces post-merge:
+
+1. **Feature flag the toggle** (`?photoMode=1` URL parameter gates
+   visibility of the `Source` chip). Default off until confidence
+   restored.
+2. **Data is safe.** Existing corridor sessions never reference the new
+   fields; reverting the feature doesn't lose corridor work.
+3. **Photo data orphans.** If we revert and users had photos under
+   `competitions/{compId}/photos/`, they remain on disk but no UI shows
+   them. Photo-helper still sees them in the candidate pool (forward
+   compat).
+4. **No DB migration to undo.** Schema additions are backwards-compatible
+   (all new fields optional).
+
+---
+
+## Open implementation questions
+
+These are not blocking design, but should be answered during early
+implementation by the implementer:
+
+1. **Debounce window for candidate pool mirror.** 300 ms is a guess.
+   Profile under rapid flag toggles and adjust.
+2. **MapLibre clustering threshold.** At what zoom level do clusters
+   form? Default likely fine; revisit if dense competitions feel busy.
+3. **Thumbnail max dimensions.** 200×150 is a guess for popup; pick
+   smaller for tooltip (80×60?). Confirm with design pass.
+4. **Should "needsPlacement" markers re-anchor to current viewport on
+   pan/zoom**, or stay where they were initially placed? ADR-013 says
+   stay; revisit if it feels off in smoke testing.
+5. **Photo-helper change for `gps` field display**. Out of scope for v1
+   (just metadata); but consider a small footer line on printed photos in
+   v2 showing "subject coords".

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -58,7 +58,6 @@ change.
       lng: number;
       lat: number;
       altitude?: number;
-      heading?: number;
       timestamp?: string;
     };
     photoId?: string;
@@ -70,7 +69,7 @@ change.
   export interface ApiPhoto {
     // ...existing fields
     gps?: {
-      capturedAt?: { lng: number; lat: number; altitude?: number; heading?: number };
+      capturedAt?: { lng: number; lat: number; altitude?: number };
       subjectAt?: { lng: number; lat: number };
       timestamp?: string;
     };
@@ -107,7 +106,7 @@ domain logic — no UI, no map, no storage. Fully unit-testable.
 - `frontend/map-corridors/src/photoImport/extractExif.ts`
   ```ts
   export type ExifData = {
-    capturedAt?: { lng: number; lat: number; altitude?: number; heading?: number };
+    capturedAt?: { lng: number; lat: number; altitude?: number };
     timestamp?: string;
     orientation?: number;
   };
@@ -145,7 +144,7 @@ domain logic — no UI, no map, no storage. Fully unit-testable.
   ```
   Orchestrates: filter HEIC (reject with reason), filter non-image MIME
   types, generate `photoId`, run extractExif + generateThumb per file with
-  `Promise.all` in batches of 8 ([ADR-015](./decisions.md#adr-015-import-throughput-main-thread-throttled-at-8-concurrent)).
+  `Promise.all` in batches of 8 ([ADR-014](./decisions.md#adr-014-import-throughput-main-thread-throttled-at-8-concurrent)).
 
 **Exit criteria.**
 
@@ -316,7 +315,7 @@ filename, timestamp, label picker, and the three action buttons.
 
 ## Phase 6 — No-GPS placement strategy
 
-**Scope.** Implement [ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy):
+**Scope.** Implement [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy):
 photos without GPS arrive in a row along the bottom of the viewport,
 ordered by capture time.
 
@@ -410,7 +409,7 @@ Every flag change in the map tool writes to
 ## Phase 9 — Send-to-editor button
 
 **Scope.** A button at the bottom of the photo list panel: "Send to editor
-(N picks)". Navigates only ([ADR-010](./decisions.md#adr-010-send-to-editor-navigates-only)).
+(N picks)". Navigates only ([ADR-009](./decisions.md#adr-009-send-to-editor-navigates-only)).
 
 **Files touched.**
 
@@ -505,7 +504,7 @@ edge cases. Move PR out of draft.
 - Decision links to each ADR.
 - Screenshots / GIFs of the four marker states.
 - Test plan checked items.
-- Known limitations (HEIC, drone, etc.).
+- Known limitations (HEIC, etc.).
 
 ---
 
@@ -579,7 +578,7 @@ implementation by the implementer:
 3. **Thumbnail max dimensions.** 200×150 is a guess for popup; pick
    smaller for tooltip (80×60?). Confirm with design pass.
 4. **Should "needsPlacement" markers re-anchor to current viewport on
-   pan/zoom**, or stay where they were initially placed? ADR-013 says
+   pan/zoom**, or stay where they were initially placed? ADR-012 says
    stay; revisit if it feels off in smoke testing.
 5. **Photo-helper change for `gps` field display**. Out of scope for v1
    (just metadata); but consider a small footer line on printed photos in

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -7,7 +7,7 @@ see [Delivery shape](#delivery-shape)).
 
 The plan assumes `feat/candidate-photos` has merged to `main` before
 implementation starts — the candidate pool is the handoff foundation
-([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool)).
+([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-a-one-way-map-picksjson-file)).
 
 ---
 
@@ -27,15 +27,22 @@ foundation. Subsequent phases layer UI on a proven base.
 
 Before opening the branch:
 
-- [ ] `feat/candidate-photos` is merged to `main`.
+- [ ] `feat/candidate-photos` is merged to `main`. (Soft gate: if it
+      slips, the new `useMapPicksSync` hook can still ship as the
+      consumer side; the candidate pool feature is required to give
+      the picks a UI home but not to define the file contract.)
 - [ ] The candidate pool's persistence works end-to-end (manual smoke).
 - [ ] `frontend/photo-helper/src/types/api.ts` defines `CandidatePool`
       and `ApiPhoto.flag` as expected.
 - [ ] `exifr` latest version checked on npm; note exact version for the
       install (no caret, per global dependency-pinning rule).
-- [ ] Sample test photos available: 1× JPEG with GPS, 1× JPEG without GPS,
-      1× JPEG with bad orientation, 1× HEIC (for the reject path),
-      1× corrupt JPEG.
+- [ ] `@vitest/browser` + Playwright browser provider available for
+      installing as devDeps.
+- [ ] Sample test photos with **anonymized synthetic GPS coords**
+      available: 1× JPEG with GPS, 1× JPEG without GPS, 1× JPEG with
+      Orientation=6 (sideways), 1× JPEG with Orientation=1 (already
+      rotated), 1× HEIC (for the reject path), 1× misnamed HEIC
+      (`.jpg` extension), 1× corrupt JPEG.
 
 ---
 
@@ -61,9 +68,10 @@ change.
       timestamp?: string;
     };
     photoId?: string;
-    needsPlacement?: boolean;
   };
   ```
+  (No `needsPlacement` field — per [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)
+  a no-GPS photo is *not* a PhotoMarker until placed.)
 - `frontend/photo-helper/src/types/api.ts` — extend `ApiPhoto`:
   ```ts
   export interface ApiPhoto {
@@ -75,7 +83,15 @@ change.
     };
   }
   ```
-- `frontend/map-corridors/package.json` — add `exifr` (exact version).
+- `frontend/map-corridors/package.json` — add `exifr` (exact version,
+  no caret per global dependency-pinning rule). Optionally `pica` if
+  Phase 1 measurement shows plain canvas downscale quality is poor
+  (likely not needed for 200×150 popups).
+- `frontend/map-corridors/package.json` — add `@vitest/browser` and a
+  Playwright browser provider to `devDependencies` (canvas tests can't
+  run in jsdom). Pin exact versions.
+- `frontend/map-corridors/vite.config.ts` — add a `test.browser` block
+  for the canvas-touching test suite (the jsdom suite stays as today).
 - `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` —
   bump session JSON schema version + add migration shim that defaults the
   new fields to `undefined` on load.
@@ -87,11 +103,24 @@ change.
   `pnpm --filter @airq/photo-helper build` succeed.
 - Existing corridor session JSONs from before the change load without
   errors (schema migration path exercised).
+- **Bundle-size budget verified.** Run `pnpm --filter @airq/map-corridors build`
+  and inspect the Vite build report; the new `exifr` import contributes
+  ≤ 12 KB gz. If higher, switch to manual EXIF parser (5 lines for GPS-only)
+  or accept and document.
+- Test fixture set bootstrapped in
+  `frontend/map-corridors/test/fixtures/photos/` with anonymized GPS
+  coords.
+- A v1→v2 schema migration unit test passes: load a pre-feature
+  `corridors-session.json`, ensure new fields default to undefined and
+  no console warnings fire.
 
 **Test focus.**
 
 - Unit test: load a v1 corridors-session.json (without new fields) →
   PhotoMarker array reads fine, `capturedAt` is undefined.
+- Unit test: a `PhotoMarker` with malformed `capturedAt: { lng: 'foo' }`
+  is rejected by the extended `sanitizePhotoMarkers` validator
+  (`frontend/map-corridors/src/types/markers.ts`).
 
 ---
 
@@ -116,12 +145,17 @@ domain logic — no UI, no map, no storage. Fully unit-testable.
   ```ts
   export async function generateThumb(
     file: File,
-    opts?: { maxWidth?: number; maxHeight?: number; quality?: number; orientation?: number }
+    opts?: { maxWidth?: number; maxHeight?: number; quality?: number }
   ): Promise<Blob>;
   ```
-  Uses canvas + `pica` (already in workspace via photo-helper; verify
-  tree-shake). Honours the EXIF orientation tag so the popup shows
-  upright.
+  Decodes via `createImageBitmap(file, { imageOrientation: 'from-image' })`
+  so EXIF Orientation is applied by the browser per spec (see
+  [ADR-015](./decisions.md#adr-015-apply-exif-orientation-via-createimagebitmap-not-manual-rotation)).
+  No manual rotation logic in our code. Downscales to `maxWidth ×
+  maxHeight` via either `OffscreenCanvas + drawImage` (good enough for
+  200×150) or `pica` for higher-quality intermediate steps. v1 starts
+  with plain canvas — pica is only needed if quality is visibly poor at
+  popup size, which we'll measure during Phase 1.
 - `frontend/map-corridors/src/photoImport/types.ts`
   ```ts
   export type ImportedPhoto = {
@@ -148,33 +182,45 @@ domain logic — no UI, no map, no storage. Fully unit-testable.
 
 **Exit criteria.**
 
-- 95%+ unit test coverage on the pipeline.
-- All edge cases covered: GPS present, GPS absent, GPS `(0,0)` (treated as
-  absent), bad orientation tag (canvas correction verified), HEIC rejected
-  with reason, corrupt JPEG → failure list.
-- Mock fixture set checked into `frontend/map-corridors/test/fixtures/`.
+- **Pure code paths** (`extractExif`, `importPhotoFiles` orchestration):
+  every branch covered in Vitest + jsdom.
+- **Canvas-touching paths** (`generateThumb`): covered in
+  `@vitest/browser` mode (added as a dev dep in Phase 0) for at least
+  the orientation, (0,0)-boundary, and corrupt-input cases. jsdom does
+  not implement Canvas2D or `createImageBitmap`, so these tests cannot
+  run in the regular vitest target.
+- Test fixtures live in `frontend/map-corridors/test/fixtures/photos/`
+  with **synthetic, anonymized** GPS coords (e.g., always (50.0, 14.0)
+  base + offsets). Phase 0 bootstraps these so no organizer's real
+  home coords get committed.
 
 **Test focus.**
 
 ```
-extractExif.test.ts
+extractExif.test.ts                                    (vitest + jsdom)
   ✓ extracts lat/lng from JPEG with GPS
   ✓ returns capturedAt: undefined for JPEG without GPS
-  ✓ treats (0,0) GPS as absent
+  ✓ treats (0,0) exact GPS as absent (not (0, 0.0001))
   ✓ returns timestamp from DateTimeOriginal in ISO format
   ✓ returns orientation tag
+  ✓ rejects HEIC by extension AND by content (mis-named .jpg HEIC)
 
-generateThumb.test.ts
-  ✓ produces JPEG at most 200×150 px
-  ✓ rotates 90/180/270 based on orientation tag
-  ✓ quality 0.7 produces < 30 KB for typical 4 MP input
+generateThumb.test.ts                                  (@vitest/browser)
+  ✓ produces JPEG at most maxWidth × maxHeight
+  ✓ output is upright for camera-sideways JPEG (Orientation=6)
+  ✓ output is upright for phone-pre-rotated JPEG (Orientation=1)
+     — guards against double-rotation
+  ✓ JPEG quality 0.7 produces < 30 KB for typical 4 MP input
+  ✓ rejects corrupt JPEG with thrown reason (caught by importPhotoFiles)
 
-importPhotoFiles.test.ts
-  ✓ runs in parallel batches of 8
+importPhotoFiles.test.ts                               (vitest + jsdom)
+  ✓ runs in parallel batches of 8 (verifies concurrency, not wall-clock)
   ✓ surfaces per-file progress
   ✓ collects failures without aborting the batch
   ✓ rejects HEIC at the top
   ✓ rejects non-image MIME types
+  ✓ simulated savePhotoFile rejection mid-batch → failure list contains
+     the file, no orphan marker
 ```
 
 ---
@@ -239,53 +285,60 @@ write to storage. Persist mode in corridor session JSON.
 
 ---
 
-## Phase 4 — Marker rendering: capture/subject distinction
+## Phase 4 — Photo markers: GeoJSON layers for static dots, `<Marker>` for picks
 
-**Scope.** Extend `MapProviderView` to render capture-vs-subject markers
-correctly. Three marker visual states ([decisions.md §UI](./decisions.md)):
-
-- **Capture-only** (no flag yet): small grey dot at `capturedAt`.
-- **Picked** (flag = `pick`): coloured pin at `lng/lat`, ghost marker at
-  `capturedAt` with dashed line between (when they differ).
-- **Rejected** (flag = `reject`): red ✗ with 40% opacity.
-- **Needs placement** (no GPS): orange `?` glyph at viewport-anchored coord.
+**Scope.** Render photo markers in two render paths per
+[ADR-016](./decisions.md#adr-016-marker-rendering-split-geojson-layer-for-static-dots-individual-marker-for-picks).
+Static visuals (capture dots, ghost markers, rejected dots, dashed
+lines) go into Mapbox GeoJSON layers. Draggable subject pins (the picks)
+remain individual `<Marker>` components.
 
 **Files touched.**
 
-- `frontend/map-corridors/src/map/MapProviderView.tsx` — extend marker
-  rendering loop (currently lines 332-375). Add a helper:
-  ```tsx
-  function renderPhotoMarker(marker: PhotoMarker): ReactNode {
-    if (marker.needsPlacement) return <NeedsPlacementMarker {...} />;
-    const hasCapture = marker.capturedAt !== undefined;
-    const flag = lookupFlag(marker.id);
-    if (flag === 'reject') return <RejectedDot ... />;
-    if (flag === 'pick') return (
-      <>
-        <SubjectPin draggable onDragEnd={...} />
-        {hasCapture && capturedDiffers(marker) && (
-          <>
-            <CaptureGhostMarker />
-            <DashedLine from={marker.capturedAt} to={marker} />
-          </>
-        )}
-      </>
-    );
-    return <CaptureDot />;
-  }
-  ```
-- `frontend/map-corridors/src/map/markers/` *(new directory)* — small
-  presentational components: `CaptureDot`, `CaptureGhostMarker`,
-  `SubjectPin`, `RejectedDot`, `NeedsPlacementMarker`, `DashedLine`
-  (rendered via a tiny GeoJSON layer).
+- `frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx`
+  *(new)* — feeds a GeoJSON source with one feature per `PhotoMarker`
+  with `capturedAt !== undefined && flag !== 'pick'`. Properties include
+  `photoId`, `flag` (used in paint expressions and click handlers).
+- `frontend/map-corridors/src/map/photoLayers/DashedLinesLayer.tsx`
+  *(new)* — feeds a GeoJSON source with one LineString per pick where
+  `capturedAt !== lng/lat`. Re-emits source data on drag-end only.
+- `frontend/map-corridors/src/map/photoLayers/RejectedDotsLayer.tsx`
+  *(new)* — separate layer (or filtered sublayer) for `flag === 'reject'`.
+  Hide-rejects toggle becomes a paint filter, not a DOM change.
+- `frontend/map-corridors/src/map/photoLayers/SubjectPin.tsx` *(new)* —
+  individual draggable `<Marker>` per pick.
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — mount these
+  layers in photo mode; preserve existing corridor-marker rendering for
+  KML/GPX flow.
+
+**Paint expressions (sketch).**
+
+- Capture dots: `circle-color` = match-expression on `flag` (grey for
+  neutral, dim for rejected if not on its own layer).
+- Capture dots: `circle-radius` 4 px.
+- Subject pins: 24×24 SVG marker, color by `flag` (typically only `pick`).
+- Dashed line: `line-dasharray: [2, 2]`, `line-width: 1`.
+
+**Click handling.**
+
+- `map.on('click', 'photo-capture-dots', e => openPopup(e.features[0].properties.photoId))`.
+- Subject pin click handled at the `<Marker>` level.
 
 **Exit criteria.**
 
-- All four visual states render correctly with sample data.
-- Dragging a `SubjectPin` updates `marker.lng/lat` (not `capturedAt`).
-- Dashed line redraws on every drag tick (or on drag-end, depending on
-  performance).
-- Clicking a marker still opens the popup (Phase 5).
+- 100 capture dots render at 60 fps on pan/zoom.
+- Clicking a capture dot opens the popup (Phase 5).
+- Subject pin drag updates `marker.lng/lat`; dashed line redraws via
+  GeoJSON source-data update on **drag-end** (not per-tick).
+- "Hide rejects" toggle (US-13) hides red dots via a Mapbox paint filter,
+  zero DOM churn.
+- Existing KML-marker rendering unchanged.
+
+**Note on library naming.** The React binding entry point is
+`react-map-gl/mapbox` (Mapbox GL), not `maplibre-gl`. Earlier doc
+references to "MapLibre clustering" were imprecise — the existing
+infrastructure uses Mapbox GL. MapLibre remains in deps as a fallback
+style provider but is not the marker-mount layer.
 
 ---
 
@@ -313,39 +366,46 @@ filename, timestamp, label picker, and the three action buttons.
 
 ---
 
-## Phase 6 — No-GPS placement strategy
+## Phase 6 — No-GPS tray + drag-onto-map
 
-**Scope.** Implement [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy):
-photos without GPS arrive in a row along the bottom of the viewport,
-ordered by capture time.
+**Scope.** Implement [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner):
+an off-map tray pinned to the bottom-left of the map holds photos with
+no GPS. The user drags a thumbnail from the tray to any point on the
+map; on drop, a `PhotoMarker` is created at the drop coordinate and the
+entry leaves the tray.
 
 **New / touched files.**
 
-- `frontend/map-corridors/src/photoImport/placeNoGpsPhotos.ts` *(new)*:
-  ```ts
-  export function placeNoGpsPhotos(
-    photos: ImportedPhoto[],
-    viewport: { bounds: [[number, number], [number, number]]; width: number; height: number },
-    opts?: { spacingPx?: number; bottomMarginPx?: number }
-  ): Array<{ photoId: string; lng: number; lat: number }>;
-  ```
-  Pure function. Sorts by `exif.timestamp` (fallback: filename
-  alphabetical). Computes lng/lat for each photo from the viewport bounds
-  + a screen-space offset (so they appear ~`bottomMarginPx` from the
-  bottom edge, `spacingPx` apart horizontally). Wraps to a second row
-  above if total width exceeds viewport width.
-- `frontend/map-corridors/src/App.tsx` — call `placeNoGpsPhotos` for
-  photos that come back from `importPhotoFiles` with no `exif.capturedAt`,
-  set `marker.needsPlacement = true`, and place at the computed coords.
-  Then add to `markers[]` as PhotoMarkers.
+- `frontend/map-corridors/src/components/NoGpsTray.tsx` *(new)* — MUI
+  Paper positioned absolutely over the map's bottom-left. Horizontal
+  scroll of thumbnails sorted by capture time. Each thumb is HTML5
+  draggable; sets `dataTransfer.setData('application/x-airq-no-gps-photo', photoId)`.
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — add a drop
+  handler on the map container. On drop, call
+  `map.unproject([clientX, clientY])` to get `{lng, lat}` and emit
+  `onNoGpsPhotoPlaced(photoId, lng, lat)`.
+- `frontend/map-corridors/src/App.tsx` — wire `onNoGpsPhotoPlaced`:
+  pop the candidate from the no-GPS list, create a `PhotoMarker` with
+  `flag: 'pick'` at the drop coord. No `capturedAt`, no ghost.
+- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` — add
+  `noGpsTrayOpen: boolean` to `CorridorsSession`.
+
+**Note: no `placeNoGpsPhotos` pure function is needed.** The earlier
+viewport-anchored lng/lat strategy is dropped (ADR-012 revised).
+No-GPS photos exist only as candidate-pool entries until placed; they
+never receive synthetic coordinates.
 
 **Exit criteria.**
 
-- Drop a batch of 5 photos with no GPS → all visible along the bottom of
-  the map, ordered by capture time.
-- Each marker is independently draggable; on first drag, `needsPlacement`
-  flips to `false` and the marker behaves like a normal subject pin.
-- Side panel "No GPS" section lists the same photos with a `?` indicator.
+- Import 5 photos with no GPS → 5 thumbs appear in the tray, ordered
+  by EXIF timestamp.
+- Drag thumb onto map → subject pin appears at exact drop coord, tray
+  shrinks by one.
+- Tray empty → collapses to chevron; click chevron re-opens tray (when
+  more no-GPS photos arrive).
+- Tray state persists across reload.
+- Tray covers ≤ 20% of map width and ≤ 120 px tall.
+- Side panel "No GPS" group lists the same photos until placed.
 
 ---
 
@@ -371,38 +431,90 @@ flag. Two-way sync with the map.
 
 ---
 
-## Phase 8 — Cross-app handoff: candidate pool mirror
+## Phase 8 — Cross-app handoff: `map-picks.json` writer + photo-helper reader
 
-**Scope.** Implement [ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool).
-Every flag change in the map tool writes to
-`session.candidates.photos[]` in the photo-helper session JSON.
+**Scope.** Implement [ADR-005](./decisions.md#adr-005-cross-app-handoff-via-a-one-way-map-picksjson-file).
+Map-corridors writes its picks to a dedicated `map-picks.json` per
+competition; photo-helper reads it on competition load and on tab
+visibility regain.
 
 **New / touched files.**
 
-- `frontend/map-corridors/src/handoff/candidatePoolMirror.ts` *(new)*:
+*Writer (map-corridors):*
+
+- `frontend/map-corridors/src/handoff/mapPicksWriter.ts` *(new)*:
   ```ts
-  export async function syncToCandidatePool(
+  export type MapPicksFile = {
+    version: 1;
+    updatedAt: string;
+    picks: MapPickEntry[];
+  };
+  export type MapPickEntry = {
+    photoId: string;
+    filename: string;
+    flag: 'pick' | 'neutral' | 'reject';
+    gps?: {
+      capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string };
+      subjectAt?: { lng: number; lat: number };
+    };
+    label?: PhotoLabel;
+  };
+  export async function writeMapPicks(
     storage: StorageInterface,
     competitionDir: DirectoryHandle,
-    markers: PhotoMarker[],
-    flags: Record<string, CandidateFlag>
+    picks: MapPickEntry[]
   ): Promise<void>;
+  export async function flushPendingMapPicks(): Promise<void>;
   ```
-  Reads photo-helper's `session.json`, replaces `candidates.photos` with
-  the photo-mode selection, writes back. Debounced; idempotent.
-- `frontend/map-corridors/src/App.tsx` — call `syncToCandidatePool` on
-  every flag change (debounced 300 ms).
+  Single writer; serialized internally so two rapid calls do not race.
+  Debounced 300 ms via a single setTimeout (`scheduleWrite` →
+  coalesce). `flushPendingMapPicks()` synchronously executes the
+  pending write if one is scheduled.
+- `frontend/map-corridors/src/App.tsx` — call `scheduleWriteMapPicks`
+  on every flag / label change. Register `pagehide` and `beforeunload`
+  listeners to call `flushPendingMapPicks()` synchronously.
+
+*Reader (photo-helper):*
+
+- `frontend/photo-helper/src/hooks/useMapPicksSync.ts` *(new)*: ~50 LoC.
+  ```ts
+  export function useMapPicksSync(
+    competitionDir: DirectoryHandle | null,
+    sessionApi: { addCandidatePhotos: (apiPhotos: ApiPhoto[]) => void; existingPhotoIds: Set<string> }
+  ): void;
+  ```
+  Effect:
+  1. On `competitionDir` change: read `map-picks.json`, project each
+     `MapPickEntry` whose `photoId` is *not* in `existingPhotoIds` into
+     an `ApiPhoto` with default `canvasState` (using existing
+     `createDefaultCanvasState()` helper), and push into the candidate
+     pool.
+  2. Subscribe to `document.visibilitychange`; re-run the read on
+     `visible`.
+- `frontend/photo-helper/src/AppApi.tsx` — call `useMapPicksSync` once
+  after the competition is loaded.
+
+**Why no lock.** One writer (map-corridors), one reader (photo-helper).
+The reader never writes; the writer never reads anyone else's file.
+Web mode's "two tabs of the same browser sharing OPFS" risk is
+contained: photo-helper read of `map-picks.json` is idempotent and
+last-write-wins reads are safe (the worst that happens is a
+millisecond-stale read on focus, fixed on the next visibilitychange).
 
 **Exit criteria.**
 
-- Set a flag in map tool → open photo-helper after debounce flush →
-  candidate tray reflects the flag.
-- Set a flag in photo-helper → photo-helper writes back to its own
-  session; map tool reads back on next focus (or via a periodic poll —
-  TBD; simplest is "stale until user toggles").
-- No corrupted JSON under rapid flag changes (debounce + sequential
-  write).
-- Photo IDs match between the two sessions (same `photoId` key).
+- Toggle a flag in map tool → after 300 ms debounce, `map-picks.json`
+  contains the new flag for the photo.
+- Open photo-helper for the same competition → candidate tray contains
+  every `pick` photo with default canvas state. Photos already in the
+  candidate pool from prior sessions are preserved (no duplicate by
+  `photoId`).
+- Toggle a flag in map tool, immediately call "Send to editor" → the
+  toggle is persisted (Phase 9 enforces the flush).
+- Multiple rapid flag changes coalesce into a single write (no torn
+  JSON, no `EBUSY` errors).
+- Photo IDs from the map writer have the `pm-` prefix; photo-helper
+  hook can identify map-origin entries.
 
 ---
 
@@ -415,15 +527,28 @@ Every flag change in the map tool writes to
 
 - `frontend/map-corridors/src/components/PhotoListPanel.tsx` — button.
 - `frontend/desktop/preload.js` — already exposes `navigateToApp`.
-- `frontend/map-corridors/src/App.tsx` — wire `onClick` to
-  `electronAPI?.navigateToApp('photo-helper', { competitionId })` for
-  Electron, or `window.location.href = '/photo-helper/?competitionId=…'`
-  for web.
+- `frontend/map-corridors/src/App.tsx` — wire `onClick` to:
+  ```ts
+  async function onSendToEditor() {
+    await flushPendingMapPicks();   // ADR-009 navigation-flush requirement
+    if (window.electronAPI?.navigateToApp) {
+      window.electronAPI.navigateToApp('photo-helper', competitionId);
+    } else {
+      window.location.href = `/photo-helper/?competitionId=${competitionId}`;
+    }
+  }
+  ```
+- Register `pagehide` and `beforeunload` listeners that synchronously
+  invoke `flushPendingMapPicks()` as a belt-and-suspenders safeguard for
+  back-button navigation, tab close, refresh.
 
 **Exit criteria.**
 
 - Button disabled when 0 picks; live count in label.
-- Click → app switches; candidate tray pre-populated.
+- Click → flush completes → app switches → candidate tray pre-populated.
+- Test: toggle flag, click Send within 50 ms — toggle is persisted
+  before navigation (verified via `map-picks.json` content + photo-helper
+  candidate tray on arrival).
 
 ---
 
@@ -454,7 +579,9 @@ photo.list.groupNeutral             "Neutral" / "Neutrální"
 photo.list.groupRejects             "Rejects" / "Zamítnuté"
 photo.list.groupNoGps               "No GPS" / "Bez GPS"
 photo.sendToEditor                  "Send to editor ({{count}})" / "Otevřít v editoru ({{count}})"
-photo.needsPlacement                "Drag to place" / "Přetáhněte na pozici"
+photo.noGpsTray.header              "Photos without GPS" / "Fotky bez GPS"
+photo.noGpsTray.dragHint            "Drag onto the map to place" / "Přetáhněte na mapu pro umístění"
+photo.noGpsTray.empty               "No photos without GPS" / "Žádné fotky bez GPS"
 ```
 
 **Exit criteria.**
@@ -462,8 +589,23 @@ photo.needsPlacement                "Drag to place" / "Přetáhněte na pozici"
 - All strings rendered via `t()`.
 - No hard-coded English in the new components.
 - Czech text uses proper diacritics (verified by reviewer).
-- Keyboard navigation: Tab through the popup actions; Esc closes popup.
-- Focus visible on all interactive elements.
+
+**Accessibility (label picker requires explicit handling).**
+
+- Label picker (20 buttons A–T or 1–20) uses `aria-pressed` for the
+  currently-assigned label and `aria-disabled="true"` for labels already
+  taken by another photo.
+- Non-color taken indicator: strikethrough + reduced font weight on
+  taken-label buttons. Color alone is insufficient for WCAG AA.
+- Keyboard navigation: Arrow keys move between label buttons; Enter
+  selects; Tab moves out of the grid to the next action.
+- Esc closes any popup.
+- Focus ring visible on all interactive elements (MUI default + audit).
+- Drag-from-tray (Phase 6) has a keyboard-equivalent: focus the
+  thumbnail, press Enter, click a point on the map. (Out of scope v1 if
+  it adds complexity; document as known a11y gap.)
+- Screen reader: each marker / pin has an `aria-label` like
+  "Photo 17, label A, picked".
 
 ---
 
@@ -512,39 +654,66 @@ edge cases. Move PR out of draft.
 
 ### Unit (Vitest)
 
-- `extractExif.test.ts` — GPS, no-GPS, (0,0), bad orientation, HEIC reject,
-  corrupt input.
-- `generateThumb.test.ts` — size, orientation correction, quality.
-- `importPhotoFiles.test.ts` — concurrency, progress, failure isolation.
-- `placeNoGpsPhotos.test.ts` — ordering, spacing, wrap, viewport math.
-- `candidatePoolMirror.test.ts` — read-modify-write idempotency, flag
-  propagation, debounce semantics.
+- `extractExif.test.ts` *(vitest+jsdom)* — GPS, no-GPS, (0,0) exact,
+  HEIC reject (by extension + by content), corrupt input.
+- `generateThumb.test.ts` *(@vitest/browser)* — size, orientation
+  correctness on Orientation=1 (already-rotated) and Orientation=6
+  (sideways), JPEG quality, corrupt input.
+- `importPhotoFiles.test.ts` *(vitest+jsdom)* — concurrency-of-8,
+  progress callbacks, failure isolation, mid-batch savePhotoFile
+  rejection.
+- `mapPicksWriter.test.ts` — debounce coalescing, `flushPendingMapPicks`
+  synchronously executes pending writes, idempotent `writeMapPicks`.
+- `useMapPicksSync.test.ts` — projects `MapPickEntry` to `ApiPhoto`
+  with default `canvasState`; merges (no duplicate by photoId);
+  re-reads on visibilitychange.
 - `photoMarker.persistence.test.ts` — round-trip through
-  `corridors-session.json` with `capturedAt`, `photoId`, `needsPlacement`.
+  `corridors-session.json` with `capturedAt`, `photoId`. Malformed
+  `capturedAt` rejected by `sanitizePhotoMarkers`.
+- `markerLayers.test.ts` — GeoJSON source data is correct for capture
+  dots, rejected dots, dashed lines.
 
 ### Integration (manual; recorded in PR)
 
 - Smoke script above.
 
-### Cross-app contract test
+### Cross-app contract test (mandatory, not optional)
 
-- Write a test that boots both photo-helper and map-corridors in a
-  shared OPFS context, sets flag in map, asserts photo-helper sees it.
-  (Optional v1 — manual smoke is acceptable initial coverage.)
+This is the load-bearing assumption of the feature, so it gets a
+real test:
+
+- Boot map-corridors against a temporary OPFS competition directory.
+- Toggle a flag → wait for debounced write → verify `map-picks.json`
+  shape and content.
+- Boot photo-helper against the same dir. Invoke `useMapPicksSync` and
+  assert the candidate pool receives the corresponding `ApiPhoto`.
+- Add a regression case: photo-helper-originated photos in the
+  candidate pool are not overwritten by map-side picks (namespace
+  check on `pm-` prefix).
+- Test in `frontend/test/cross-app/` as a new test target, running
+  against an OPFS shim so it works in CI.
 
 ---
 
 ## Risks and mitigations
 
-| Risk | Mitigation |
-|---|---|
-| `exifr` tree-shake doesn't kick in → 30 KB+ added | Verify via Vite build report after Phase 0. Fall back to inline canvas EXIF parser if size unacceptable. |
-| `pica` not available from map-corridors (workspace boundary) | Import directly; or add `pica` to map-corridors `dependencies` (it's already in photo-helper). Cost is duplicate dep declaration only — same file ends up bundled once. |
-| Concurrent writes to `session.json` (map and photo-helper open in two windows) | v1 assumes single-window apps (Electron is). Document the assumption. Add file-level write retry with stat check. |
-| OPFS quota at high photo counts | Existing `isStorageLow` warning fires. New "Many photos (N, ~N MB)" warning in photo mode after 50 photos. |
-| User accidentally clicks "Send to editor" with 0 picks | Button disabled when picks = 0. |
-| Coordinate precision loss when dragging at high zoom | MapLibre returns float64; we store float64. No issue. |
-| Browser drag-and-drop API quirks on Windows | Already exercised by existing dropzone code in photo-helper / map-corridors. Reuse the same dropzone library (react-dropzone). |
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `exifr` tree-shake doesn't kick in → 30 KB+ added | MED | Phase 0 gates on a measured ≤ 12 KB gz contribution. Fall back to inline canvas EXIF parser (~5 lines for GPS-only) if size unacceptable. |
+| `pica` added but bloats map-corridors bundle | LOW | v1 starts without `pica` — plain canvas downscale to 200×150 is adequate for popup thumbs. Only add `pica` if Phase 1 measurement shows visible quality regression at popup size. |
+| Marker render perf at 100+ photos | HIGH | Resolved by ADR-016 (GeoJSON layers for static dots; `<Marker>` only for picks). Phase 4 exit criterion verifies 60 fps at 100 dots. |
+| Concurrent writers to a single JSON file | RESOLVED | ADR-005 (revised) uses one-way `map-picks.json`: one writer (map-corridors), one reader (photo-helper). No lock needed. |
+| Navigation race: debounced write lost on app switch | RESOLVED | ADR-009 (revised) requires `await flushPendingMapPicks()` before navigation + `pagehide`/`beforeunload` listeners. |
+| EXIF orientation double-rotation on phone-pre-rotated photos | RESOLVED | ADR-015: use `createImageBitmap(file, { imageOrientation: 'from-image' })` — the browser handles both conventions per spec. |
+| OPFS quota at high photo counts | MED | Hard pre-flight check: `getStorageEstimate().usage + estimatedBatch > 0.8 * quota` blocks the drop with a friendly modal. Existing `isStorageLow` warning continues to fire. |
+| Mapbox token not configured on first app open | MED | Photo source mode is useless without a map. Surface the token-config CTA prominently. Fallback to OpenStreetMap raster tile (no token needed) if token absent. |
+| User accidentally clicks "Send to editor" with 0 picks | LOW | Button disabled when picks = 0. |
+| Coordinate precision loss when dragging at high zoom | LOW | float64 throughout. Existing `dragMovedPxRef` threshold of 8 px equals ~1.2 m at zoom 19 — could misclassify a precise placement as click. Lower threshold to 3 px for photo-mode subject pins. |
+| Browser drag-and-drop API quirks on Windows | LOW | Already exercised by existing dropzone code. Reuse `react-dropzone`. |
+| `competitionService.saveSessionPhotos` re-fetches all blobs on every save | MED | Existing dedup-by-id at line 591 helps but every persistence still iterates all pools. At 100 photos this can add 200–400 ms per save. Mitigation: track a dirty-photo set; only re-fetch blob URLs for changed photos. |
+| Photo blob orphans after OPFS eviction | LOW | On session load, validate each `photoId` in the candidate pool has a corresponding file in `photos/`. Surface a non-blocking banner if any are missing. |
+| Web tab × two = OPFS shared origin race | MED | Mitigated by ADR-005's single-writer-per-file design. Photo-helper reads on visibilitychange so a stale read self-heals within a focus cycle. |
+| HEIC by content but `.jpg` extension | LOW | `extractExif` checks file content (magic bytes), not just extension. Test fixture covers misnamed HEIC. |
 
 ---
 
@@ -577,9 +746,14 @@ implementation by the implementer:
    form? Default likely fine; revisit if dense competitions feel busy.
 3. **Thumbnail max dimensions.** 200×150 is a guess for popup; pick
    smaller for tooltip (80×60?). Confirm with design pass.
-4. **Should "needsPlacement" markers re-anchor to current viewport on
-   pan/zoom**, or stay where they were initially placed? ADR-012 says
-   stay; revisit if it feels off in smoke testing.
+4. **No-GPS tray scroll vs. wrap behavior** at very high counts (50+
+   no-GPS photos). v1 ships horizontal scroll only. If hit, add a
+   "scroll to next" affordance or wrap to two rows.
 5. **Photo-helper change for `gps` field display**. Out of scope for v1
    (just metadata); but consider a small footer line on printed photos in
    v2 showing "subject coords".
+6. **OSM-tile fallback when Mapbox token is absent**. Mentioned in the
+   risk table as a mitigation, but the exact tile source and attribution
+   need confirming.
+7. **`extractExif` HEIC-by-content detection** — verify `exifr` accepts a
+   magic-byte sniff or whether we need a separate prefix check.

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -53,25 +53,35 @@ change.
 
 **Files touched.**
 
-- `frontend/map-corridors/src/types/markers.ts` — extend `PhotoMarker`:
+- `frontend/map-corridors/src/types/markers.ts` — extend `PhotoMarker`,
+  preserving the existing `Readonly<...>` immutability wrapper used
+  throughout the codebase:
   ```ts
-  export type PhotoMarker = {
+  export type PhotoMarker = Readonly<{
     id: string;
     lng: number;
     lat: number;
     name: string;
     label?: PhotoLabel;
-    capturedAt?: {
+    capturedAt?: Readonly<{
       lng: number;
       lat: number;
       altitude?: number;
       timestamp?: string;
-    };
+    }>;
     photoId?: string;
-  };
+  }>;
   ```
-  (No `needsPlacement` field — per [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)
-  a no-GPS photo is *not* a PhotoMarker until placed.)
+  Notes:
+  - No `flag` field (per [ADR-017](./decisions.md#adr-017-flag-lives-in-map-picksjson-only-denormalized-to-geojson-properties-at-render-time);
+    flag lives only in `map-picks.json`).
+  - No `needsPlacement` field (per [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner);
+    no-GPS photos exist as candidate-pool entries until placed).
+- `frontend/map-corridors/src/types/markers.ts` — extend
+  `isPhotoMarker` to validate optional `capturedAt` (nested
+  `isFinite` lng/lat) and `photoId` (string, non-empty). The existing
+  `sanitizePhotoMarkers` array filter then handles upgrade-from-pre-feature
+  data without further changes.
 - `frontend/photo-helper/src/types/api.ts` — extend `ApiPhoto`:
   ```ts
   export interface ApiPhoto {
@@ -87,14 +97,25 @@ change.
   no caret per global dependency-pinning rule). Optionally `pica` if
   Phase 1 measurement shows plain canvas downscale quality is poor
   (likely not needed for 200×150 popups).
-- `frontend/map-corridors/package.json` — add `@vitest/browser` and a
-  Playwright browser provider to `devDependencies` (canvas tests can't
-  run in jsdom). Pin exact versions.
-- `frontend/map-corridors/vite.config.ts` — add a `test.browser` block
-  for the canvas-touching test suite (the jsdom suite stays as today).
-- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` —
-  bump session JSON schema version + add migration shim that defaults the
-  new fields to `undefined` on load.
+- `frontend/map-corridors/vitest.config.ts` — confirm jsdom environment
+  is available; for the `generateThumb` test cases that need real
+  Canvas / `createImageBitmap`, the **first attempt** is to use the
+  `canvas` npm package as a jsdom shim (already on the
+  `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml`). Only
+  if the shim proves inadequate, add `@vitest/browser` + Playwright
+  browser provider as a separate `test:browser` script — gated off
+  the default `pnpm test` so CI is not forced to install a Chromium
+  download. Pin exact versions if/when adopted.
+- `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` — extend
+  `CorridorsSession` with `sourceMode: 'corridor' | 'photo'` (default
+  `'corridor'`) and `noGpsTrayOpen: boolean` (default `true`). Expose
+  `setSourceMode` and `setNoGpsTrayOpen` setters from the hook,
+  mirroring the existing `setMarkers` pattern. **Note on the existing
+  `version` field**: it is a per-mutation write counter
+  (`session.version + 1` on every persist), not a schema version.
+  Backwards compatibility for pre-feature sessions relies on
+  `sanitizePhotoMarkers` (extended above) ignoring missing fields,
+  not on a schema-version bump.
 
 **Exit criteria.**
 
@@ -103,10 +124,12 @@ change.
   `pnpm --filter @airq/photo-helper build` succeed.
 - Existing corridor session JSONs from before the change load without
   errors (schema migration path exercised).
-- **Bundle-size budget verified.** Run `pnpm --filter @airq/map-corridors build`
-  and inspect the Vite build report; the new `exifr` import contributes
-  ≤ 12 KB gz. If higher, switch to manual EXIF parser (5 lines for GPS-only)
-  or accept and document.
+- **Bundle-size measured.** Run `pnpm --filter @airq/map-corridors build`
+  and inspect the Vite build report. Aim for `exifr` to contribute
+  ≤ 15 KB gz (its documented lite-build target is ~9 KB). If
+  significantly higher (e.g., > 25 KB), reconsider the library or
+  switch to a 5-line manual GPS-only parser. Record the measured
+  number in the PR description.
 - Test fixture set bootstrapped in
   `frontend/map-corridors/test/fixtures/photos/` with anonymized GPS
   coords.
@@ -196,32 +219,17 @@ domain logic — no UI, no map, no storage. Fully unit-testable.
 
 **Test focus.**
 
-```
-extractExif.test.ts                                    (vitest + jsdom)
-  ✓ extracts lat/lng from JPEG with GPS
-  ✓ returns capturedAt: undefined for JPEG without GPS
-  ✓ treats (0,0) exact GPS as absent (not (0, 0.0001))
-  ✓ returns timestamp from DateTimeOriginal in ISO format
-  ✓ returns orientation tag
-  ✓ rejects HEIC by extension AND by content (mis-named .jpg HEIC)
-
-generateThumb.test.ts                                  (@vitest/browser)
-  ✓ produces JPEG at most maxWidth × maxHeight
-  ✓ output is upright for camera-sideways JPEG (Orientation=6)
-  ✓ output is upright for phone-pre-rotated JPEG (Orientation=1)
-     — guards against double-rotation
-  ✓ JPEG quality 0.7 produces < 30 KB for typical 4 MP input
-  ✓ rejects corrupt JPEG with thrown reason (caught by importPhotoFiles)
-
-importPhotoFiles.test.ts                               (vitest + jsdom)
-  ✓ runs in parallel batches of 8 (verifies concurrency, not wall-clock)
-  ✓ surfaces per-file progress
-  ✓ collects failures without aborting the batch
-  ✓ rejects HEIC at the top
-  ✓ rejects non-image MIME types
-  ✓ simulated savePhotoFile rejection mid-batch → failure list contains
-     the file, no orphan marker
-```
+- `extractExif.test.ts` *(vitest + jsdom)*: GPS present, GPS absent,
+  GPS `(0,0)` exact, ISO timestamp, orientation tag, HEIC reject by
+  content (mis-named `.jpg`).
+- `generateThumb.test.ts` *(vitest + jsdom + canvas shim)*: size cap,
+  JPEG quality < 30 KB for 4 MP input, corrupt input throws, contentHash
+  produced. Single browser-spec test: produces upright JPEG for
+  Orientation=6 — we trust `createImageBitmap` for the Orientation=1
+  no-op case rather than testing the browser implementation.
+- `importPhotoFiles.test.ts` *(vitest + jsdom)*: batch concurrency,
+  progress callbacks, failure isolation, mid-batch storage rejection,
+  HEIC rejection.
 
 ---
 
@@ -328,17 +336,27 @@ remain individual `<Marker>` components.
 
 - 100 capture dots render at 60 fps on pan/zoom.
 - Clicking a capture dot opens the popup (Phase 5).
-- Subject pin drag updates `marker.lng/lat`; dashed line redraws via
-  GeoJSON source-data update on **drag-end** (not per-tick).
+- Subject pin drag updates `marker.lng/lat`; the active drag's dashed
+  line redraws each rAF tick (one line, cheap); non-active dashed
+  lines redraw only when their underlying coords change.
 - "Hide rejects" toggle (US-13) hides red dots via a Mapbox paint filter,
   zero DOM churn.
+- Dev smoke verifies layers persist correctly across React StrictMode
+  double-mount and Vite HMR reloads.
 - Existing KML-marker rendering unchanged.
 
-**Note on library naming.** The React binding entry point is
-`react-map-gl/mapbox` (Mapbox GL), not `maplibre-gl`. Earlier doc
-references to "MapLibre clustering" were imprecise — the existing
-infrastructure uses Mapbox GL. MapLibre remains in deps as a fallback
-style provider but is not the marker-mount layer.
+See [ADR-016](./decisions.md#adr-016-marker-rendering-split-geojson-layer-for-static-dots-individual-marker-for-picks)
+for the library-naming note and the additive-not-replacing nature of
+this change for corridor markers.
+
+**Dashed line drag tracking.** During an active subject-pin drag, the
+dashed line back to the capture ghost is updated per animation frame
+(rAF-throttled GeoJSON source data update for the *active* pin only).
+Drag-end commits the final position. Pre-drag and post-drag states use
+the cached source data.
+
+**Active drag uses `setDragPan(false)`** during a marker drag so the map
+doesn't pan under the user's finger.
 
 ---
 
@@ -395,15 +413,21 @@ viewport-anchored lng/lat strategy is dropped (ADR-012 revised).
 No-GPS photos exist only as candidate-pool entries until placed; they
 never receive synthetic coordinates.
 
+**Edge case.** If a user starts dragging from the tray while a marker
+popup is open, the popup is closed on `dragstart` from the tray to
+prevent the drop landing on the popup DOM instead of the map canvas.
+
 **Exit criteria.**
 
 - Import 5 photos with no GPS → 5 thumbs appear in the tray, ordered
   by EXIF timestamp.
 - Drag thumb onto map → subject pin appears at exact drop coord, tray
   shrinks by one.
+- Drag thumb when a popup is open → popup closes on `dragstart`; drop
+  lands on the map underneath.
 - Tray empty → collapses to chevron; click chevron re-opens tray (when
   more no-GPS photos arrive).
-- Tray state persists across reload.
+- Tray state persists across reload (`noGpsTrayOpen` field).
 - Tray covers ≤ 20% of map width and ≤ 120 px tall.
 - Side panel "No GPS" group lists the same photos until placed.
 
@@ -474,23 +498,50 @@ visibility regain.
   on every flag / label change. Register `pagehide` and `beforeunload`
   listeners to call `flushPendingMapPicks()` synchronously.
 
+*Photo-helper prep (first commit of this branch):*
+
+- Refactor `frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts`:
+  extract the inline canvas-state literal in `buildPhotoFromFile`
+  (around line 234) into an exported helper:
+  ```ts
+  export function createDefaultCanvasState(): ApiPhoto['canvasState'];
+  ```
+  Pure function, no `File` argument. `buildPhotoFromFile` calls it to
+  build photo-helper-originated photos; `useMapPicksSync` (below)
+  reuses it.
+
 *Reader (photo-helper):*
 
-- `frontend/photo-helper/src/hooks/useMapPicksSync.ts` *(new)*: ~50 LoC.
+- `frontend/photo-helper/src/hooks/useMapPicksSync.ts` *(new)*: ~70 LoC.
+  Implements upsert + delete semantics per
+  [ADR-019](./decisions.md#adr-019-usemappickssync-upsert-semantics-delete-propagation):
   ```ts
   export function useMapPicksSync(
     competitionDir: DirectoryHandle | null,
-    sessionApi: { addCandidatePhotos: (apiPhotos: ApiPhoto[]) => void; existingPhotoIds: Set<string> }
+    storage: StorageInterface,
+    sessionApi: {
+      candidates: ApiPhoto[];
+      upsertCandidate: (photo: ApiPhoto) => void;
+      removeCandidate: (photoId: string) => void;
+    }
   ): void;
   ```
-  Effect:
-  1. On `competitionDir` change: read `map-picks.json`, project each
-     `MapPickEntry` whose `photoId` is *not* in `existingPhotoIds` into
-     an `ApiPhoto` with default `canvasState` (using existing
-     `createDefaultCanvasState()` helper), and push into the candidate
-     pool.
-  2. Subscribe to `document.visibilitychange`; re-run the read on
-     `visible`.
+  Effect (runs on `competitionDir` change and on
+  `document.visibilitychange === 'visible'`):
+  1. Read `competitions/{compId}/map-picks.json`; if absent, no-op.
+  2. Build a `Set<photoId>` from the read entries.
+  3. For each `MapPickEntry`:
+     - If `photoId` not in pool: load the blob
+       (`storage.getPhotoBlob(photosDir, photoId)`), `URL.createObjectURL`,
+       construct `ApiPhoto` via `createDefaultCanvasState()`,
+       `upsertCandidate`.
+     - If `photoId` already in pool and entry is map-originated
+       (`pm-` prefix): `upsertCandidate` with the new
+       `flag` / `label` (preserve `canvasState` and other photo-helper
+       fields).
+  4. For each existing candidate with `photoId.startsWith('pm-')` that
+     is **not** in the read set: `removeCandidate(photoId)`. This
+     cleans up after deletes in map-corridors.
 - `frontend/photo-helper/src/AppApi.tsx` — call `useMapPicksSync` once
   after the competition is loaded.
 
@@ -538,9 +589,11 @@ millisecond-stale read on focus, fixed on the next visibilitychange).
     }
   }
   ```
-- Register `pagehide` and `beforeunload` listeners that synchronously
-  invoke `flushPendingMapPicks()` as a belt-and-suspenders safeguard for
-  back-button navigation, tab close, refresh.
+- Register a `pagehide` listener that calls `flushPendingMapPicks()`.
+  On web, this is best-effort (OPFS writes are async; if the page is
+  frozen mid-write, the next session sees the last successful write).
+  `beforeunload` is intentionally **not** used — it doesn't await
+  async work and only adds the appearance of safety.
 
 **Exit criteria.**
 
@@ -640,6 +693,12 @@ edge cases. Move PR out of draft.
 14. Drop a `.heic` file → friendly error toast.
 15. Drop a corrupt `.jpg` → it appears in the failure list, import does
     not abort.
+16. Fresh install, no Mapbox token configured → photo mode surfaces
+    the token-config CTA prominently. After dismissing, photo mode
+    still works with the OSM fallback (or shows a clear "configure
+    a map provider" empty state if no fallback ships).
+17. Re-import the same folder a second time → "N photos already
+    imported, M new" toast; no duplicate thumbs in the right-side panel.
 
 **PR description checklist.**
 
@@ -677,43 +736,47 @@ edge cases. Move PR out of draft.
 
 - Smoke script above.
 
-### Cross-app contract test (mandatory, not optional)
+### Cross-app contract coverage
 
-This is the load-bearing assumption of the feature, so it gets a
-real test:
+The `map-picks.json` contract is the load-bearing handoff between the
+two apps. Primary coverage comes from per-side unit tests that exercise
+the contract from each direction:
 
-- Boot map-corridors against a temporary OPFS competition directory.
-- Toggle a flag → wait for debounced write → verify `map-picks.json`
-  shape and content.
-- Boot photo-helper against the same dir. Invoke `useMapPicksSync` and
-  assert the candidate pool receives the corresponding `ApiPhoto`.
-- Add a regression case: photo-helper-originated photos in the
-  candidate pool are not overwritten by map-side picks (namespace
-  check on `pm-` prefix).
-- Test in `frontend/test/cross-app/` as a new test target, running
-  against an OPFS shim so it works in CI.
+- `mapPicksWriter.test.ts` (map-corridors side): writes a fixture
+  picks set, asserts the produced `map-picks.json` matches the
+  expected shape and content.
+- `useMapPicksSync.test.ts` (photo-helper side): given a fixture
+  `map-picks.json`, asserts the hook upserts / deletes correctly and
+  preserves photo-helper-originated entries (`pm-` namespace check).
+
+A full cross-app integration test (booting both apps against a
+shared OPFS shim) is **recommended** but not blocking; if the per-side
+unit tests stay tight and the Phase 11 manual smoke exercises the
+end-to-end path, the integration test can land as a follow-up.
 
 ---
 
 ## Risks and mitigations
 
+Risks already resolved by an ADR are not repeated here — see ADR-005
+(write race), ADR-009 (navigation race), ADR-015 (EXIF double-rotation),
+ADR-016 (marker perf), ADR-018 (OPFS quota policy), ADR-019 (deletion
+propagation).
+
 | Risk | Severity | Mitigation |
 |---|---|---|
-| `exifr` tree-shake doesn't kick in → 30 KB+ added | MED | Phase 0 gates on a measured ≤ 12 KB gz contribution. Fall back to inline canvas EXIF parser (~5 lines for GPS-only) if size unacceptable. |
-| `pica` added but bloats map-corridors bundle | LOW | v1 starts without `pica` — plain canvas downscale to 200×150 is adequate for popup thumbs. Only add `pica` if Phase 1 measurement shows visible quality regression at popup size. |
-| Marker render perf at 100+ photos | HIGH | Resolved by ADR-016 (GeoJSON layers for static dots; `<Marker>` only for picks). Phase 4 exit criterion verifies 60 fps at 100 dots. |
-| Concurrent writers to a single JSON file | RESOLVED | ADR-005 (revised) uses one-way `map-picks.json`: one writer (map-corridors), one reader (photo-helper). No lock needed. |
-| Navigation race: debounced write lost on app switch | RESOLVED | ADR-009 (revised) requires `await flushPendingMapPicks()` before navigation + `pagehide`/`beforeunload` listeners. |
-| EXIF orientation double-rotation on phone-pre-rotated photos | RESOLVED | ADR-015: use `createImageBitmap(file, { imageOrientation: 'from-image' })` — the browser handles both conventions per spec. |
-| OPFS quota at high photo counts | MED | Hard pre-flight check: `getStorageEstimate().usage + estimatedBatch > 0.8 * quota` blocks the drop with a friendly modal. Existing `isStorageLow` warning continues to fire. |
-| Mapbox token not configured on first app open | MED | Photo source mode is useless without a map. Surface the token-config CTA prominently. Fallback to OpenStreetMap raster tile (no token needed) if token absent. |
+| `exifr` bundle larger than expected | MED | Phase 0 measures actual contribution and records in PR. Soft target ≤ 15 KB gz; if > 25 KB, switch to a manual GPS-only parser (~5 lines). |
+| `pica` added but bloats map-corridors bundle | LOW | v1 starts without `pica` — plain canvas downscale to 200×150 is adequate for popup thumbs. Only add if Phase 1 measurement shows visible quality regression. |
+| Mapbox token not configured on first app open | MED | Photo source mode is useless without a map. Surface the token-config CTA prominently when entering photo mode without a token. Fallback to OpenStreetMap raster tile (no token needed) — see [Open question](#open-implementation-questions). |
 | User accidentally clicks "Send to editor" with 0 picks | LOW | Button disabled when picks = 0. |
-| Coordinate precision loss when dragging at high zoom | LOW | float64 throughout. Existing `dragMovedPxRef` threshold of 8 px equals ~1.2 m at zoom 19 — could misclassify a precise placement as click. Lower threshold to 3 px for photo-mode subject pins. |
-| Browser drag-and-drop API quirks on Windows | LOW | Already exercised by existing dropzone code. Reuse `react-dropzone`. |
-| `competitionService.saveSessionPhotos` re-fetches all blobs on every save | MED | Existing dedup-by-id at line 591 helps but every persistence still iterates all pools. At 100 photos this can add 200–400 ms per save. Mitigation: track a dirty-photo set; only re-fetch blob URLs for changed photos. |
-| Photo blob orphans after OPFS eviction | LOW | On session load, validate each `photoId` in the candidate pool has a corresponding file in `photos/`. Surface a non-blocking banner if any are missing. |
-| Web tab × two = OPFS shared origin race | MED | Mitigated by ADR-005's single-writer-per-file design. Photo-helper reads on visibilitychange so a stale read self-heals within a focus cycle. |
+| Coordinate precision at high zoom (sub-meter) | LOW | float64 throughout. The existing `dragMovedPxRef` click-vs-drag threshold of 8 px (≈ 1.2 m at zoom 19) is shared by all marker types in `MapProviderView`; do not lower it globally. If photo-mode subject pins prove to misclassify drag-as-click, add a per-marker threshold prop rather than changing the default. |
+| Browser drag-and-drop quirks on Windows | LOW | Already exercised by existing dropzone code. Reuse `react-dropzone`. |
+| `competitionService.saveSessionPhotos` re-fetches all blobs on every save | MED | At 100 photos this can add 200–400 ms per save. Track a dirty-photo set; only re-fetch blob URLs for changed photos. |
+| Photo blob orphans after OPFS eviction | LOW | On session load, validate each `photoId` has a corresponding file in `photos/`. Surface a non-blocking banner if any are missing. |
 | HEIC by content but `.jpg` extension | LOW | `extractExif` checks file content (magic bytes), not just extension. Test fixture covers misnamed HEIC. |
+| StrictMode double-mount drops GeoJSON source registrations in dev | LOW | Smoke against `pnpm dev` before merge; pattern is documented in `react-map-gl` issues. Production builds aren't affected. |
+| Cross-tab photo write collision (same content, two tabs) | LOW | `pm-` namespace prevents accidental collisions across apps; deliberate cross-tab duplication is last-write-wins (acceptable). `savePhotoFile` is documented as last-write-wins. |
+| `getPathForFile` Electron-only | LOW | Map-corridors photo import path uses the standard browser File API; no Electron-only path needed (unlike photo-helper's existing `read-photo-file` IPC for some edge cases). Document in Phase 3. |
 
 ---
 

--- a/docs/photo-map-culling/user-stories.md
+++ b/docs/photo-map-culling/user-stories.md
@@ -28,8 +28,8 @@ geographic context immediately and skip the blind Explorer-thumbnail step.
 - After drop, the map zooms (fit-bounds) to enclose all photos with GPS.
 - Each photo with GPS appears as a small grey dot at its capture location.
 - Import progress is visible (progress bar / count) for batches > 10 photos.
-- Files without GPS are still imported, placed along the lower edge of the
-  visible map ([ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy), [US-8](#us-8--work-with-photos-that-have-no-gps)).
+- Files without GPS are still imported, surfaced in an off-map tray
+  pinned to the map corner ([ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner), [US-8](#us-8--work-with-photos-that-have-no-gps)).
 - Existing KML/GPX corridor data, if loaded, remains visible alongside photos.
 
 **Out of scope:** HEIC files trigger an error toast ([ADR-006](./decisions.md#adr-006-no-heic-support-in-v1)).
@@ -64,8 +64,10 @@ and the corridor check.
 - Clicking "Include" in the popup flips the photo's flag to `pick`.
 - The grey capture dot becomes a coloured pin at the same location, marked
   for subject placement.
-- The photo appears in the photo-helper candidate tray with `flag: 'pick'`
-  on the next visit ([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool)).
+- The flag change is persisted to `map-picks.json` within 300 ms (debounced).
+- Photo-helper, on next competition load (or tab focus), reads
+  `map-picks.json` and adds the photo to its candidate tray with
+  `flag: 'pick'` ([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-a-one-way-map-picksjson-file)).
 - The pin is visually distinct from corridor-derived markers (different
   default colour or border style).
 
@@ -144,26 +146,32 @@ and answer sheet.
 ## US-8 — Work with photos that have no GPS
 
 **As an** organizer who occasionally has photos without GPS metadata, **I
-want** them placed somewhere reasonable on the map, **so that** I can
-quickly drag them to where they belong without hunting for them in a
-sidebar.
+want** to see them as draggable thumbnails on the map surface, **so that**
+I can grab one and place it where it belongs without hunting for it in a
+hidden sidebar.
 
 **Acceptance criteria**
 
-- Photos without GPS appear along the **lower edge of the current map
-  viewport**, in a single row.
-- They are ordered left-to-right by EXIF `DateTimeOriginal` (with filename
-  as a tiebreaker for photos missing time).
-- Each is rendered as a distinct "needs placement" marker — orange/yellow
-  background with a `?` glyph — visually different from located photos.
-- Spacing between markers is ~80 px so they don't overlap.
-- If more no-GPS photos than fit in the viewport width, they wrap to a
-  second row above the first.
-- When the user drags one to a position, it converts to a normal subject
-  pin (no ghost marker / dashed line, since there was no capture point).
-- They are also listed in the right-side panel under a "No GPS" section
-  ([US-12](#us-12--filter-the-photo-list-by-flag-or-no-gps)).
-- Strategy locked in [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy).
+- Photos without GPS appear as thumbnails in an **off-map tray** pinned
+  to the bottom-left corner of the map view, layered above the map but
+  not anchored to map coordinates.
+- Tray scrolls horizontally; thumbnails are ordered left-to-right by
+  EXIF `DateTimeOriginal` (with filename as a tiebreaker for photos
+  missing time).
+- Tray height ≤ ~120 px so it does not dominate the map.
+- A thumbnail in the tray can be dragged onto any point on the map. On
+  drop, a normal subject pin (flag = `pick`) is created at the projected
+  lng/lat (`map.unproject([clientX, clientY])`) and the thumbnail leaves
+  the tray.
+- Each thumbnail offers click-to-popup (label assignment, mark
+  rejected, etc.) without leaving the tray.
+- When the tray is empty, it collapses to a small chevron icon so the
+  map surface is fully visible.
+- Tray collapsed/expanded state persists across reload via
+  `corridors-session.json:noGpsTrayOpen`.
+- These same photos are also listed in the right-side panel under a
+  "No GPS" section ([US-12](#us-12--filter-the-photo-list-by-flag-or-no-gps)).
+- Strategy locked in [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner).
 
 ---
 

--- a/docs/photo-map-culling/user-stories.md
+++ b/docs/photo-map-culling/user-stories.md
@@ -1,0 +1,284 @@
+# User Stories — Photo Map Culling
+
+Primary role: **Competition organizer**. They shoot the photos, run them
+through the helpers, and produce both the printed photo sheet and the
+answer sheet.
+
+Format:
+
+> **As a** [role], **I want** [action], **so that** [benefit].
+
+Each story has acceptance criteria phrased so they can be checked against a
+manual run or written as a test. Stories link to the relevant ADRs in
+[decisions.md](./decisions.md) where the design is locked.
+
+---
+
+## US-1 — Import GPS-tagged photos onto a map
+
+**As an** organizer, **I want** to drag-and-drop a batch of 30–100 photos
+that have GPS EXIF data onto the map app, **so that** I see them in their
+geographic context immediately and skip the blind Explorer-thumbnail step.
+
+**Acceptance criteria**
+
+- Photo source mode is selectable via an explicit toggle at the top of
+  map-corridors ([ADR-002](./decisions.md#adr-002-explicit-mode-toggle)).
+- In photo source mode, the dropzone accepts `.jpg`, `.jpeg`, `.png`.
+- After drop, the map zooms (fit-bounds) to enclose all photos with GPS.
+- Each photo with GPS appears as a small grey dot at its capture location.
+- Import progress is visible (progress bar / count) for batches > 10 photos.
+- Files without GPS are still imported, placed along the lower edge of the
+  visible map ([ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy), [US-8](#us-8--work-with-photos-that-have-no-gps)).
+- Existing KML/GPX corridor data, if loaded, remains visible alongside photos.
+
+**Out of scope:** HEIC files trigger an error toast ([ADR-006](./decisions.md#adr-006-no-heic-support-in-v1)).
+
+---
+
+## US-2 — Preview a photo before deciding
+
+**As an** organizer, **I want** to quickly preview the photo behind a map
+dot, **so that** I can decide whether it's a usable shot without opening a
+separate viewer.
+
+**Acceptance criteria**
+
+- Hovering a capture dot shows a small thumbnail tooltip (~80×60 px).
+- Clicking a capture dot opens a popup with a larger thumbnail (~200×150),
+  filename, capture time, and action buttons (Include / Skip / Reject).
+- The thumbnail loads instantly because it was pre-generated at import time
+  ([ADR-012](./decisions.md#adr-012-thumbnail-storage-in-photosthumbs)).
+- Popup can be dismissed by clicking elsewhere on the map or pressing Esc.
+
+---
+
+## US-3 — Include a photo in the final selection
+
+**As an** organizer, **I want** to mark a photo as "use this one", **so
+that** it propagates downstream to the photo editor (for cropping/printing)
+and the corridor check.
+
+**Acceptance criteria**
+
+- Clicking "Include" in the popup flips the photo's flag to `pick`.
+- The grey capture dot becomes a coloured pin at the same location, marked
+  for subject placement.
+- The photo appears in the photo-helper candidate tray with `flag: 'pick'`
+  on the next visit ([ADR-005](./decisions.md#adr-005-cross-app-handoff-via-shared-candidate-pool)).
+- The pin is visually distinct from corridor-derived markers (different
+  default colour or border style).
+
+---
+
+## US-4 — Skip a photo
+
+**As an** organizer, **I want** to mark a photo as "not for this batch but
+maybe later", **so that** it stays accessible but doesn't clutter the final
+selection.
+
+**Acceptance criteria**
+
+- Clicking "Skip" in the popup sets the photo's flag to `neutral`.
+- The capture dot stays grey; no subject pin appears.
+- The photo appears in the right-side list under "Neutral".
+- Photo is **not** included in the count sent to the editor.
+
+---
+
+## US-5 — Reject a photo
+
+**As an** organizer, **I want** to mark a photo as "actively bad" (blurry,
+wrong subject, etc.), **so that** it's visually flagged out without being
+deleted (in case I change my mind).
+
+**Acceptance criteria**
+
+- Clicking "Reject" sets the photo's flag to `reject`.
+- The dot turns red with low opacity (≤ 40%).
+- A "Hide rejects" toggle in the toolbar hides red dots from the map.
+- Rejects also appear in the photo-helper tray as `reject`, matching the
+  existing candidate-pool semantics.
+
+---
+
+## US-6 — Move the subject pin from capture point to actual subject
+
+**As an** organizer, **I want** to drag a photo's pin from where I was
+standing to where the photographed object actually is, **so that** the
+corridor legality check and answer sheet use the right coordinates.
+
+**Acceptance criteria**
+
+- On Include, the subject pin defaults to the capture point
+  ([ADR-008](./decisions.md#adr-008-default-subject-pin-position-at-capture-point)).
+- The pin is draggable; on drag-end, its `lng/lat` updates.
+- The original capture point becomes a small ghost marker (dimmer than the
+  pin), with a dashed line connecting them, so the relationship is visible.
+- If the user doesn't drag, the ghost marker and pin overlap and the line
+  collapses to zero length.
+- The pin's coordinates are the ones used by the corridor legality check
+  and answer-sheet generator.
+
+---
+
+## US-7 — Assign a competition label
+
+**As an** organizer, **I want** to assign a letter (A–T) or number (1–20)
+to each picked photo, **so that** it maps to the competition's photo grid
+and answer sheet.
+
+**Acceptance criteria**
+
+- Discipline (Rally vs Precision) is inherited from the active competition
+  ([ADR-009](./decisions.md#adr-009-discipline-support-both-rally-and-precision)).
+- Rally uses letters A–T, Precision uses numbers 1–20 (existing
+  `getLabelsForDiscipline` from `@airq/shared-discipline`).
+- The popup shows a label picker. Already-assigned labels are visually
+  marked as taken.
+- Labels appear as small badges on the pin on the map.
+- Removing a label frees it for reuse.
+
+---
+
+## US-8 — Work with photos that have no GPS
+
+**As an** organizer who occasionally has photos without GPS metadata, **I
+want** them placed somewhere reasonable on the map, **so that** I can
+quickly drag them to where they belong without hunting for them in a
+sidebar.
+
+**Acceptance criteria**
+
+- Photos without GPS appear along the **lower edge of the current map
+  viewport**, in a single row.
+- They are ordered left-to-right by EXIF `DateTimeOriginal` (with filename
+  as a tiebreaker for photos missing time).
+- Each is rendered as a distinct "needs placement" marker — orange/yellow
+  background with a `?` glyph — visually different from located photos.
+- Spacing between markers is ~80 px so they don't overlap.
+- If more no-GPS photos than fit in the viewport width, they wrap to a
+  second row above the first.
+- When the user drags one to a position, it converts to a normal subject
+  pin (no ghost marker / dashed line, since there was no capture point).
+- They are also listed in the right-side panel under a "No GPS" section
+  ([US-12](#us-12--filter-the-photo-list-by-flag-or-no-gps)).
+- Strategy locked in [ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy).
+
+---
+
+## US-9 — Switch between corridor and photo source without losing work
+
+**As an** organizer, **I want** to flip between corridor-mode (KML/GPX) and
+photo-mode without losing data in either, **so that** I can review both in
+the same session.
+
+**Acceptance criteria**
+
+- The mode toggle is a non-destructive UI control. Switching does not
+  delete markers or photos.
+- Both corridor markers and photo-derived markers can be visible
+  simultaneously (the toggle controls the *input* surface, not visibility).
+- The toggle's state persists per-competition in the corridor session JSON.
+
+---
+
+## US-10 — Send selections to the photo editor
+
+**As an** organizer, **I want** a one-click action to jump to the photo
+editor after I've finished culling, **so that** I can immediately start
+cropping/labeling without manually opening a different app.
+
+**Acceptance criteria**
+
+- A "Send to editor (N picks)" button is visible when ≥ 1 photo has flag
+  `pick`.
+- Clicking it navigates the app to photo-helper via the existing
+  `electronAPI.navigateToApp('photo-helper', { competitionId })` IPC
+  (Electron) or `/photo-helper/?competitionId=…` URL (web).
+- **No** explicit data transfer happens at click time — data already lives
+  in the shared candidate pool ([ADR-010](./decisions.md#adr-010-send-to-editor-navigates-only)).
+- On arrival in photo-helper, the candidate tray contains all picked
+  photos, ready for slot assignment.
+
+---
+
+## US-11 — Persistence across restarts
+
+**As an** organizer, **I want** my culling work to survive app restarts,
+browser refreshes, and computer reboots, **so that** I can pause and resume
+without re-importing.
+
+**Acceptance criteria**
+
+- All picked / neutral / rejected flags persist in
+  `competitions/{compId}/corridors-session.json` and mirror to the
+  photo-helper `session.json`'s `candidates.photos[]`.
+- Thumbnails persist in `competitions/{compId}/photos/thumbs/{photoId}.jpg`.
+- Original photo blobs persist in `competitions/{compId}/photos/{photoId}`.
+- Subject pin coordinates and label assignments survive reload.
+- Reload after a force-quit mid-import recovers cleanly (partial photos
+  are visible if their full save completed; partial ones are discarded).
+
+---
+
+## US-12 — Filter the photo list by flag or "no GPS"
+
+**As an** organizer working with 50+ photos, **I want** to filter the photo
+list to just picks, just rejects, or just no-GPS, **so that** I can focus
+on one decision at a time.
+
+**Acceptance criteria**
+
+- A right-side photo list panel renders alongside the map.
+- The panel groups photos by flag: Picks / Neutral / Rejects / No GPS.
+- Clicking a list item flies the map to that photo and opens its popup.
+- Clicking a flag group header collapses/expands the group.
+- The panel can be collapsed into a drawer on narrow viewports.
+
+---
+
+## US-13 — Reject filter / Hide rejects
+
+**As an** organizer who has triaged a batch and rejected some, **I want**
+to hide the red rejected dots on the map, **so that** I can see the surface
+without visual noise — but still revisit rejects from the side panel if I
+change my mind.
+
+**Acceptance criteria**
+
+- A "Hide rejects" toggle in the toolbar.
+- When on, red dots are hidden from the map. Rejects still appear in the
+  side panel (under their group).
+- The toggle's state persists per-session.
+
+---
+
+## US-14 — Per-competition isolation
+
+**As an** organizer running back-to-back competitions, **I want** photos
+imported into competition A to not appear in competition B, **so that** I
+don't accidentally print one event's photos for another.
+
+**Acceptance criteria**
+
+- All photo data is scoped under `competitions/{compId}/`.
+- Switching active competition via the launcher reloads photos for the new
+  one only.
+- No global photo bucket exists.
+
+---
+
+## US-15 — Replace the existing manual-click marker workflow when desired
+
+**As an** organizer who has used the old click-on-map workflow, **I want**
+to still be able to fall back to it if EXIF data is unavailable or
+unreliable, **so that** the new feature never traps me.
+
+**Acceptance criteria**
+
+- The corridor source mode (click-to-place) is fully preserved.
+- It is the default mode for a fresh competition without any photo imports.
+- Switching to photo mode never disables the click-to-place behaviour for
+  the corridor markers already on the map; new EXIF markers and click-placed
+  markers coexist on the same `markers[]` array.

--- a/docs/photo-map-culling/user-stories.md
+++ b/docs/photo-map-culling/user-stories.md
@@ -22,9 +22,9 @@ geographic context immediately and skip the blind Explorer-thumbnail step.
 
 **Acceptance criteria**
 
-- Photo source mode is selectable via an explicit toggle at the top of
-  map-corridors ([ADR-002](./decisions.md#adr-002-explicit-mode-toggle)).
-- In photo source mode, the dropzone accepts `.jpg`, `.jpeg`, `.png`.
+- The map-corridors dropzone accepts `.jpg`, `.jpeg`, `.png` in addition
+  to KML/GPX. Routing is implicit by file extension — no mode toggle
+  ([ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle)).
 - After drop, the map zooms (fit-bounds) to enclose all photos with GPS.
 - Each photo with GPS appears as a small grey dot at its capture location.
 - Import progress is visible (progress bar / count) for batches > 10 photos.
@@ -175,19 +175,24 @@ hidden sidebar.
 
 ---
 
-## US-9 — Switch between corridor and photo source without losing work
+## US-9 — Corridor and photo work coexist on one map
 
-**As an** organizer, **I want** to flip between corridor-mode (KML/GPX) and
-photo-mode without losing data in either, **so that** I can review both in
-the same session.
+**As an** organizer, **I want** to load a KML corridor and EXIF photos in
+the same session and see both on the same map, **so that** I can verify a
+photo's subject is inside the corridor without leaving the view.
 
 **Acceptance criteria**
 
-- The mode toggle is a non-destructive UI control. Switching does not
-  delete markers or photos.
-- Both corridor markers and photo-derived markers can be visible
-  simultaneously (the toggle controls the *input* surface, not visibility).
-- The toggle's state persists per-competition in the corridor session JSON.
+- A KML/GPX corridor and JPEG photos can be dropped onto map-corridors in
+  any order; both render simultaneously without switching anything.
+- No "Corridor / Photo" toggle exists in the UI ([ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle)).
+- Dropping a KML when photos are already on the map does not remove the
+  photos; dropping photos when a corridor is loaded does not remove the
+  corridor.
+- The right-side photo list panel auto-appears when there is ≥ 1 imported
+  photo and auto-hides when there are none. No user action required.
+- The session file (`corridors-session.json`) carries no `sourceMode`
+  field — there's no mode to persist.
 
 ---
 
@@ -285,8 +290,9 @@ unreliable, **so that** the new feature never traps me.
 
 **Acceptance criteria**
 
-- The corridor source mode (click-to-place) is fully preserved.
-- It is the default mode for a fresh competition without any photo imports.
-- Switching to photo mode never disables the click-to-place behaviour for
-  the corridor markers already on the map; new EXIF markers and click-placed
-  markers coexist on the same `markers[]` array.
+- Click-to-place corridor-marker placement is fully preserved — it is the
+  existing map-corridors behaviour and continues to work at all times.
+- Importing photos never disables click-to-place; click-placed markers and
+  EXIF-imported markers coexist on the same `markers[]` array.
+- A fresh competition without any photo imports renders identically to
+  today's map-corridors (no extra chrome, no photo side panel).

--- a/docs/photo-map-culling/user-stories.md
+++ b/docs/photo-map-culling/user-stories.md
@@ -29,7 +29,7 @@ geographic context immediately and skip the blind Explorer-thumbnail step.
 - Each photo with GPS appears as a small grey dot at its capture location.
 - Import progress is visible (progress bar / count) for batches > 10 photos.
 - Files without GPS are still imported, placed along the lower edge of the
-  visible map ([ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy), [US-8](#us-8--work-with-photos-that-have-no-gps)).
+  visible map ([ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy), [US-8](#us-8--work-with-photos-that-have-no-gps)).
 - Existing KML/GPX corridor data, if loaded, remains visible alongside photos.
 
 **Out of scope:** HEIC files trigger an error toast ([ADR-006](./decisions.md#adr-006-no-heic-support-in-v1)).
@@ -48,7 +48,7 @@ separate viewer.
 - Clicking a capture dot opens a popup with a larger thumbnail (~200×150),
   filename, capture time, and action buttons (Include / Skip / Reject).
 - The thumbnail loads instantly because it was pre-generated at import time
-  ([ADR-012](./decisions.md#adr-012-thumbnail-storage-in-photosthumbs)).
+  ([ADR-011](./decisions.md#adr-011-thumbnail-storage-in-photosthumbs)).
 - Popup can be dismissed by clicking elsewhere on the map or pressing Esc.
 
 ---
@@ -111,7 +111,7 @@ corridor legality check and answer sheet use the right coordinates.
 **Acceptance criteria**
 
 - On Include, the subject pin defaults to the capture point
-  ([ADR-008](./decisions.md#adr-008-default-subject-pin-position-at-capture-point)).
+  ([ADR-007](./decisions.md#adr-007-default-subject-pin-position-at-capture-point)).
 - The pin is draggable; on drag-end, its `lng/lat` updates.
 - The original capture point becomes a small ghost marker (dimmer than the
   pin), with a dashed line connecting them, so the relationship is visible.
@@ -131,7 +131,7 @@ and answer sheet.
 **Acceptance criteria**
 
 - Discipline (Rally vs Precision) is inherited from the active competition
-  ([ADR-009](./decisions.md#adr-009-discipline-support-both-rally-and-precision)).
+  ([ADR-008](./decisions.md#adr-008-discipline-support-both-rally-and-precision)).
 - Rally uses letters A–T, Precision uses numbers 1–20 (existing
   `getLabelsForDiscipline` from `@airq/shared-discipline`).
 - The popup shows a label picker. Already-assigned labels are visually
@@ -163,7 +163,7 @@ sidebar.
   pin (no ghost marker / dashed line, since there was no capture point).
 - They are also listed in the right-side panel under a "No GPS" section
   ([US-12](#us-12--filter-the-photo-list-by-flag-or-no-gps)).
-- Strategy locked in [ADR-013](./decisions.md#adr-013-no-gps-photo-placement-strategy).
+- Strategy locked in [ADR-012](./decisions.md#adr-012-no-gps-photo-placement-strategy).
 
 ---
 
@@ -197,7 +197,7 @@ cropping/labeling without manually opening a different app.
   `electronAPI.navigateToApp('photo-helper', { competitionId })` IPC
   (Electron) or `/photo-helper/?competitionId=…` URL (web).
 - **No** explicit data transfer happens at click time — data already lives
-  in the shared candidate pool ([ADR-010](./decisions.md#adr-010-send-to-editor-navigates-only)).
+  in the shared candidate pool ([ADR-009](./decisions.md#adr-009-send-to-editor-navigates-only)).
 - On arrival in photo-helper, the candidate tray contains all picked
   photos, ready for slot assignment.
 


### PR DESCRIPTION
## Summary

Design exploration for a new feature that collapses today's two-step photo cull/place workflow into a single map-driven step. Drop GPS-tagged photos → see them as dots on a map at capture location → click to cull → drag pin from capture to subject location. Selections flow automatically into both photo-helper (candidate tray) and map-corridors (PhotoMarkers + answer sheet).

**Implemented as a new \`Photo source\` mode inside the existing \`map-corridors\` app** — not a new sub-app and not a photo-helper extension (see [ADR-001](docs/photo-map-culling/decisions.md#adr-001-extend-map-corridors-rather-than-build-a-new-app)).

Docs only. No code touched.

## Doc structure

\`docs/photo-map-culling/\`
- \`README.md\` — feature overview, workflow diagram, time-budget estimate
- \`user-stories.md\` — 15 user stories with acceptance criteria
- \`decisions.md\` — 16 ADRs (each with options considered, decision, consequences)
- \`implementation-plan.md\` — 11 phases, file-level scope, exit criteria, test plan, rollback

## Commit history

1. \`3752b7f\` — initial 4-file doc structure
2. \`42f51c8\` — strip all drone references (out of scope)
3. \`4f33083\` — incorporate adversarial review (critic + advocate subagents)

## Architectural pivots locked

- **Extend \`map-corridors\`** (not new app, not photo-helper extension)
- **One-way \`map-picks.json\`** as the cross-app contract — single writer per file, no lock (revised from earlier \"mirror into session.json\" after review)
- **Single \`PhotoMarker.lng/lat\` = subject** + optional \`capturedAt\` metadata — zero migration for existing consumers
- **Off-map tray** for no-GPS photos (revised from viewport-anchored placement after review)
- **\`createImageBitmap\`** for EXIF orientation (not manual rotation — prevents double-rotation bugs)
- **Marker rendering split**: GeoJSON layers for static dots, individual \`<Marker>\` for picks only (handles 100+ photos at 60 fps)
- **HEIC out of scope v1**
- **Drones out of scope** (not used in this competition photography workflow)

## Test plan

This PR is doc-only. Review checklist:

- [ ] Read README for the workflow story
- [ ] Read user-stories for the UX surface
- [ ] Read decisions.md ADRs — especially ADR-001 (app boundary), ADR-005 (cross-app contract), ADR-012 (no-GPS tray)
- [ ] Read implementation-plan.md for phasing — Phase 0 + Phase 1 are the first commit-worthy slice
- [ ] Flag any architectural call you disagree with so we revise here before code starts
- [ ] Confirm \`feat/candidate-photos\` is the right upstream dependency