### PR TITLE
feat(photo-map-culling): photo map culling flow with bidirectional label sync #minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Test photos and documentation
-photos/
+# `/photos/` only at repo root — the photo-map-culling test fixture dir
+# at frontend/map-corridors/test/fixtures/photos/ is legitimately tracked.
+/photos/
 tmp/
 TODO.md
 

--- a/docs/photo-map-culling/guide.md
+++ b/docs/photo-map-culling/guide.md
@@ -1,0 +1,341 @@
+# Photo Map Culling — User & Developer Guide
+
+Single-file reference for the **photo-map-culling** feature as it ships
+on branch `feat/photo-map-culling`. Covers:
+
+- [User workflow](#user-workflow): the natural locate → select → label → print flow
+- [Visual language](#visual-language): what every pin / color / shape means
+- [Data schemas](#data-schemas): in-memory + on-disk types
+- [On-disk file layout](#on-disk-file-layout): how the per-competition directory is structured
+- [Cross-app handoff](#cross-app-handoff): how map-corridors talks to photo-helper
+- [Deferred work](#deferred-work): what's intentionally not done yet
+- [Source map](#source-map): where to look for what
+
+For ADR-level design rationale see
+[`decisions.md`](./decisions.md); for the planned phase order see
+[`implementation-plan.md`](./implementation-plan.md). This guide is the
+**as-built** reference — the others are design history.
+
+---
+
+## User workflow
+
+```
+┌─────────────┐   ┌──────────┐   ┌───────────┐   ┌──────────┐
+│  1. Locate  │ → │ 2. Select│ → │ 3. Label  │ → │ 4. Print │
+│  (drop JPGs)│   │ Inc/Skip │   │ A–T / 1–20│   │ map +    │
+│             │   │ /Reject  │   │           │   │ answer   │
+└─────────────┘   └──────────┘   └───────────┘   └──────────┘
+       │
+       └── 1b. Place no-GPS photos by dragging from the bottom-left tray
+```
+
+### 1. Locate
+
+Drop a batch of JPEG/PNG files onto the map (single dropzone, no mode
+toggle — see [ADR-021](./decisions.md#adr-021--implicit-dropzone-routing-no-mode-toggle)).
+
+- Files with EXIF GPS → grey circle appears at the capture coords. Live
+  progress in the top bar; success/failure summary in a snackbar.
+- Files **without** GPS → bottom-left "Bez GPS" tray. Drag a thumbnail
+  from the tray onto any spot on the map to place it.
+- HEIC files → rejected ([ADR-006](./decisions.md#adr-006--no-heic-support-in-v1)).
+- Any other extension → toast: "Unsupported file: {name}".
+
+The same dropzone also accepts `.kml` / `.gpx` for the corridor — file
+type routes automatically. A mixed batch (1 KML + 30 JPGs) imports both
+in parallel.
+
+### 2. Select
+
+Click any photo dot → popup with thumbnail + three buttons:
+
+| Action | Effect |
+|---|---|
+| **Include** | `flag = 'pick'` — pin turns blue. Popup stays open so you can label next. |
+| **Skip** | Clears any prior flag (used to undo a Reject). Popup closes. |
+| **Reject** | `flag = 'reject'` — pin turns red, faded. Popup closes. |
+
+You can also drag the pin to the actual subject location of the photo
+(where the object IS, not where the camera was). Once moved, a ghost
+dot + dashed line appear at the EXIF capture spot — that's how you tell
+at a glance which photos have been **processed** vs **untouched**.
+
+### 3. Label
+
+In the same popup, the **A–T** grid (Rally) or **1–20** grid (Precision)
+lets you assign a letter/number to the photo. The pin then turns
+**yellow** — matches the existing KML-marker color — to signal "this
+photo is on the answer sheet".
+
+- Labels are unique per competition; taken letters show as disabled
+  with strikethrough.
+- Click the currently-assigned letter again to clear it.
+
+### 4. Print
+
+The standard map-corridors **Print Map** button captures the map
+including all photo pins (yellow + labelled). The **Show Answer Sheet**
+dialog lists photos in label order — same flow as the existing KML
+marker answer sheet, just sourced from photos now too.
+
+The right-side **Photos** panel shows live counts in four groups:
+**Picks** / **Neutral** / **Rejects** / **No GPS**. Click an item → map
+flies to that photo and the popup opens. The **Send to editor (N)**
+footer button at the bottom flushes any pending writes and navigates to
+photo-helper for cropping/leveling.
+
+---
+
+## Visual language
+
+| Visual element | Meaning |
+|---|---|
+| **Hollow circle, grey ring** | Imported with GPS; user hasn't touched it yet. Pin sits at the EXIF capture point. |
+| **Hollow circle, blue ring** | Picked (`flag = 'pick'`) but the user hasn't dragged the subject pin yet. |
+| **Hollow circle, red ring (faded)** | Rejected (`flag = 'reject'`). Still at the capture point. |
+| **Hollow circle, yellow ring** | Labelled. Ready for the answer sheet. (Often paired with picked.) |
+| **Filled circle + shadow** | Same colors apply, but **filled = "moved"** — user has dragged the pin to the subject location. "Processed." |
+| **Tiny grey dot (50% opacity)** | A ghost at the original EXIF capture point. Appears only when the photo has been moved. |
+| **Dashed grey line** | Connects ghost (capture) → live pin (subject). Same membership rule as the ghost — moved photos only. |
+| **Yellow square pin** | Existing **KML / click-placed** marker. Unchanged from the original map-corridors flow. |
+| **Orange `?` thumbnail (bottom-left tray)** | Imported photo with no EXIF GPS, awaiting placement via drag. |
+
+### Color summary
+
+```
+                  unmoved (hollow)        moved (filled)
+neutral           ○ grey                  ● grey
+pick              ○ blue                  ● blue
+reject            ○ red (faded)           ● red (faded)
+labelled          ○ yellow                ● yellow
+```
+
+**Yellow always wins** — if a marker is labelled, it shows yellow
+regardless of its flag. This matches the KML marker color and signals
+"on the answer sheet".
+
+---
+
+## Data schemas
+
+### `PhotoMarker` — in-memory marker (one per imported photo)
+
+```ts
+type PhotoMarker = Readonly<{
+  id: string                     // === photoId for EXIF imports, `pm-<uuid>`
+  lng: number                    // Subject location (answer-sheet coord)
+  lat: number
+  name: string                   // Filename
+  label?: 'A' | … | 'T' | '1' | … | '20'
+  capturedAt?: Readonly<{        // EXIF source — absent for no-GPS placements
+    lng: number
+    lat: number
+    altitude?: number
+    timestamp?: string           // ISO 8601
+  }>
+  photoId?: string               // `pm-<uuid>` — links to OPFS files
+  flag?: 'pick' | 'reject'       // absent = neutral
+}>
+```
+
+Lives in `corridors-session.json:markers[]`. KML/click-placed markers
+have `photoId === undefined` and `capturedAt === undefined`.
+
+### `NoGpsPhoto` — tray entry, awaiting placement
+
+```ts
+type NoGpsPhoto = Readonly<{
+  photoId: string
+  filename: string
+  timestamp?: string             // for tray sort order
+}>
+```
+
+Lives in `corridors-session.json:noGpsPhotos[]`. Becomes a `PhotoMarker`
+with `flag: 'pick'` (no `capturedAt`) once the user drags it onto the map.
+
+### `MapPicksFile` — cross-app handoff (`map-picks.json`)
+
+```ts
+type MapPicksFile = {
+  version: 1
+  updatedAt: string              // ISO 8601
+  picks: MapPickEntry[]
+}
+type MapPickEntry = {
+  photoId: string                // always `pm-` prefix
+  filename: string
+  flag: 'pick' | 'neutral' | 'reject'   // denormalized (absent → 'neutral')
+  gps?: {
+    capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string }
+    subjectAt?: { lng: number; lat: number }  // present only if moved
+  }
+  label?: string
+}
+```
+
+Written debounced (300 ms) by map-corridors; read by photo-helper on
+competition load + on `visibilitychange === 'visible'`.
+
+### `ApiPhoto.gps` — photo-helper side (currently informational)
+
+```ts
+interface ApiPhoto {
+  // …existing fields…
+  flag?: 'pick' | 'neutral' | 'reject'
+  gps?: {
+    capturedAt?: { lng; lat; altitude? }
+    subjectAt?: { lng; lat }
+    timestamp?: string
+  }
+}
+```
+
+Set by `useMapPicksSync` when it inserts a map-originated photo into the
+candidate pool. Photo-helper uses `flag` for tray filtering and may
+later use `gps` for cross-reference in the printed PDF.
+
+---
+
+## On-disk file layout
+
+OPFS (web) and Electron native filesystem use the same layout:
+
+```
+photo-sessions/
+└── competitions/
+    └── {competitionId}/
+        ├── session.json                 ← photo-helper's ApiPhotoSession
+        ├── map-picks.json               ← cross-app handoff (Phase 8)
+        ├── corridors/
+        │   ├── session.json             ← map-corridors' CorridorsSession
+        │   └── original-kml.json        ← captured KML text for re-export
+        └── photos/
+            ├── {photoId}                ← original photo bytes (no ext)
+            ├── {photoId}                 …more photos…
+            └── thumbs/
+                ├── {photoId}.jpg        ← 200×150 thumbnail
+                └── {photoId}.jpg         …
+```
+
+- **photoId convention**: `pm-<uuid>` for map-imported photos,
+  `photo-<timestamp>-<rand>` for photo-helper-imported photos. The
+  `pm-` prefix is load-bearing — `useMapPicksSync` uses it to decide
+  ownership of entries during cleanup.
+- **Storage abstraction**: see
+  [`@airq/shared-storage`](../../frontend/shared-storage/src/types.ts).
+  The `StorageInterface` has `savePhotoFile`, `savePhotoThumb`,
+  `getPhotoBlob`, `getPhotoThumb`, etc. — backed by OPFS in the browser
+  and by `fs` in Electron via IPC.
+
+### `CorridorsSession` shape (relevant fields)
+
+```ts
+type CorridorsSession = {
+  id: string
+  version: number                // per-mutation write counter, not schema version
+  // …other corridor fields…
+  markers: readonly PhotoMarker[]              // KML clicks AND imported photos
+  groundMarkers: readonly GroundMarker[]       // FAI canvas signs (precision)
+  noGpsPhotos: readonly NoGpsPhoto[]           // tray entries awaiting placement
+  noGpsTrayOpen: boolean                       // tray collapse state
+}
+```
+
+---
+
+## Cross-app handoff
+
+Currently **one-way** (map-corridors → photo-helper):
+
+```
+┌────────────────┐  flag change /  ┌──────────────┐ visibilitychange ┌────────────────┐
+│ map-corridors  │  drag / label   │ map-picks    │  ───────────►    │ photo-helper   │
+│ (writes)       │  ───────────►   │ .json        │                  │ candidate tray │
+└────────────────┘   300 ms debounce └────────────┘                  └────────────────┘
+```
+
+- **Writer**: `frontend/map-corridors/src/handoff/mapPicksWriter.ts`.
+  `scheduleWriteMapPicks` debounces 300 ms; `flushPendingMapPicks` is
+  called by the "Send to editor" button + `pagehide` for best-effort
+  durability before navigation/unload.
+- **Reader**: `frontend/photo-helper/src/hooks/useMapPicksSync.ts`.
+  Mounted from `AppApi.tsx`. Implements upsert + delete semantics per
+  [ADR-019](./decisions.md#adr-019--usemappickssync-upsert-semantics-delete-propagation).
+  Photo-helper-originated photos (no `pm-` prefix) are NEVER touched
+  by the sync.
+
+---
+
+## Deferred work
+
+Things intentionally NOT done in v1, in rough priority order:
+
+1. **Two-way label sync.** If a user assigns a label in photo-helper's
+   editor it should propagate back to map-corridors (and vice-versa).
+   Today map-corridors is the single label authority. Path forward:
+   photo-helper writes its own `photo-helper-picks.json` mirror file;
+   map-corridors reads it on visibilitychange. Symmetrical to the
+   existing `map-picks.json` flow. ~50 LoC.
+2. **Browser-mode tests for Canvas + EXIF Orientation.** The two
+   `.todo` placeholders in
+   `frontend/map-corridors/src/__tests__/generateThumb.test.ts`
+   (real-pixel JPEG output + Orientation=6 rotation) require
+   `@vitest/browser` + Playwright. Worth doing once a regression appears.
+3. **Re-import dedup UI.** ADR-020 specifies SHA-1 content-hash dedup;
+   the writer side records the hash but the import path doesn't yet
+   check it. A re-imported photo today gets a new `pm-` id + new disk
+   entry. Wire by hashing during `importPhotoFiles` and looking up in
+   `map-picks.json` before insert.
+4. **Hover preview tooltip.** Doc plan envisions 80×60 mini-thumb on
+   marker hover, distinct from the popup-on-click. Nice-to-have.
+5. **Keyboard equivalent for tray drag.** WCAG concern noted in
+   [Phase 10](./implementation-plan.md). Focus thumb → Enter → click
+   map. Out of scope v1.
+6. **OPFS quota pre-flight warning.** ADR-018. Soft warning at 50%
+   used, hard gate at 80%. Currently the import silently proceeds and
+   relies on disk-full failures bubbling up.
+
+---
+
+## Source map
+
+| Where | What |
+|---|---|
+| `frontend/map-corridors/src/photoImport/` | Pure import pipeline: `extractExif`, `generateThumb`, `importPhotoFiles`, storage wrapper `importPhotosToStorage`. Tested in `__tests__/`. |
+| `frontend/map-corridors/src/handoff/mapPicksWriter.ts` | Debounced JSON writer; pure projection helpers `buildMapPickEntry` / `buildMapPicks`. |
+| `frontend/map-corridors/src/map/photoLayers/` | `captureFeatures.ts` (ghost + dashed-line projections + `isPhotoMoved`) and `CaptureDotsLayer.tsx` (passive Mapbox overlay layers — name kept for import stability; export is `PhotoOverlayLayers`). |
+| `frontend/map-corridors/src/components/PhotoMarkerPopup.tsx` | Click-on-pin popup. Thumb + Include / Skip / Reject + label picker. |
+| `frontend/map-corridors/src/components/NoGpsTray.tsx` | Bottom-left tray for no-GPS imports. Drag emits `application/x-airq-no-gps-photo`. |
+| `frontend/map-corridors/src/components/PhotoListPanel.tsx` | Right-side groups + "Send to editor" footer. |
+| `frontend/map-corridors/src/components/usePhotoThumbUrl.ts` | Shared thumb-loading hook with URL revocation. |
+| `frontend/map-corridors/src/components/groupPhotosByFlag.ts` | Pure helper for the side-panel groups. |
+| `frontend/map-corridors/src/map/MapProviderView.tsx` | The map shell. Photo-marker render branch is `?.filter(m => !!m.photoId).map(...)` near the bottom of the JSX tree. |
+| `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts` | Owns the session JSON + resolves `photosDir`, `competitionDir`. |
+| `frontend/photo-helper/src/hooks/useMapPicksSync.ts` | Counterpart reader hook. Mounted in `AppApi.tsx`. |
+| `frontend/shared-storage/src/photoThumbs.ts` | Thumbnail storage helpers `savePhotoThumb` / `getPhotoThumb` / `deletePhotoThumb`. Same impl behind both OPFS and Electron backends. |
+
+---
+
+## Quick smoke matrix
+
+Manual checks against a live Electron build (no automated browser
+tests for these yet):
+
+1. Drop 3 JPGs with GPS → 3 hollow grey circles at their EXIF coords.
+2. Hover a circle → cursor goes pointer.
+3. Click a circle → popup appears with thumb + filename + 3 buttons + label grid.
+4. Click **Include** → circle gets blue ring. Popup stays open.
+5. Assign label **A** → circle turns yellow + label badge appears next to it.
+6. Drag the pin 100 m away → fills in (still yellow), ghost dot + dashed line appear at EXIF spot.
+7. Click another circle → previous popup closes, new one opens (no double-click).
+8. **Send to editor (1)** → photo-helper opens, candidate tray contains the labelled photo.
+9. Drop 2 no-GPS JPGs → bottom-left tray appears with 2 thumbs.
+10. Drag a tray thumb onto the map → blue filled circle at drop point. Tray shrinks.
+11. Reload the page → all state survives (markers, tray entries, labels, flags).
+
+---
+
+*Last updated against branch `feat/photo-map-culling` commit ~`c1a8f8e`. When
+the as-built state drifts from this doc, update the doc.*

--- a/docs/photo-map-culling/guide.md
+++ b/docs/photo-map-culling/guide.md
@@ -247,24 +247,67 @@ type CorridorsSession = {
 
 ## Cross-app handoff
 
-Currently **one-way** (map-corridors → photo-helper):
+**Bidirectional** via two mirror files, one per writer.
 
 ```
-┌────────────────┐  flag change /  ┌──────────────┐ visibilitychange ┌────────────────┐
-│ map-corridors  │  drag / label   │ map-picks    │  ───────────►    │ photo-helper   │
-│ (writes)       │  ───────────►   │ .json        │                  │ candidate tray │
-└────────────────┘   300 ms debounce └────────────┘                  └────────────────┘
+                  ┌──────────────────────┐
+                  │   map-picks.json     │
+   ┌──writes──►   │   (flag, gps, label) │   ──reads──┐
+   │              └──────────────────────┘            │
+┌──┴────────────┐                              ┌──────▼───────────┐
+│ map-corridors │                              │  photo-helper    │
+└──────▲────────┘                              └──────┬───────────┘
+       │       ┌──────────────────────────────┐      │
+       └──reads──   photo-helper-picks.json   ◄──writes──┘
+               │   (label only — newer-wins)  │
+               └──────────────────────────────┘
 ```
 
-- **Writer**: `frontend/map-corridors/src/handoff/mapPicksWriter.ts`.
+| File | Writer | Reader | Owns |
+|---|---|---|---|
+| `map-picks.json` | map-corridors | photo-helper | flag, gps, label (with `labelUpdatedAt`) |
+| `photo-helper-picks.json` | photo-helper | map-corridors | label (with `labelUpdatedAt`) |
+
+Each file has exactly one writer (no write race). Both files include a
+per-photo `labelUpdatedAt` ISO timestamp; the reader applies the remote
+label only when `remote.labelUpdatedAt > local.labelUpdatedAt`. Equal
+timestamps → local wins (deterministic tie-break that protects edits
+in-flight when a `visibilitychange` happens to land on the same ms).
+
+### Writers
+
+- **map-corridors** — `frontend/map-corridors/src/handoff/mapPicksWriter.ts`.
   `scheduleWriteMapPicks` debounces 300 ms; `flushPendingMapPicks` is
-  called by the "Send to editor" button + `pagehide` for best-effort
-  durability before navigation/unload.
-- **Reader**: `frontend/photo-helper/src/hooks/useMapPicksSync.ts`.
-  Mounted from `AppApi.tsx`. Implements upsert + delete semantics per
+  called by the "Send to editor" button + `pagehide`.
+- **photo-helper** — `frontend/photo-helper/src/handoff/editorPicksWriter.ts`.
+  Symmetric: `scheduleWriteEditorPicks` / `flushPendingEditorPicks`.
+  Only `pm-`-prefixed candidates emit entries (photo-helper-originated
+  photos stay in the editor and never propagate).
+
+### Readers
+
+- **photo-helper** — `frontend/photo-helper/src/hooks/useMapPicksSync.ts`.
+  Upsert + delete semantics per
   [ADR-019](./decisions.md#adr-019--usemappickssync-upsert-semantics-delete-propagation).
-  Photo-helper-originated photos (no `pm-` prefix) are NEVER touched
-  by the sync.
+  Label changes propagate via the same newer-wins rule.
+- **map-corridors** — `frontend/map-corridors/src/hooks/useEditorPicksSync.ts`.
+  Read-only-update — never inserts markers (the editor file isn't a
+  source of new photos). Newer-wins label updates only.
+
+### Known limitations
+
+- Cross-app **label-collision prevention** is implicit through the
+  pm- label sync: editor-set labels show up on the map's local markers
+  after the next read, automatically appearing in `usedLabels`. Two
+  CORNER cases aren't covered:
+  - **KML-click-placed markers** in map-corridors that use a letter
+    photo-helper has independently claimed for one of its **non-pm-**
+    photos. Map's local `usedLabels` won't include the editor-only
+    photo's letter. Mitigation: the editor's picker rejects the
+    collision when the user goes to assign.
+  - **Symmetric** of the above. Same reasoning, opposite direction.
+  Both are rare in the typical workflow (most photos flow map → editor).
+  Add `claimedLabels: string[]` to both files if this surfaces in practice.
 
 ---
 
@@ -272,13 +315,7 @@ Currently **one-way** (map-corridors → photo-helper):
 
 Things intentionally NOT done in v1, in rough priority order:
 
-1. **Two-way label sync.** If a user assigns a label in photo-helper's
-   editor it should propagate back to map-corridors (and vice-versa).
-   Today map-corridors is the single label authority. Path forward:
-   photo-helper writes its own `photo-helper-picks.json` mirror file;
-   map-corridors reads it on visibilitychange. Symmetrical to the
-   existing `map-picks.json` flow. ~50 LoC.
-2. **Browser-mode tests for Canvas + EXIF Orientation.** The two
+1. **Browser-mode tests for Canvas + EXIF Orientation.** The two
    `.todo` placeholders in
    `frontend/map-corridors/src/__tests__/generateThumb.test.ts`
    (real-pixel JPEG output + Orientation=6 rotation) require

--- a/docs/photo-map-culling/label-sync-plan.md
+++ b/docs/photo-map-culling/label-sync-plan.md
@@ -1,0 +1,119 @@
+# Label sync plan — bidirectional map ↔ editor
+
+Implementation plan for synchronizing photo labels (A–T / 1–20) between
+map-corridors and photo-helper. Approved batch: all five phases land
+in one PR on `feat/photo-map-culling`.
+
+## Why
+
+User requirement: "the letter/number can be assigned also in the photo
+editor app." Currently labels flow neither direction reliably — even
+the one-way map → editor path is broken (`useMapPicksSync` ignores
+`entry.label` on insert, never propagates label changes on update).
+
+## Architecture — two mirror files, per-photo `labelUpdatedAt`
+
+```
+map-corridors  ──writes──►  competitions/{compId}/map-picks.json
+                  ◄─reads───
+                            competitions/{compId}/photo-helper-picks.json
+                  ──reads─►
+photo-helper   ──writes──┘
+```
+
+Each file has exactly one writer; both apps read both files.
+Conflict resolution: `labelUpdatedAt` per photo, newer wins. Equal
+timestamps → local wins (deterministic tie-break; rare in practice).
+
+## Schema changes
+
+```ts
+// Added to PhotoMarker (map-corridors)
+type PhotoMarker = Readonly<{
+  // …existing…
+  label?: PhotoLabel
+  labelUpdatedAt?: string   // NEW — ISO 8601
+}>
+
+// Added to ApiPhoto (photo-helper)
+interface ApiPhoto {
+  // …existing…
+  label: string
+  labelUpdatedAt?: string   // NEW — ISO 8601
+}
+
+// Added to MapPickEntry (map-picks.json)
+type MapPickEntry = {
+  // …existing…
+  label?: string
+  labelUpdatedAt?: string   // NEW
+}
+
+// NEW file format
+type EditorPicksFile = {
+  version: 1
+  updatedAt: string
+  picks: Array<{
+    photoId: string         // pm-prefix; editor-only photos excluded
+    label: string           // '' means explicitly cleared
+    labelUpdatedAt: string
+  }>
+}
+```
+
+## Phases
+
+### Phase A — Fix one-way (map → editor) label sync
+- `useCompetitionSystem`: new `setCandidateLabel(photoId, label)` mutator,
+  stamps `labelUpdatedAt = now()`.
+- `useMapPicksSync` insert path: use `entry.label`, not `''`.
+- `useMapPicksSync` update path: compare both label and flag (newer-wins
+  on label, simple-diff on flag).
+- Tests in `useMapPicksSync.test.ts`.
+
+### Phase B — Editor writer `photo-helper-picks.json`
+- New `frontend/photo-helper/src/handoff/editorPicksWriter.ts`. Mirror
+  of `mapPicksWriter.ts`: 300 ms debounce, serialized writes,
+  `flushPendingEditorPicks()`.
+- `AppApi.tsx`: useEffect on `session.candidates` + slot photos →
+  schedule write. Pagehide flushes best-effort.
+- Tests with fake timers.
+
+### Phase C — Map reader for `photo-helper-picks.json`
+- New `frontend/map-corridors/src/hooks/useEditorPicksSync.ts`. Mirror
+  of `useMapPicksSync.ts`: runs on competition load + visibilitychange.
+- Applies `entry.label` to local `marker.label` only when
+  `entry.labelUpdatedAt > marker.labelUpdatedAt` (newer wins).
+- Never inserts markers (the editor file isn't a source of new photos).
+- Tests for newer-wins, older-loses, missing-file, equal-timestamp
+  (local wins).
+
+### Phase D — Collision prevention via cross-app `usedLabels`
+- Map-corridors: `usedLabels` becomes (local marker labels) ∪
+  (labels from the last-read `photo-helper-picks.json`).
+- Photo-helper: existing label-claim logic gains union with
+  `map-picks.json` labels.
+- Picker UI disables collisions in both apps.
+
+### Phase E — Docs
+- Update `docs/photo-map-culling/guide.md`:
+  - Strike out "two-way label sync" from Deferred work.
+  - "Cross-app handoff" diagram shows both files.
+  - "Data schemas" includes `labelUpdatedAt`.
+- ADR-022 in `decisions.md`: "Bidirectional label sync via two mirror
+  files with per-photo `labelUpdatedAt`."
+
+## Edge cases (verified by tests)
+
+| Case | Behaviour |
+|---|---|
+| Missing `photo-helper-picks.json` | No-op, no error. |
+| User labels in map then editor within 300 ms | Last writer wins; rare in single-user flow. |
+| Map sets "A" on photo X; editor unaware; editor user picks "A" for Y | Editor's `usedLabels` union from `map-picks.json` disables "A". |
+| Tie-break on equal `labelUpdatedAt` | Local always wins — protects in-flight edits. |
+| User clears label | Empty string + new timestamp. Other side sees newer; clears. |
+| Editor deletes a `pm-` candidate | Map keeps marker + label. Editor file omits the photo; map ignores absence. |
+
+## Effort
+
+~2 days total, all in `feat/photo-map-culling`.

--- a/frontend/map-corridors/package.json
+++ b/frontend/map-corridors/package.json
@@ -21,6 +21,7 @@
     "@tmcw/togeojson": "^7.1.2",
     "@turf/turf": "^7.2.0",
     "@vis.gl/react-maplibre": "^8.0.4",
+    "exifr": "7.1.3",
     "mapbox-gl": "^3.17.0",
     "maplibre-gl": "^5.7.0",
     "react": "^19.1.1",

--- a/frontend/map-corridors/scripts/verify-exif.mjs
+++ b/frontend/map-corridors/scripts/verify-exif.mjs
@@ -1,0 +1,45 @@
+// One-off EXIF verification for the 3 sample JPGs at repo root.
+// Run: cd frontend/map-corridors && pnpm exec node scripts/verify-exif.mjs
+//
+// Confirms that `exifr` (the library Phase 0 of photo-map-culling pins) can
+// extract GPS + timestamp + orientation from real Ricoh-camera photos
+// before we wire it into the import pipeline (Phase 1).
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import exifr from 'exifr'
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..')
+const files = ['RIMG0169.JPG', 'RIMG0170.JPG', 'RIMG0172.JPG']
+
+function fmtCoord(n, axis) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '(none)'
+  const dir = axis === 'lat' ? (n >= 0 ? 'N' : 'S') : (n >= 0 ? 'E' : 'W')
+  return `${Math.abs(n).toFixed(6)}° ${dir}`
+}
+
+for (const name of files) {
+  const path = resolve(REPO_ROOT, name)
+  const buf = await readFile(path)
+
+  // Mirror the doc's Phase 1 plan: subset parse, GPS-only + a few tags.
+  const gps = await exifr.gps(buf)
+  const meta = await exifr.parse(buf, {
+    pick: ['DateTimeOriginal', 'GPSAltitude', 'Orientation', 'Make', 'Model'],
+  })
+
+  console.log(`\n=== ${name} (${(buf.byteLength / 1024).toFixed(0)} KB) ===`)
+  if (gps) {
+    console.log(`  GPS:        ${fmtCoord(gps.latitude, 'lat')}, ${fmtCoord(gps.longitude, 'lon')}`)
+    console.log(`  altitude:   ${meta?.GPSAltitude ?? '(none)'} m`)
+  } else {
+    console.log('  GPS:        (none)')
+  }
+  console.log(`  taken:      ${meta?.DateTimeOriginal?.toISOString?.() ?? meta?.DateTimeOriginal ?? '(none)'}`)
+  console.log(`  orientation:${meta?.Orientation ?? '(none)'}`)
+  console.log(`  camera:     ${[meta?.Make, meta?.Model].filter(Boolean).join(' ') || '(none)'}`)
+  if (gps) {
+    const url = `https://www.google.com/maps/?q=${gps.latitude},${gps.longitude}`
+    console.log(`  map:        ${url}`)
+  }
+}

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -196,6 +196,7 @@ function App() {
     setGroundMarkers: persistGroundMarkers,
     setNoGpsPhotos: persistNoGpsPhotos,
     setNoGpsTrayOpen: persistNoGpsTrayOpen,
+    placeNoGpsPhoto,
     setUse1NmAfterSp,
     setComputedData,
     saveOriginalKmlText,
@@ -613,10 +614,18 @@ function App() {
   // Phase 9 — Send-to-editor button handler. Flushes the pending
   // map-picks write FIRST (ADR-009 navigation-flush requirement) so a
   // toggle made within the 300ms debounce window before the click still
-  // lands on disk before photo-helper opens. Then navigates via the
-  // existing Electron IPC, or falls back to a URL change in web mode.
+  // lands on disk before photo-helper opens. If the flush rejects
+  // (quota / OPFS InvalidStateError) we abort navigation — otherwise
+  // photo-helper would open against a stale handoff file with no UI
+  // signal that the picks didn't make it.
   const handleSendToEditor = useCallback(async () => {
-    await flushPendingMapPicks()
+    try {
+      await flushPendingMapPicks()
+    } catch (err) {
+      console.error('flushPendingMapPicks failed before nav:', err)
+      setSnack({ severity: 'error', text: t('photo.handoff.flushFailed') })
+      return
+    }
     if (!competitionId) return
     const api = (window as { electronAPI?: { navigateToApp?: (app: string, id: string) => void } }).electronAPI
     if (api?.navigateToApp) {
@@ -624,7 +633,7 @@ function App() {
     } else {
       window.location.href = `/photo-helper/?competitionId=${competitionId}`
     }
-  }, [competitionId])
+  }, [competitionId, t])
 
   // Phase 8a — mirror the in-memory photo markers into map-picks.json
   // every time they change. The writer debounces (300ms) so rapid flag
@@ -646,7 +655,12 @@ function App() {
 
   // Phase C — read photo-helper-picks.json on competition load and on
   // visibilitychange. Newer-wins applies remote labels to local markers.
-  useEditorPicksSync(storage, competitionDir, persistMarkers)
+  // Failures surface via the snack — without this, a sync that rejected
+  // (e.g. quota at persistMarkers) silently diverged from disk.
+  const handleEditorSyncError = useCallback((_err: unknown) => {
+    setSnack({ severity: 'warning', text: t('photo.handoff.editorSyncFailed') })
+  }, [t])
+  useEditorPicksSync(storage, competitionDir, persistMarkers, handleEditorSyncError)
 
   // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
   // an intermediate until Phase 8 moves the source of truth to
@@ -678,28 +692,17 @@ function App() {
     void setPhotoFlag(markerId, 'reject')
   }, [setPhotoFlag])
 
-  // Phase 6 — drop-from-tray handler. Atomic: remove the entry from
-  // noGpsPhotos AND push a PhotoMarker. We do both writes back-to-back
-  // (each await persists session.json) — a crash between them would
-  // leave the photo "duplicated" (in both lists). Acceptable risk: on
-  // reload the marker takes precedence visually (tray entry is just a
-  // stale candidate; user can manually delete from tray if needed).
+  // Phase 6 — drop-from-tray handler. Atomic: a single persistSession
+  // mutates BOTH markers and noGpsPhotos in one write, so a partial
+  // failure can no longer leave the photo duplicated in both lists.
   const handleNoGpsPhotoPlaced = useCallback(async (photoId: string, lng: number, lat: number) => {
-    if (!session) return
-    const entry = session.noGpsPhotos?.find(p => p.photoId === photoId)
-    if (!entry) return
-    // No `capturedAt` on no-GPS-placed markers — these photos never had
-    // EXIF GPS, so there's no "where the camera was" to draw a ghost from.
-    await persistMarkers((prev) => [...prev, {
-      id: photoId,
-      photoId,
-      lng,
-      lat,
-      name: entry.filename,
-      flag: 'pick',
-    }])
-    await persistNoGpsPhotos((prev) => prev.filter(p => p.photoId !== photoId))
-  }, [session, persistMarkers, persistNoGpsPhotos])
+    try {
+      await placeNoGpsPhoto(photoId, lng, lat)
+    } catch (err) {
+      console.error('placeNoGpsPhoto failed:', err)
+      setSnack({ severity: 'error', text: err instanceof Error ? err.message : String(err) })
+    }
+  }, [placeNoGpsPhoto])
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -525,6 +525,35 @@ function App() {
       const result = await importPhotosToStorage(storage, photosDir, files, {
         onProgress: (done, total) => setImportProgress({ done, total }),
       })
+      // Phase 4: surface imported photos on the map. Each ImportedPhoto
+      // becomes a PhotoMarker with `lng/lat = capturedAt` (subject starts
+      // at capture point per ADR-007) and `photoId` set so the
+      // capture-dots layer can find it. No-GPS photos (capturedAt absent)
+      // land in the markers array too but render via Phase 6's tray.
+      if (result.ok.length > 0) {
+        await persistMarkers((prev) => {
+          const next = [...prev]
+          for (const p of result.ok) {
+            const startLng = p.exif.capturedAt?.lng
+            const startLat = p.exif.capturedAt?.lat
+            if (startLng === undefined || startLat === undefined) continue
+            next.push({
+              id: p.photoId,
+              photoId: p.photoId,
+              lng: startLng,
+              lat: startLat,
+              name: p.file.name,
+              capturedAt: {
+                lng: startLng,
+                lat: startLat,
+                ...(p.exif.capturedAt?.altitude !== undefined ? { altitude: p.exif.capturedAt.altitude } : {}),
+                ...(p.exif.timestamp ? { timestamp: p.exif.timestamp } : {}),
+              },
+            })
+          }
+          return next
+        })
+      }
       if (result.failed.length === 0) {
         setSnack({
           severity: 'success',
@@ -553,7 +582,7 @@ function App() {
     } finally {
       setImportProgress(null)
     }
-  }, [storage, photosDir, t])
+  }, [storage, photosDir, t, persistMarkers])
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -584,6 +584,36 @@ function App() {
     }
   }, [storage, photosDir, t, persistMarkers])
 
+  // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
+  // an intermediate until Phase 8 moves the source of truth to
+  // map-picks.json — see PhotoMarker type docstring.
+  const setPhotoFlag = useCallback(async (markerId: string, flag: 'pick' | 'reject' | null) => {
+    await persistMarkers((prev) =>
+      prev.map(m => {
+        if (m.id !== markerId) return m
+        if (flag === null) {
+          const { flag: _ignored, ...rest } = m
+          return rest as typeof m
+        }
+        return { ...m, flag }
+      }),
+    )
+  }, [persistMarkers])
+
+  const handlePhotoInclude = useCallback((markerId: string) => {
+    void setPhotoFlag(markerId, 'pick')
+  }, [setPhotoFlag])
+
+  const handlePhotoSkip = useCallback((markerId: string) => {
+    // Skip = explicitly leave the photo neutral. If it was previously
+    // rejected (user revisiting from Phase 7's panel), Skip restores it.
+    void setPhotoFlag(markerId, null)
+  }, [setPhotoFlag])
+
+  const handlePhotoReject = useCallback((markerId: string) => {
+    void setPhotoFlag(markerId, 'reject')
+  }, [setPhotoFlag])
+
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []
     const isMarkerDrag = types.includes('application/x-photo-marker') || types.includes('application/x-ground-marker')
@@ -1072,6 +1102,11 @@ function App() {
               onGroundMarkerTypeChange: handleGroundMarkerTypeChange,
               onGroundMarkerDelete: handleGroundMarkerDelete,
             }}
+            photoStorage={storage}
+            photoDir={photosDir}
+            onPhotoInclude={handlePhotoInclude}
+            onPhotoSkip={handlePhotoSkip}
+            onPhotoReject={handlePhotoReject}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -37,6 +37,7 @@ import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers
 import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline } from './types/markers'
 import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
+import { NoGpsTray } from './components/NoGpsTray'
 
 // File-type routing for the dropzone. KML/GPX → existing corridor
 // parser, JPEG/PNG → photo import pipeline (Phase 3 of photo-map-culling,
@@ -185,6 +186,8 @@ function App() {
     setMapStyleId,
     setMarkers: persistMarkers,
     setGroundMarkers: persistGroundMarkers,
+    setNoGpsPhotos: persistNoGpsPhotos,
+    setNoGpsTrayOpen: persistNoGpsTrayOpen,
     setUse1NmAfterSp,
     setComputedData,
     saveOriginalKmlText,
@@ -525,34 +528,49 @@ function App() {
       const result = await importPhotosToStorage(storage, photosDir, files, {
         onProgress: (done, total) => setImportProgress({ done, total }),
       })
-      // Phase 4: surface imported photos on the map. Each ImportedPhoto
-      // becomes a PhotoMarker with `lng/lat = capturedAt` (subject starts
-      // at capture point per ADR-007) and `photoId` set so the
-      // capture-dots layer can find it. No-GPS photos (capturedAt absent)
-      // land in the markers array too but render via Phase 6's tray.
+      // Phase 4/6: surface imported photos. Photos WITH EXIF GPS become
+      // PhotoMarkers and join the capture-dots layer (Phase 4). Photos
+      // WITHOUT GPS get pushed to noGpsPhotos and surface in the
+      // bottom-left tray (Phase 6, ADR-012); they receive a marker only
+      // once the user drags one onto the map.
       if (result.ok.length > 0) {
-        await persistMarkers((prev) => {
-          const next = [...prev]
-          for (const p of result.ok) {
-            const startLng = p.exif.capturedAt?.lng
-            const startLat = p.exif.capturedAt?.lat
-            if (startLng === undefined || startLat === undefined) continue
-            next.push({
-              id: p.photoId,
-              photoId: p.photoId,
-              lng: startLng,
-              lat: startLat,
-              name: p.file.name,
-              capturedAt: {
-                lng: startLng,
-                lat: startLat,
-                ...(p.exif.capturedAt?.altitude !== undefined ? { altitude: p.exif.capturedAt.altitude } : {}),
+        const withGps = result.ok.filter(p => p.exif.capturedAt !== undefined)
+        const withoutGps = result.ok.filter(p => p.exif.capturedAt === undefined)
+        if (withGps.length > 0) {
+          await persistMarkers((prev) => {
+            const next = [...prev]
+            for (const p of withGps) {
+              const captured = p.exif.capturedAt!
+              next.push({
+                id: p.photoId,
+                photoId: p.photoId,
+                lng: captured.lng,
+                lat: captured.lat,
+                name: p.file.name,
+                capturedAt: {
+                  lng: captured.lng,
+                  lat: captured.lat,
+                  ...(captured.altitude !== undefined ? { altitude: captured.altitude } : {}),
+                  ...(p.exif.timestamp ? { timestamp: p.exif.timestamp } : {}),
+                },
+              })
+            }
+            return next
+          })
+        }
+        if (withoutGps.length > 0) {
+          await persistNoGpsPhotos((prev) => {
+            const next = [...prev]
+            for (const p of withoutGps) {
+              next.push({
+                photoId: p.photoId,
+                filename: p.file.name,
                 ...(p.exif.timestamp ? { timestamp: p.exif.timestamp } : {}),
-              },
-            })
-          }
-          return next
-        })
+              })
+            }
+            return next
+          })
+        }
       }
       if (result.failed.length === 0) {
         setSnack({
@@ -582,7 +600,7 @@ function App() {
     } finally {
       setImportProgress(null)
     }
-  }, [storage, photosDir, t, persistMarkers])
+  }, [storage, photosDir, t, persistMarkers, persistNoGpsPhotos])
 
   // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
   // an intermediate until Phase 8 moves the source of truth to
@@ -613,6 +631,29 @@ function App() {
   const handlePhotoReject = useCallback((markerId: string) => {
     void setPhotoFlag(markerId, 'reject')
   }, [setPhotoFlag])
+
+  // Phase 6 — drop-from-tray handler. Atomic: remove the entry from
+  // noGpsPhotos AND push a PhotoMarker. We do both writes back-to-back
+  // (each await persists session.json) — a crash between them would
+  // leave the photo "duplicated" (in both lists). Acceptable risk: on
+  // reload the marker takes precedence visually (tray entry is just a
+  // stale candidate; user can manually delete from tray if needed).
+  const handleNoGpsPhotoPlaced = useCallback(async (photoId: string, lng: number, lat: number) => {
+    if (!session) return
+    const entry = session.noGpsPhotos?.find(p => p.photoId === photoId)
+    if (!entry) return
+    // No `capturedAt` on no-GPS-placed markers — these photos never had
+    // EXIF GPS, so there's no "where the camera was" to draw a ghost from.
+    await persistMarkers((prev) => [...prev, {
+      id: photoId,
+      photoId,
+      lng,
+      lat,
+      name: entry.filename,
+      flag: 'pick',
+    }])
+    await persistNoGpsPhotos((prev) => prev.filter(p => p.photoId !== photoId))
+  }, [session, persistMarkers, persistNoGpsPhotos])
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []
@@ -1107,6 +1148,15 @@ function App() {
             onPhotoInclude={handlePhotoInclude}
             onPhotoSkip={handlePhotoSkip}
             onPhotoReject={handlePhotoReject}
+            onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}
+          />
+          {/* Phase 6 — no-GPS tray, pinned to bottom-left of the map. */}
+          <NoGpsTray
+            photos={session?.noGpsPhotos ?? []}
+            open={session?.noGpsTrayOpen ?? true}
+            onToggleOpen={() => { void persistNoGpsTrayOpen(!(session?.noGpsTrayOpen ?? true)) }}
+            storage={storage}
+            photosDir={photosDir}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -39,6 +39,11 @@ import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
+import {
+  buildMapPicks,
+  flushPendingMapPicks,
+  scheduleWriteMapPicks,
+} from './handoff/mapPicksWriter'
 
 // File-type routing for the dropzone. KML/GPX → existing corridor
 // parser, JPEG/PNG → photo import pipeline (Phase 3 of photo-map-culling,
@@ -184,6 +189,7 @@ function App() {
     backendAvailable,
     storage,
     photosDir,
+    competitionDir,
     setMapStyleId,
     setMarkers: persistMarkers,
     setGroundMarkers: persistGroundMarkers,
@@ -602,6 +608,24 @@ function App() {
       setImportProgress(null)
     }
   }, [storage, photosDir, t, persistMarkers, persistNoGpsPhotos])
+
+  // Phase 8a — mirror the in-memory photo markers into map-picks.json
+  // every time they change. The writer debounces (300ms) so rapid flag
+  // toggles coalesce into one disk write. Pagehide flushes best-effort.
+  useEffect(() => {
+    if (!storage || !competitionDir) return
+    const picks = buildMapPicks(markers)
+    scheduleWriteMapPicks(storage, competitionDir, picks)
+  }, [markers, storage, competitionDir])
+
+  // Pagehide-flush. Fire-and-forget per ADR-009 (async OPFS won't fully
+  // settle before unload, but kicking the timer is strictly better than
+  // letting the debounce drop the latest changes).
+  useEffect(() => {
+    const onPageHide = () => { void flushPendingMapPicks() }
+    window.addEventListener('pagehide', onPageHide)
+    return () => window.removeEventListener('pagehide', onPageHide)
+  }, [])
 
   // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
   // an intermediate until Phase 8 moves the source of truth to

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -44,6 +44,7 @@ import {
   flushPendingMapPicks,
   scheduleWriteMapPicks,
 } from './handoff/mapPicksWriter'
+import { useEditorPicksSync } from './hooks/useEditorPicksSync'
 
 // File-type routing for the dropzone. KML/GPX → existing corridor
 // parser, JPEG/PNG → photo import pipeline (Phase 3 of photo-map-culling,
@@ -643,6 +644,10 @@ function App() {
     return () => window.removeEventListener('pagehide', onPageHide)
   }, [])
 
+  // Phase C — read photo-helper-picks.json on competition load and on
+  // visibilitychange. Newer-wins applies remote labels to local markers.
+  useEditorPicksSync(storage, competitionDir, persistMarkers)
+
   // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
   // an intermediate until Phase 8 moves the source of truth to
   // map-picks.json — see PhotoMarker type docstring.
@@ -1000,12 +1005,18 @@ function App() {
       if (!current) return prev
       const isUsedElsewhere = prev.some(m => m.id !== id && m.label === label)
       if (isUsedElsewhere) return prev
-      return prev.map(m => m.id === id ? { ...m, label } : m)
+      // Stamp labelUpdatedAt so the editor's sync reads "newer than mine"
+      // and adopts the change. Required for bidirectional label sync
+      // (Phase D of photo-map-culling).
+      return prev.map(m => m.id === id ? { ...m, label, labelUpdatedAt: new Date().toISOString() } : m)
     })
   }, [persistMarkers])
 
   const handleMarkerLabelClear = useCallback((id: string) => {
-    persistMarkers(prev => prev.map(m => m.id === id ? ({ ...m, label: undefined }) : m))
+    persistMarkers(prev => prev.map(m => m.id === id
+      ? ({ ...m, label: undefined, labelUpdatedAt: new Date().toISOString() })
+      : m,
+    ))
   }, [persistMarkers])
 
   // Ground marker callbacks

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -9,7 +9,7 @@ import type { GeoJSON } from 'geojson'
 import { buildPreciseCorridorsAndGates, DISCIPLINE_CONFIGS } from './corridors/preciseCorridor'
 import type { Discipline } from './corridors/preciseCorridor'
 
-import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Tooltip, Alert } from '@mui/material'
+import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Tooltip, Alert, Snackbar, LinearProgress } from '@mui/material'
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
@@ -35,6 +35,71 @@ import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
 import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
 import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline } from './types/markers'
+import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
+import type { ImportFailureReason, ImportFailure } from './photoImport/types'
+
+// File-type routing for the dropzone. KML/GPX → existing corridor
+// parser, JPEG/PNG → photo import pipeline (Phase 3 of photo-map-culling,
+// ADR-021 — implicit routing, no mode toggle). Anything else lands in
+// `unsupported` so the caller can surface a name-bearing toast.
+const SUPPORTED_KML_EXT_RX = /\.(kml|gpx)$/i
+const SUPPORTED_IMAGE_EXT_RX = /\.(jpe?g|png)$/i
+
+function classifyDroppedFiles(files: File[]): {
+  kml: File[]
+  image: File[]
+  unsupported: File[]
+} {
+  const kml: File[] = []
+  const image: File[] = []
+  const unsupported: File[] = []
+  for (const f of files) {
+    if (SUPPORTED_KML_EXT_RX.test(f.name)) {
+      kml.push(f)
+    } else if (SUPPORTED_IMAGE_EXT_RX.test(f.name) || f.type === 'image/jpeg' || f.type === 'image/png') {
+      image.push(f)
+    } else {
+      unsupported.push(f)
+    }
+  }
+  return { kml, image, unsupported }
+}
+
+// Pick the dominant failure category for the result snackbar.
+// HEIC complaints come first because that's the only "you need to do
+// something different" failure — corrupt and storage are operational.
+function summarizeFailures(
+  failed: ImportFailure[],
+  t: (key: string, params?: Record<string, string | number>) => string,
+): { severity: 'error'; text: string } {
+  const counts: Record<ImportFailureReason, number> = {
+    heic: 0, corrupt: 0, unsupported: 0, storage: 0,
+  }
+  for (const f of failed) counts[f.reason]++
+
+  if (counts.heic > 0) {
+    return {
+      severity: 'error',
+      text: counts.heic === 1
+        ? t('photo.import.failureHeicOne')
+        : t('photo.import.failureHeic', { count: counts.heic }),
+    }
+  }
+  if (counts.storage > 0) {
+    return {
+      severity: 'error',
+      text: counts.storage === 1
+        ? t('photo.import.failureStorageOne')
+        : t('photo.import.failureStorage', { count: counts.storage }),
+    }
+  }
+  return {
+    severity: 'error',
+    text: counts.corrupt === 1
+      ? t('photo.import.failureCorruptOne')
+      : t('photo.import.failureCorrupt', { count: counts.corrupt }),
+  }
+}
 
 function App() {
   const { t } = useI18n()
@@ -115,6 +180,8 @@ function App() {
   const {
     session,
     backendAvailable,
+    storage,
+    photosDir,
     setMapStyleId,
     setMarkers: persistMarkers,
     setGroundMarkers: persistGroundMarkers,
@@ -344,6 +411,13 @@ function App() {
   // photo-helper and other apps inherit it on next launch.
   const [importedKmlDir, setImportedKmlDir] = useState<string | null>(null)
 
+  // Photo-import UI state (Phase 3). `importProgress` drives the
+  // LinearProgress bar; null = idle. `snack` is the one user-visible
+  // feedback channel — progress, success/partial summary, unsupported
+  // hints. Severity drives the MUI Alert color.
+  const [importProgress, setImportProgress] = useState<{ done: number; total: number } | null>(null)
+  const [snack, setSnack] = useState<{ severity: 'success' | 'info' | 'warning' | 'error'; text: string } | null>(null)
+
   // Hydrate from the competition's persisted working dir on mount so that
   // re-opening map-corridors later (without a fresh KML import) still
   // remembers where the user wants files to land.
@@ -440,6 +514,47 @@ function App() {
     }
   }, [session?.geojson, effectiveDiscipline, use1NmAfterSp, effectiveConfig])
 
+  const handlePhotoFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return
+    if (!storage || !photosDir) {
+      setSnack({ severity: 'warning', text: t('photo.import.noCompetition') })
+      return
+    }
+    setImportProgress({ done: 0, total: files.length })
+    try {
+      const result = await importPhotosToStorage(storage, photosDir, files, {
+        onProgress: (done, total) => setImportProgress({ done, total }),
+      })
+      if (result.failed.length === 0) {
+        setSnack({
+          severity: 'success',
+          text: result.ok.length === 1
+            ? t('photo.import.successOne')
+            : t('photo.import.success', { count: result.ok.length }),
+        })
+      } else if (result.ok.length === 0) {
+        setSnack(summarizeFailures(result.failed, t))
+      } else {
+        setSnack({
+          severity: 'warning',
+          text: t('photo.import.partial', {
+            ok: result.ok.length,
+            total: files.length,
+            failed: result.failed.length,
+          }),
+        })
+      }
+    } catch (err) {
+      // importPhotosToStorage shouldn't throw — per-file failures land in
+      // result.failed. A top-level throw means something foundational broke
+      // (storage init, etc.). Surface it generically.
+      console.error('photo import failed:', err)
+      setSnack({ severity: 'error', text: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setImportProgress(null)
+    }
+  }, [storage, photosDir, t])
+
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []
     const isMarkerDrag = types.includes('application/x-photo-marker') || types.includes('application/x-ground-marker')
@@ -477,23 +592,43 @@ function App() {
     } else if (dt.files && dt.files.length) {
       for (let i = 0; i < dt.files.length; i++) dropped.push(dt.files[i])
     }
-    const kmlOrGpx = dropped.filter(f => f.name.toLowerCase().endsWith('.kml') || f.name.toLowerCase().endsWith('.gpx'))
-    if (kmlOrGpx.length) {
-      await onFiles(kmlOrGpx)
+    const { kml, image, unsupported } = classifyDroppedFiles(dropped)
+    if (unsupported.length > 0) {
+      setSnack({
+        severity: 'warning',
+        text: t('photo.import.unsupported', { name: unsupported.map(f => f.name).join(', ') }),
+      })
     }
-  }, [onFiles])
+    // Mixed batches: parse the KML and import photos in parallel. Neither
+    // path blocks the other (ADR-021 implicit routing).
+    const tasks: Promise<unknown>[] = []
+    if (kml.length) tasks.push(onFiles(kml))
+    if (image.length) tasks.push(handlePhotoFiles(image))
+    await Promise.all(tasks)
+  }, [onFiles, handlePhotoFiles, t])
 
   const onClickSelectFile = useCallback(() => {
     fileInputRef.current?.click()
   }, [])
 
   const onFileInputChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files
-    if (!files || files.length === 0) return
-    await onFiles([files[0]])
+    const fileList = e.target.files
+    if (!fileList || fileList.length === 0) return
+    const selected = Array.from(fileList)
+    const { kml, image, unsupported } = classifyDroppedFiles(selected)
+    if (unsupported.length > 0) {
+      setSnack({
+        severity: 'warning',
+        text: t('photo.import.unsupported', { name: unsupported.map(f => f.name).join(', ') }),
+      })
+    }
+    const tasks: Promise<unknown>[] = []
+    if (kml.length) tasks.push(onFiles(kml))
+    if (image.length) tasks.push(handlePhotoFiles(image))
+    await Promise.all(tasks)
     // allow selecting the same file again later
     e.target.value = ''
-  }, [onFiles])
+  }, [onFiles, handlePhotoFiles, t])
 
   const handleExportKML = useCallback(async () => {
     const originalKmlText = await loadOriginalKmlText()
@@ -799,7 +934,7 @@ function App() {
           '& .MuiFormControlLabel-label': { color: 'white', fontSize: '0.8rem' },
           '& .MuiCheckbox-root': { color: 'rgba(255,255,255,0.7)', '&.Mui-checked': { color: 'white' } },
         }}>
-          <input type="file" ref={fileInputRef} onChange={onFileInputChange} accept=".kml,.gpx,application/vnd.google-earth.kml+xml,application/gpx+xml" style={{ display: 'none' }} />
+          <input type="file" multiple ref={fileInputRef} onChange={onFileInputChange} accept=".kml,.gpx,.jpg,.jpeg,.png,application/vnd.google-earth.kml+xml,application/gpx+xml,image/jpeg,image/png" style={{ display: 'none' }} />
           <Button variant="contained" size="small" onClick={onClickSelectFile}>{t('app.selectKml')}</Button>
           {(session?.leftSegments || session?.rightSegments || session?.gates) && (
             <Button variant="outlined" size="small" onClick={handleExportKML} startIcon={<Download sx={{ fontSize: 16 }} />}>{t('app.exportKml')}</Button>
@@ -978,6 +1113,33 @@ function App() {
         </Box>
       </DialogContent>
     </Dialog>
+    {/* Phase 3 photo-import UX (docs/photo-map-culling).
+        LinearProgress sits below the controls row during a batch import.
+        Snackbar at top-right shows summary on completion + unsupported
+        hints. Both are non-blocking — user can keep working on the map. */}
+    {importProgress && importProgress.total > 0 && (
+      <Box sx={{ position: 'fixed', top: 0, left: 0, right: 0, zIndex: 30 }}>
+        <LinearProgress
+          variant="determinate"
+          value={Math.round((importProgress.done / importProgress.total) * 100)}
+        />
+        <Box sx={{ bgcolor: 'primary.main', color: 'white', px: 2, py: 0.5, fontSize: 13 }}>
+          {t('photo.import.progress', { done: importProgress.done, total: importProgress.total })}
+        </Box>
+      </Box>
+    )}
+    <Snackbar
+      open={snack !== null}
+      autoHideDuration={snack?.severity === 'error' ? null : 6000}
+      onClose={() => setSnack(null)}
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+    >
+      {snack ? (
+        <Alert severity={snack.severity} onClose={() => setSnack(null)} sx={{ width: '100%' }}>
+          {snack.text}
+        </Alert>
+      ) : undefined}
+    </Snackbar>
     </>
   )
 }

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -38,6 +38,7 @@ import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline } from './types/mark
 import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
+import { PhotoListPanel } from './components/PhotoListPanel'
 
 // File-type routing for the dropzone. KML/GPX → existing corridor
 // parser, JPEG/PNG → photo import pipeline (Phase 3 of photo-map-culling,
@@ -1157,6 +1158,15 @@ function App() {
             onToggleOpen={() => { void persistNoGpsTrayOpen(!(session?.noGpsTrayOpen ?? true)) }}
             storage={storage}
             photosDir={photosDir}
+          />
+          {/* Phase 7 — right-side photo list panel. Auto-hides when there
+              are no imported photos (KML-only sessions look unchanged). */}
+          <PhotoListPanel
+            markers={markers}
+            noGpsPhotos={session?.noGpsPhotos ?? []}
+            storage={storage}
+            photosDir={photosDir}
+            onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -609,6 +609,22 @@ function App() {
     }
   }, [storage, photosDir, t, persistMarkers, persistNoGpsPhotos])
 
+  // Phase 9 — Send-to-editor button handler. Flushes the pending
+  // map-picks write FIRST (ADR-009 navigation-flush requirement) so a
+  // toggle made within the 300ms debounce window before the click still
+  // lands on disk before photo-helper opens. Then navigates via the
+  // existing Electron IPC, or falls back to a URL change in web mode.
+  const handleSendToEditor = useCallback(async () => {
+    await flushPendingMapPicks()
+    if (!competitionId) return
+    const api = (window as { electronAPI?: { navigateToApp?: (app: string, id: string) => void } }).electronAPI
+    if (api?.navigateToApp) {
+      api.navigateToApp('photo-helper', competitionId)
+    } else {
+      window.location.href = `/photo-helper/?competitionId=${competitionId}`
+    }
+  }, [competitionId])
+
   // Phase 8a — mirror the in-memory photo markers into map-picks.json
   // every time they change. The writer debounces (300ms) so rapid flag
   // toggles coalesce into one disk write. Pagehide flushes best-effort.
@@ -1191,6 +1207,7 @@ function App() {
             storage={storage}
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
+            onSendToEditor={competitionId ? handleSendToEditor : undefined}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
+++ b/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
@@ -1,140 +1,117 @@
 import { describe, it, expect } from 'vitest'
-import { buildCaptureDotFeatures } from '../map/photoLayers/captureFeatures'
+import {
+  buildDashedLineFeatures,
+  buildGhostFeatures,
+  isPhotoMoved,
+} from '../map/photoLayers/captureFeatures'
 import type { PhotoMarker } from '../types/markers'
 
-// Phase 4 of photo-map-culling.
-// captureFeatures is the pure projection that turns the in-memory marker
-// array into the GeoJSON the capture-dots layer consumes. The component
-// itself can't be tested in jsdom (no Mapbox); these tests cover the
-// filter and shape — the parts that decide what the user actually sees.
+// Phase 4/5 follow-up of photo-map-culling.
+// The "every photo is a draggable <Marker>" model retired the
+// capture-dots layer. The remaining GeoJSON-layer projections are:
+//   • ghost dot at the original EXIF capture point
+//   • dashed line from capturedAt to the live subject pin
+// Both render ONLY when the user has dragged the photo (subject ≠
+// capture). Unmoved photos see only their live <Marker>.
 
-function pm(overrides: Partial<PhotoMarker>): PhotoMarker {
-  return {
-    id: 'pm-1',
-    lng: 14,
-    lat: 50,
-    name: 'IMG_0001.JPG',
-    ...overrides,
-  } as PhotoMarker
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', ...over } as PhotoMarker
 }
 
-describe('buildCaptureDotFeatures — filter', () => {
-  it('includes a photo marker with capturedAt + photoId + no label', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', capturedAt: { lng: 14.1, lat: 50.1 } }),
-    ])
-    expect(fc.features).toHaveLength(1)
+describe('isPhotoMoved', () => {
+  it('false when capturedAt is absent', () => {
+    expect(isPhotoMoved(pm({}))).toBe(false)
   })
-
-  it('excludes markers without capturedAt (KML click placements)', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: undefined, capturedAt: undefined }),
-    ])
-    expect(fc.features).toEqual([])
+  it('false when subject == capture (untouched)', () => {
+    expect(isPhotoMoved(pm({
+      lng: 14, lat: 50,
+      capturedAt: { lng: 14, lat: 50 },
+    }))).toBe(false)
   })
-
-  it('excludes markers without photoId even if capturedAt is set', () => {
-    // Defensive: capturedAt without photoId would be a malformed state,
-    // but we tolerate it instead of breaking the renderer.
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: undefined, capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features).toEqual([])
+  it('true when only longitude moved', () => {
+    expect(isPhotoMoved(pm({
+      lng: 14.001, lat: 50,
+      capturedAt: { lng: 14, lat: 50 },
+    }))).toBe(true)
   })
-
-  it('excludes labelled markers (picks are rendered as subject pins, not capture dots)', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', label: 'A', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features).toEqual([])
-  })
-
-  it('mixed batch — keeps only the photo-imported neutral ones', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ id: 'kml-1', photoId: undefined, capturedAt: undefined }),         // KML click
-      pm({ id: 'pm-1', photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }), // photo, neutral
-      pm({ id: 'pm-2', photoId: 'pid-2', label: 'A', capturedAt: { lng: 14.5, lat: 50.5 } }), // photo, picked
-    ])
-    expect(fc.features.map(f => f.id)).toEqual(['pm-1'])
+  it('true when only latitude moved', () => {
+    expect(isPhotoMoved(pm({
+      lng: 14, lat: 50.001,
+      capturedAt: { lng: 14, lat: 50 },
+    }))).toBe(true)
   })
 })
 
-describe('buildCaptureDotFeatures — geometry + properties', () => {
-  it('positions the feature at capturedAt, NOT at the marker subject (lng/lat)', () => {
-    // Critical: after the user drags the subject pin, marker.lng/lat moves
-    // but capturedAt does not. The capture dot must stay where the camera
-    // GPS recorded the photo, otherwise it'd be a duplicate of the pin.
-    const fc = buildCaptureDotFeatures([
-      pm({
-        photoId: 'pid-1',
-        lng: 14.999,        // subject dragged far away
-        lat: 50.999,
-        capturedAt: { lng: 14.1, lat: 50.1 }, // EXIF source
-      }),
-    ])
-    expect(fc.features[0].geometry.coordinates).toEqual([14.1, 50.1])
-  })
-
-  it('writes photoId, filename and flag into the feature properties', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-abc', name: 'RIMG0169.JPG', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features[0].properties).toEqual({
-      photoId: 'pid-abc',
-      name: 'RIMG0169.JPG',
-      flag: 'neutral',
-    })
-  })
-
-  it('uses marker.id as the GeoJSON feature id (stable identity for paint expressions)', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ id: 'pm-feature-id', photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features[0].id).toBe('pm-feature-id')
-  })
-
-  it('returns a valid empty FeatureCollection for empty input', () => {
-    expect(buildCaptureDotFeatures([])).toEqual({ type: 'FeatureCollection', features: [] })
-  })
-
-  it('feature type is always Point', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features[0].geometry.type).toBe('Point')
-  })
-})
-
-describe('buildCaptureDotFeatures — flag (Phase 5)', () => {
-  it('absent flag denormalizes to "neutral" in properties', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features[0].properties.flag).toBe('neutral')
-  })
-
-  it('flag="reject" is preserved (red dot via paint expression)', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', flag: 'reject', capturedAt: { lng: 14, lat: 50 } }),
-    ])
-    expect(fc.features).toHaveLength(1)
-    expect(fc.features[0].properties.flag).toBe('reject')
-  })
-
-  it('flag="pick" excludes the marker from the capture-dot layer entirely', () => {
-    // Picks render as a draggable subject pin, even without a label yet.
-    const fc = buildCaptureDotFeatures([
-      pm({ photoId: 'pid-1', flag: 'pick', capturedAt: { lng: 14, lat: 50 } }),
+describe('buildGhostFeatures', () => {
+  it('emits nothing for unmoved photos', () => {
+    const fc = buildGhostFeatures([
+      pm({ photoId: 'pid-1', lng: 14, lat: 50, capturedAt: { lng: 14, lat: 50 } }),
     ])
     expect(fc.features).toEqual([])
   })
 
-  it('mixed flags — keeps neutral + reject, drops pick', () => {
-    const fc = buildCaptureDotFeatures([
-      pm({ id: 'n', photoId: 'pid-n', capturedAt: { lng: 14, lat: 50 } }),
-      pm({ id: 'r', photoId: 'pid-r', flag: 'reject', capturedAt: { lng: 14.1, lat: 50.1 } }),
-      pm({ id: 'p', photoId: 'pid-p', flag: 'pick', capturedAt: { lng: 14.2, lat: 50.2 } }),
+  it('emits one ghost per moved photo, positioned at capturedAt', () => {
+    const fc = buildGhostFeatures([
+      pm({ id: 'm1', photoId: 'pid-1', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 } }),
     ])
-    expect(fc.features.map(f => f.id).sort()).toEqual(['n', 'r'])
+    expect(fc.features).toHaveLength(1)
+    expect(fc.features[0].geometry.coordinates).toEqual([14, 50])
+    expect(fc.features[0].properties.photoId).toBe('pid-1')
+    expect(fc.features[0].id).toBe('m1')
+  })
+
+  it('skips KML markers (no photoId)', () => {
+    const fc = buildGhostFeatures([
+      pm({ photoId: undefined, lng: 14.5, lat: 50.5 }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('skips photos without capturedAt (no-GPS placements)', () => {
+    const fc = buildGhostFeatures([
+      pm({ photoId: 'pid-1', capturedAt: undefined, lng: 14, lat: 50 }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('mixed batch — only moved photo markers leave a ghost', () => {
+    const fc = buildGhostFeatures([
+      pm({ id: 'kml', photoId: undefined, lng: 14, lat: 50 }),
+      pm({ id: 'unmoved', photoId: 'p1', lng: 14, lat: 50, capturedAt: { lng: 14, lat: 50 } }),
+      pm({ id: 'moved', photoId: 'p2', lng: 14.2, lat: 50.2, capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features.map(f => f.id)).toEqual(['moved'])
+  })
+})
+
+describe('buildDashedLineFeatures', () => {
+  it('emits a LineString from capturedAt to lng/lat for moved photos', () => {
+    const fc = buildDashedLineFeatures([
+      pm({ photoId: 'p1', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toHaveLength(1)
+    expect(fc.features[0].geometry.type).toBe('LineString')
+    expect(fc.features[0].geometry.coordinates).toEqual([[14, 50], [14.5, 50.5]])
+  })
+
+  it('skips unmoved photos (no need for a zero-length line)', () => {
+    const fc = buildDashedLineFeatures([
+      pm({ photoId: 'p1', lng: 14, lat: 50, capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('skips photos without capturedAt', () => {
+    const fc = buildDashedLineFeatures([
+      pm({ photoId: 'p1', capturedAt: undefined }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('writes photoId into properties for downstream lookups', () => {
+    const fc = buildDashedLineFeatures([
+      pm({ photoId: 'pid-abc', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features[0].properties.photoId).toBe('pid-abc')
   })
 })

--- a/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
+++ b/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
@@ -75,11 +75,15 @@ describe('buildCaptureDotFeatures — geometry + properties', () => {
     expect(fc.features[0].geometry.coordinates).toEqual([14.1, 50.1])
   })
 
-  it('writes photoId and filename into the feature properties', () => {
+  it('writes photoId, filename and flag into the feature properties', () => {
     const fc = buildCaptureDotFeatures([
       pm({ photoId: 'pid-abc', name: 'RIMG0169.JPG', capturedAt: { lng: 14, lat: 50 } }),
     ])
-    expect(fc.features[0].properties).toEqual({ photoId: 'pid-abc', name: 'RIMG0169.JPG' })
+    expect(fc.features[0].properties).toEqual({
+      photoId: 'pid-abc',
+      name: 'RIMG0169.JPG',
+      flag: 'neutral',
+    })
   })
 
   it('uses marker.id as the GeoJSON feature id (stable identity for paint expressions)', () => {
@@ -98,5 +102,39 @@ describe('buildCaptureDotFeatures — geometry + properties', () => {
       pm({ photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
     ])
     expect(fc.features[0].geometry.type).toBe('Point')
+  })
+})
+
+describe('buildCaptureDotFeatures — flag (Phase 5)', () => {
+  it('absent flag denormalizes to "neutral" in properties', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features[0].properties.flag).toBe('neutral')
+  })
+
+  it('flag="reject" is preserved (red dot via paint expression)', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', flag: 'reject', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toHaveLength(1)
+    expect(fc.features[0].properties.flag).toBe('reject')
+  })
+
+  it('flag="pick" excludes the marker from the capture-dot layer entirely', () => {
+    // Picks render as a draggable subject pin, even without a label yet.
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', flag: 'pick', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('mixed flags — keeps neutral + reject, drops pick', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ id: 'n', photoId: 'pid-n', capturedAt: { lng: 14, lat: 50 } }),
+      pm({ id: 'r', photoId: 'pid-r', flag: 'reject', capturedAt: { lng: 14.1, lat: 50.1 } }),
+      pm({ id: 'p', photoId: 'pid-p', flag: 'pick', capturedAt: { lng: 14.2, lat: 50.2 } }),
+    ])
+    expect(fc.features.map(f => f.id).sort()).toEqual(['n', 'r'])
   })
 })

--- a/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
+++ b/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { buildCaptureDotFeatures } from '../map/photoLayers/captureFeatures'
+import type { PhotoMarker } from '../types/markers'
+
+// Phase 4 of photo-map-culling.
+// captureFeatures is the pure projection that turns the in-memory marker
+// array into the GeoJSON the capture-dots layer consumes. The component
+// itself can't be tested in jsdom (no Mapbox); these tests cover the
+// filter and shape — the parts that decide what the user actually sees.
+
+function pm(overrides: Partial<PhotoMarker>): PhotoMarker {
+  return {
+    id: 'pm-1',
+    lng: 14,
+    lat: 50,
+    name: 'IMG_0001.JPG',
+    ...overrides,
+  } as PhotoMarker
+}
+
+describe('buildCaptureDotFeatures — filter', () => {
+  it('includes a photo marker with capturedAt + photoId + no label', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', capturedAt: { lng: 14.1, lat: 50.1 } }),
+    ])
+    expect(fc.features).toHaveLength(1)
+  })
+
+  it('excludes markers without capturedAt (KML click placements)', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: undefined, capturedAt: undefined }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('excludes markers without photoId even if capturedAt is set', () => {
+    // Defensive: capturedAt without photoId would be a malformed state,
+    // but we tolerate it instead of breaking the renderer.
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: undefined, capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('excludes labelled markers (picks are rendered as subject pins, not capture dots)', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', label: 'A', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
+  it('mixed batch — keeps only the photo-imported neutral ones', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ id: 'kml-1', photoId: undefined, capturedAt: undefined }),         // KML click
+      pm({ id: 'pm-1', photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }), // photo, neutral
+      pm({ id: 'pm-2', photoId: 'pid-2', label: 'A', capturedAt: { lng: 14.5, lat: 50.5 } }), // photo, picked
+    ])
+    expect(fc.features.map(f => f.id)).toEqual(['pm-1'])
+  })
+})
+
+describe('buildCaptureDotFeatures — geometry + properties', () => {
+  it('positions the feature at capturedAt, NOT at the marker subject (lng/lat)', () => {
+    // Critical: after the user drags the subject pin, marker.lng/lat moves
+    // but capturedAt does not. The capture dot must stay where the camera
+    // GPS recorded the photo, otherwise it'd be a duplicate of the pin.
+    const fc = buildCaptureDotFeatures([
+      pm({
+        photoId: 'pid-1',
+        lng: 14.999,        // subject dragged far away
+        lat: 50.999,
+        capturedAt: { lng: 14.1, lat: 50.1 }, // EXIF source
+      }),
+    ])
+    expect(fc.features[0].geometry.coordinates).toEqual([14.1, 50.1])
+  })
+
+  it('writes photoId and filename into the feature properties', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-abc', name: 'RIMG0169.JPG', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features[0].properties).toEqual({ photoId: 'pid-abc', name: 'RIMG0169.JPG' })
+  })
+
+  it('uses marker.id as the GeoJSON feature id (stable identity for paint expressions)', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ id: 'pm-feature-id', photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features[0].id).toBe('pm-feature-id')
+  })
+
+  it('returns a valid empty FeatureCollection for empty input', () => {
+    expect(buildCaptureDotFeatures([])).toEqual({ type: 'FeatureCollection', features: [] })
+  })
+
+  it('feature type is always Point', () => {
+    const fc = buildCaptureDotFeatures([
+      pm({ photoId: 'pid-1', capturedAt: { lng: 14, lat: 50 } }),
+    ])
+    expect(fc.features[0].geometry.type).toBe('Point')
+  })
+})

--- a/frontend/map-corridors/src/__tests__/componentLogic.test.ts
+++ b/frontend/map-corridors/src/__tests__/componentLogic.test.ts
@@ -1,0 +1,96 @@
+// Pure-logic tests for component helpers that are easy to break and
+// hard to spot in a manual smoke test. Kept off of RTL on purpose —
+// the rules below have nothing to do with rendering, and a typo would
+// otherwise ship silently. See PR #64 review.
+
+import { describe, it, expect } from 'vitest'
+import { compareNoGpsPhotos, NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
+import { labelButtonState } from '../components/PhotoMarkerPopup'
+import type { NoGpsPhoto } from '../types/markers'
+
+function ngp(over: Partial<NoGpsPhoto>): NoGpsPhoto {
+  return { photoId: 'pm-1', filename: 'x.jpg', ...over } as NoGpsPhoto
+}
+
+describe('NoGpsTray — drag contract', () => {
+  it('exports the public MIME type used by MapProviderView for drop detection', () => {
+    // The drag MIME is the only contract between the tray and the map
+    // drop handler — a rename on one side without the other is a silent
+    // feature break. Pin it.
+    expect(NO_GPS_PHOTO_DRAG_TYPE).toBe('application/x-airq-no-gps-photo')
+  })
+})
+
+describe('compareNoGpsPhotos — sort order', () => {
+  it('orders timestamped entries ASC by timestamp', () => {
+    const sorted = [
+      ngp({ photoId: 'b', filename: 'b.jpg', timestamp: '2024-02-01T00:00:00Z' }),
+      ngp({ photoId: 'a', filename: 'a.jpg', timestamp: '2024-01-01T00:00:00Z' }),
+    ].sort(compareNoGpsPhotos).map(p => p.photoId)
+    expect(sorted).toEqual(['a', 'b'])
+  })
+
+  it('places entries without timestamp at the end', () => {
+    const sorted = [
+      ngp({ photoId: 'noTs', filename: 'no.jpg' }),
+      ngp({ photoId: 'withTs', filename: 'with.jpg', timestamp: '2024-01-01T00:00:00Z' }),
+    ].sort(compareNoGpsPhotos).map(p => p.photoId)
+    expect(sorted).toEqual(['withTs', 'noTs'])
+  })
+
+  it('tie-breaks alphabetically by filename when timestamps are equal', () => {
+    const t = '2024-01-01T00:00:00Z'
+    const sorted = [
+      ngp({ photoId: 'z', filename: 'z.jpg', timestamp: t }),
+      ngp({ photoId: 'a', filename: 'a.jpg', timestamp: t }),
+    ].sort(compareNoGpsPhotos).map(p => p.photoId)
+    expect(sorted).toEqual(['a', 'z'])
+  })
+
+  it('tie-breaks alphabetically when BOTH lack a timestamp', () => {
+    const sorted = [
+      ngp({ photoId: 'z', filename: 'z.jpg' }),
+      ngp({ photoId: 'a', filename: 'a.jpg' }),
+    ].sort(compareNoGpsPhotos).map(p => p.photoId)
+    expect(sorted).toEqual(['a', 'z'])
+  })
+})
+
+describe('labelButtonState — picker click rules', () => {
+  it("set: unused letter that isn't current → click sets it", () => {
+    const s = labelButtonState({ thisLabel: 'A', currentLabel: undefined, usedLabels: [] })
+    expect(s).toEqual({ disabled: false, isCurrent: false, intent: 'set' })
+  })
+
+  it("clear: re-clicking the CURRENT letter clears it (intent: 'clear')", () => {
+    const s = labelButtonState({ thisLabel: 'A', currentLabel: 'A', usedLabels: ['A'] })
+    expect(s).toEqual({ disabled: false, isCurrent: true, intent: 'clear' })
+  })
+
+  it('disabled: a letter used elsewhere is disabled (intent: noop)', () => {
+    const s = labelButtonState({ thisLabel: 'B', currentLabel: 'A', usedLabels: ['A', 'B'] })
+    expect(s).toEqual({ disabled: true, isCurrent: false, intent: 'noop' })
+  })
+
+  it("NOT disabled: a letter used by ME (this marker) stays clickable so I can clear", () => {
+    // Critical: `used && !isCurrent` predicate. If a regression flips
+    // this to `used`, the user loses the ability to clear their own label.
+    const s = labelButtonState({ thisLabel: 'A', currentLabel: 'A', usedLabels: ['A'] })
+    expect(s.disabled).toBe(false)
+    expect(s.intent).toBe('clear')
+  })
+})
+
+describe('PhotoListPanel — Send-to-editor disabled invariant', () => {
+  it('is disabled when picks.length === 0 (covered by groupPhotosByFlag tests)', () => {
+    // The actual `disabled={groups.picks.length === 0}` lives in the
+    // panel JSX. The grouping is fully tested by groupPhotosByFlag.test
+    // — we just pin the rule here as a doc-test so a regression that
+    // changes the predicate (e.g. `> 0` instead of `=== 0`) gets caught
+    // by reviewers grepping for this file.
+    const picksEmpty: { length: number } = { length: 0 }
+    const picksNonempty: { length: number } = { length: 3 }
+    expect(picksEmpty.length === 0).toBe(true)
+    expect(picksNonempty.length === 0).toBe(false)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/extractExif.test.ts
+++ b/frontend/map-corridors/src/__tests__/extractExif.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import exifr from 'exifr'
+import { extractExif } from '../photoImport/extractExif'
+import { HeicNotSupportedError } from '../photoImport/types'
+
+// Mock exifr — we test the LOGIC in extractExif, not exifr itself. Phase
+// 1b's generateThumb tests exercise the actual Canvas/createImageBitmap
+// path with real JPEG bytes; here we want fast, deterministic, jsdom-only.
+vi.mock('exifr', () => ({
+  default: {
+    gps: vi.fn(),
+    parse: vi.fn(),
+  },
+}))
+
+const gpsMock = exifr.gps as unknown as Mock
+const parseMock = exifr.parse as unknown as Mock
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeFile(bytes: Uint8Array, name = 'photo.jpg', type = 'image/jpeg'): File {
+  return new File([bytes], name, { type })
+}
+
+// Minimal JPEG: SOI + EOI. extractExif only sniffs first 12 bytes for HEIC,
+// so for non-HEIC tests this is enough to bypass that gate.
+function jpegBytes(size = 64): Uint8Array {
+  const out = new Uint8Array(size)
+  out[0] = 0xff; out[1] = 0xd8 // SOI
+  out[out.length - 2] = 0xff; out[out.length - 1] = 0xd9 // EOI
+  return out
+}
+
+// ISO base-media file: bytes 4..7 = "ftyp", 8..11 = brand.
+function ftypBytes(brand: string, size = 32): Uint8Array {
+  const out = new Uint8Array(size)
+  // box size
+  out[0] = 0; out[1] = 0; out[2] = 0; out[3] = size
+  // "ftyp"
+  out[4] = 0x66; out[5] = 0x74; out[6] = 0x79; out[7] = 0x70
+  // brand (4 ASCII chars)
+  for (let i = 0; i < 4; i++) out[8 + i] = brand.charCodeAt(i)
+  return out
+}
+
+describe('extractExif — HEIC content rejection', () => {
+  it.each(['heic', 'heix', 'mif1', 'msf1'])('rejects HEIC brand %s by content', async (brand) => {
+    // Mislabeled — .jpg extension, image/jpeg MIME, but HEIC bytes inside.
+    const file = makeFile(ftypBytes(brand), 'photo.jpg', 'image/jpeg')
+    await expect(extractExif(file)).rejects.toBeInstanceOf(HeicNotSupportedError)
+    expect(gpsMock).not.toHaveBeenCalled()
+    expect(parseMock).not.toHaveBeenCalled()
+  })
+
+  it('includes the original filename in the error message', async () => {
+    const file = makeFile(ftypBytes('heic'), 'IMG_0001.jpg')
+    await expect(extractExif(file)).rejects.toThrow(/IMG_0001\.jpg/)
+  })
+
+  it('does NOT reject non-HEIC `ftyp` brands (e.g. mp4)', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue(null)
+    // mp42 is an ftyp brand but not HEIC — should fall through to exifr.
+    const file = makeFile(ftypBytes('mp42'), 'video.jpg')
+    await expect(extractExif(file)).resolves.toEqual({})
+  })
+
+  it('does NOT reject short JPEGs (< 12 bytes) on the HEIC sniff', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue(null)
+    const file = makeFile(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]), 'tiny.jpg')
+    await expect(extractExif(file)).resolves.toEqual({})
+  })
+})
+
+describe('extractExif — GPS extraction', () => {
+  it('extracts valid lat/lng + altitude', async () => {
+    gpsMock.mockResolvedValue({ latitude: 50.1, longitude: 14.2 })
+    parseMock.mockResolvedValue({ GPSAltitude: 350 })
+    const file = makeFile(jpegBytes())
+    expect(await extractExif(file)).toEqual({
+      capturedAt: { lat: 50.1, lng: 14.2, altitude: 350 },
+    })
+  })
+
+  it('returns lat/lng without altitude when altitude is missing', async () => {
+    gpsMock.mockResolvedValue({ latitude: 50.1, longitude: 14.2 })
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect(await extractExif(file)).toEqual({
+      capturedAt: { lat: 50.1, lng: 14.2 },
+    })
+  })
+
+  it('omits capturedAt when GPS is absent', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).capturedAt).toBeUndefined()
+  })
+
+  it('treats exact (0, 0) as no GPS (camera-lock-failed sentinel)', async () => {
+    gpsMock.mockResolvedValue({ latitude: 0, longitude: 0 })
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).capturedAt).toBeUndefined()
+  })
+
+  it('keeps non-zero coordinate even when one axis is 0', async () => {
+    gpsMock.mockResolvedValue({ latitude: 0, longitude: 14.2 })
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).capturedAt).toEqual({ lat: 0, lng: 14.2 })
+  })
+
+  it.each([
+    ['NaN lat', { latitude: NaN, longitude: 14.2 }],
+    ['Infinity lng', { latitude: 50.1, longitude: Infinity }],
+    ['out-of-range lat', { latitude: 91, longitude: 14.2 }],
+    ['out-of-range lng', { latitude: 50.1, longitude: 181 }],
+    ['non-number lat', { latitude: 'fifty', longitude: 14.2 }],
+  ])('rejects %s', async (_label, value) => {
+    gpsMock.mockResolvedValue(value as { latitude: number; longitude: number })
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).capturedAt).toBeUndefined()
+  })
+
+  it('omits invalid altitude but keeps valid GPS', async () => {
+    gpsMock.mockResolvedValue({ latitude: 50.1, longitude: 14.2 })
+    parseMock.mockResolvedValue({ GPSAltitude: NaN })
+    const file = makeFile(jpegBytes())
+    expect(await extractExif(file)).toEqual({
+      capturedAt: { lat: 50.1, lng: 14.2 },
+    })
+  })
+})
+
+describe('extractExif — timestamp', () => {
+  it('formats DateTimeOriginal as ISO 8601 UTC', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ DateTimeOriginal: new Date('2024-03-15T10:30:00Z') })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).timestamp).toBe('2024-03-15T10:30:00.000Z')
+  })
+
+  it('omits timestamp when DateTimeOriginal is absent', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).timestamp).toBeUndefined()
+  })
+
+  it('omits timestamp when DateTimeOriginal is an Invalid Date', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ DateTimeOriginal: new Date('bogus') })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).timestamp).toBeUndefined()
+  })
+
+  it('omits timestamp when DateTimeOriginal is a string (not parsed by exifr)', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ DateTimeOriginal: '2024:03:15 10:30:00' })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).timestamp).toBeUndefined()
+  })
+})
+
+describe('extractExif — orientation', () => {
+  it.each([1, 2, 3, 4, 5, 6, 7, 8])('returns numeric orientation %i', async (o) => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ Orientation: o })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).orientation).toBe(o)
+  })
+
+  it.each([
+    ['0 (out of range)', 0],
+    ['9 (out of range)', 9],
+    ['-1 (out of range)', -1],
+    ['3.5 (non-integer)', 3.5],
+  ])('omits orientation for %s', async (_label, value) => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ Orientation: value })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).orientation).toBeUndefined()
+  })
+
+  it('omits orientation when exifr returns a translated string', async () => {
+    // If `translateValues` accidentally gets re-enabled by a future refactor,
+    // exifr returns 'Horizontal (normal)' instead of 1. Guard against it.
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({ Orientation: 'Horizontal (normal)' })
+    const file = makeFile(jpegBytes())
+    expect((await extractExif(file)).orientation).toBeUndefined()
+  })
+})
+
+describe('extractExif — error resilience', () => {
+  it('returns {} when both exifr.gps and exifr.parse throw', async () => {
+    gpsMock.mockRejectedValue(new Error('corrupt'))
+    parseMock.mockRejectedValue(new Error('corrupt'))
+    const file = makeFile(jpegBytes())
+    expect(await extractExif(file)).toEqual({})
+  })
+
+  it('returns partial result when only one of gps/parse throws', async () => {
+    gpsMock.mockResolvedValue({ latitude: 50.1, longitude: 14.2 })
+    parseMock.mockRejectedValue(new Error('parse failed'))
+    const file = makeFile(jpegBytes())
+    expect(await extractExif(file)).toEqual({
+      capturedAt: { lat: 50.1, lng: 14.2 },
+    })
+  })
+
+  it('exifr.parse is called with translateValues:false to keep numeric Orientation', async () => {
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue({})
+    const file = makeFile(jpegBytes())
+    await extractExif(file)
+    expect(parseMock).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({ translateValues: false }),
+    )
+  })
+})

--- a/frontend/map-corridors/src/__tests__/extractExif.test.ts
+++ b/frontend/map-corridors/src/__tests__/extractExif.test.ts
@@ -22,7 +22,10 @@ beforeEach(() => {
 })
 
 function makeFile(bytes: Uint8Array, name = 'photo.jpg', type = 'image/jpeg'): File {
-  return new File([bytes], name, { type })
+  // Cast: `Uint8Array<ArrayBufferLike>` confuses the strict TS lib about
+  // BlobPart assignability when the buffer could be a SharedArrayBuffer.
+  // Runtime is fine — we always allocate fresh ArrayBuffer-backed views.
+  return new File([bytes as BlobPart], name, { type })
 }
 
 // Minimal JPEG: SOI + EOI. extractExif only sniffs first 12 bytes for HEIC,

--- a/frontend/map-corridors/src/__tests__/extractExif.test.ts
+++ b/frontend/map-corridors/src/__tests__/extractExif.test.ts
@@ -50,7 +50,7 @@ function ftypBytes(brand: string, size = 32): Uint8Array {
 }
 
 describe('extractExif — HEIC content rejection', () => {
-  it.each(['heic', 'heix', 'mif1', 'msf1'])('rejects HEIC brand %s by content', async (brand) => {
+  it.each(['heic', 'heix', 'hevc', 'hevx', 'heim', 'heis'])('rejects HEIC brand %s by content', async (brand) => {
     // Mislabeled — .jpg extension, image/jpeg MIME, but HEIC bytes inside.
     const file = makeFile(ftypBytes(brand), 'photo.jpg', 'image/jpeg')
     await expect(extractExif(file)).rejects.toBeInstanceOf(HeicNotSupportedError)
@@ -61,6 +61,16 @@ describe('extractExif — HEIC content rejection', () => {
   it('includes the original filename in the error message', async () => {
     const file = makeFile(ftypBytes('heic'), 'IMG_0001.jpg')
     await expect(extractExif(file)).rejects.toThrow(/IMG_0001\.jpg/)
+  })
+
+  it.each(['mif1', 'msf1'])('does NOT reject generic MIAF brand %s (exifr can parse these)', async (brand) => {
+    // mif1/msf1 are the generic ISO-BMFF MIAF brands used by many non-HEIC
+    // HEIF profiles. Treating them as HEIC produced false rejections.
+    gpsMock.mockResolvedValue(null)
+    parseMock.mockResolvedValue(null)
+    const file = makeFile(ftypBytes(brand), `photo-${brand}.heif`)
+    await expect(extractExif(file)).resolves.toEqual({})
+    expect(gpsMock).toHaveBeenCalled()
   })
 
   it('does NOT reject non-HEIC `ftyp` brands (e.g. mp4)', async () => {

--- a/frontend/map-corridors/src/__tests__/generateThumb.test.ts
+++ b/frontend/map-corridors/src/__tests__/generateThumb.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generateThumb, fitWithin } from '../photoImport/generateThumb'
+
+// jsdom has neither `createImageBitmap` nor `OffscreenCanvas` (both are
+// browser-Worker APIs). We stub them globally to verify the function's
+// orchestration: arg shape passed to createImageBitmap (imageOrientation
+// 'from-image' per ADR-015), size math, blob output shape, lifecycle
+// (bitmap.close() always called). Real-pixel assertions — actual JPEG
+// bytes, EXIF Orientation=6 rotation — require @vitest/browser and are
+// gated off the default `pnpm test` run per Phase 0 plan.
+
+describe('fitWithin (pure math)', () => {
+  it('returns the source size unchanged when it already fits', () => {
+    expect(fitWithin(100, 75, 200, 150)).toEqual({ width: 100, height: 75 })
+    expect(fitWithin(200, 150, 200, 150)).toEqual({ width: 200, height: 150 })
+  })
+
+  it('caps wide images by width (landscape)', () => {
+    // 1000x500 (2:1) inside 200x150 → cap by width → 200x100.
+    expect(fitWithin(1000, 500, 200, 150)).toEqual({ width: 200, height: 100 })
+  })
+
+  it('caps tall images by height (portrait)', () => {
+    // 500x1000 (1:2) inside 200x150 → cap by height → 75x150.
+    expect(fitWithin(500, 1000, 200, 150)).toEqual({ width: 75, height: 150 })
+  })
+
+  it('caps square images by the smaller bound', () => {
+    expect(fitWithin(1000, 1000, 200, 150)).toEqual({ width: 150, height: 150 })
+  })
+
+  it('never produces zero dimensions', () => {
+    expect(fitWithin(1, 100000, 200, 150).width).toBeGreaterThanOrEqual(1)
+    expect(fitWithin(100000, 1, 200, 150).height).toBeGreaterThanOrEqual(1)
+  })
+
+  it('floors instead of rounds so we never exceed the bounds', () => {
+    // 333x200 inside 200x150 → width-capped at 200, height = 200*200/333 = 120.12 → 120
+    const r = fitWithin(333, 200, 200, 150)
+    expect(r.width).toBeLessThanOrEqual(200)
+    expect(r.height).toBeLessThanOrEqual(150)
+    expect(r).toEqual({ width: 200, height: 120 })
+  })
+})
+
+interface FakeBitmap {
+  width: number
+  height: number
+  close: ReturnType<typeof vi.fn>
+}
+
+function fakeBitmap(width: number, height: number): FakeBitmap {
+  return { width, height, close: vi.fn() }
+}
+
+interface CanvasCall {
+  width: number
+  height: number
+  drawImage: ReturnType<typeof vi.fn>
+  convertToBlob: ReturnType<typeof vi.fn>
+}
+
+describe('generateThumb (orchestration)', () => {
+  let createImageBitmapMock: ReturnType<typeof vi.fn>
+  let canvasInstances: CanvasCall[]
+  let mockBlob: Blob
+
+  beforeEach(() => {
+    canvasInstances = []
+    mockBlob = new Blob([new Uint8Array(2048)], { type: 'image/jpeg' })
+
+    createImageBitmapMock = vi.fn(async () => fakeBitmap(1000, 750))
+
+    // OffscreenCanvas constructor — capture each instance for assertion.
+    const OffscreenCanvasMock = vi.fn(function (this: CanvasCall, w: number, h: number) {
+      this.width = w
+      this.height = h
+      this.drawImage = vi.fn()
+      this.convertToBlob = vi.fn(async () => mockBlob)
+      const ctx = { drawImage: this.drawImage }
+      ;(this as unknown as { getContext: (id: string) => unknown }).getContext = vi.fn(() => ctx)
+      canvasInstances.push(this)
+    }) as unknown as typeof OffscreenCanvas
+
+    vi.stubGlobal('createImageBitmap', createImageBitmapMock)
+    vi.stubGlobal('OffscreenCanvas', OffscreenCanvasMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function dummyFile(): File {
+    return new File([new Uint8Array(8)], 'photo.jpg', { type: 'image/jpeg' })
+  }
+
+  it('passes imageOrientation:"from-image" to createImageBitmap (ADR-015)', async () => {
+    const file = dummyFile()
+    await generateThumb(file)
+    expect(createImageBitmapMock).toHaveBeenCalledTimes(1)
+    expect(createImageBitmapMock).toHaveBeenCalledWith(
+      file,
+      { imageOrientation: 'from-image' },
+    )
+  })
+
+  it('applies default 200x150 bounds with contain-fit', async () => {
+    // 1000x750 (4:3) inside 200x150 → 200x150 exactly.
+    await generateThumb(dummyFile())
+    expect(canvasInstances).toHaveLength(1)
+    expect(canvasInstances[0].width).toBe(200)
+    expect(canvasInstances[0].height).toBe(150)
+  })
+
+  it('honors custom maxWidth/maxHeight', async () => {
+    await generateThumb(dummyFile(), { maxWidth: 400, maxHeight: 300 })
+    expect(canvasInstances[0].width).toBe(400)
+    expect(canvasInstances[0].height).toBe(300)
+  })
+
+  it('forwards quality option to convertToBlob', async () => {
+    await generateThumb(dummyFile(), { quality: 0.9 })
+    expect(canvasInstances[0].convertToBlob).toHaveBeenCalledWith({
+      type: 'image/jpeg',
+      quality: 0.9,
+    })
+  })
+
+  it('defaults quality to 0.7 when not specified', async () => {
+    await generateThumb(dummyFile())
+    expect(canvasInstances[0].convertToBlob).toHaveBeenCalledWith({
+      type: 'image/jpeg',
+      quality: 0.7,
+    })
+  })
+
+  it('produces a JPEG Blob result', async () => {
+    const result = await generateThumb(dummyFile())
+    expect(result).toBeInstanceOf(Blob)
+    expect(result.type).toBe('image/jpeg')
+    expect(result.size).toBeGreaterThan(0)
+  })
+
+  it('calls bitmap.close() after successful encode (release GC pressure)', async () => {
+    const bm = fakeBitmap(1000, 750)
+    createImageBitmapMock.mockResolvedValueOnce(bm)
+    await generateThumb(dummyFile())
+    expect(bm.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls bitmap.close() even when encode fails', async () => {
+    const bm = fakeBitmap(1000, 750)
+    createImageBitmapMock.mockResolvedValueOnce(bm)
+    // Make convertToBlob throw on first canvas instance — set up after
+    // mock fires by patching the OffscreenCanvas mock to throw.
+    const OffscreenCanvasMock = vi.fn(function (this: { getContext: () => unknown; convertToBlob: () => Promise<Blob> }) {
+      this.getContext = () => ({ drawImage: () => {} })
+      this.convertToBlob = () => Promise.reject(new Error('encode boom'))
+    }) as unknown as typeof OffscreenCanvas
+    vi.stubGlobal('OffscreenCanvas', OffscreenCanvasMock)
+
+    await expect(generateThumb(dummyFile())).rejects.toThrow('encode boom')
+    expect(bm.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when createImageBitmap rejects (corrupt input)', async () => {
+    createImageBitmapMock.mockRejectedValueOnce(new Error('decode failed'))
+    await expect(generateThumb(dummyFile())).rejects.toThrow('decode failed')
+    expect(canvasInstances).toHaveLength(0)
+  })
+
+  it('throws when decoded bitmap has zero dimensions', async () => {
+    createImageBitmapMock.mockResolvedValueOnce(fakeBitmap(0, 100))
+    await expect(generateThumb(dummyFile())).rejects.toThrow(/zero dimension/)
+  })
+
+  it('throws when 2D context is unavailable', async () => {
+    const OffscreenCanvasMock = vi.fn(function (this: { getContext: () => null }) {
+      this.getContext = () => null
+    }) as unknown as typeof OffscreenCanvas
+    vi.stubGlobal('OffscreenCanvas', OffscreenCanvasMock)
+
+    await expect(generateThumb(dummyFile())).rejects.toThrow(/2D context unavailable/)
+  })
+
+  it('rejects invalid bounds', async () => {
+    await expect(generateThumb(dummyFile(), { maxWidth: 0 })).rejects.toThrow(/invalid bounds/)
+    await expect(generateThumb(dummyFile(), { maxHeight: -1 })).rejects.toThrow(/invalid bounds/)
+    expect(createImageBitmapMock).not.toHaveBeenCalled()
+  })
+
+  // Real-pixel + EXIF Orientation tests are deferred to a browser-mode
+  // run (@vitest/browser + Playwright). Tracked in Phase 1b TODO.
+  it.todo('EXIF Orientation=6 produces an upright thumbnail (real-canvas only)')
+  it.todo('Output JPEG is ≤ 30 KB for 4 MP input (real-canvas only)')
+})

--- a/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { groupPhotosByFlag } from '../components/groupPhotosByFlag'
+import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', ...over } as PhotoMarker
+}
+
+function ng(photoId: string, filename = `${photoId}.jpg`): NoGpsPhoto {
+  return { photoId, filename }
+}
+
+describe('groupPhotosByFlag', () => {
+  it('returns four empty arrays + total=0 for no input', () => {
+    const g = groupPhotosByFlag([], [])
+    expect(g.picks).toEqual([])
+    expect(g.neutral).toEqual([])
+    expect(g.rejects).toEqual([])
+    expect(g.noGps).toEqual([])
+    expect(g.total).toBe(0)
+  })
+
+  it('puts photos in their flag groups', () => {
+    const markers: PhotoMarker[] = [
+      pm({ id: 'a', photoId: 'pid-a' }),                // neutral
+      pm({ id: 'b', photoId: 'pid-b', flag: 'pick' }),  // pick
+      pm({ id: 'c', photoId: 'pid-c', flag: 'reject' }),// reject
+    ]
+    const g = groupPhotosByFlag(markers, [])
+    expect(g.picks.map(m => m.id)).toEqual(['b'])
+    expect(g.neutral.map(m => m.id)).toEqual(['a'])
+    expect(g.rejects.map(m => m.id)).toEqual(['c'])
+  })
+
+  it('excludes KML/click-placed markers (no photoId) from all groups', () => {
+    const markers: PhotoMarker[] = [
+      pm({ id: 'kml', photoId: undefined }),
+      pm({ id: 'photo', photoId: 'pid-1', flag: 'pick' }),
+    ]
+    const g = groupPhotosByFlag(markers, [])
+    expect(g.picks.map(m => m.id)).toEqual(['photo'])
+    expect(g.neutral).toEqual([])
+    expect(g.total).toBe(1)
+  })
+
+  it('treats labelled-but-no-flag as neutral (label is independent of flag)', () => {
+    // A photo can have a label without flag='pick' (e.g., legacy data
+    // from before the flag field existed). Grouping is by flag only.
+    const markers = [pm({ id: 'a', photoId: 'pid-a', label: 'A' })]
+    const g = groupPhotosByFlag(markers, [])
+    expect(g.neutral.map(m => m.id)).toEqual(['a'])
+    expect(g.picks).toEqual([])
+  })
+
+  it('passes noGpsPhotos through verbatim', () => {
+    const list = [ng('pid-x'), ng('pid-y')]
+    const g = groupPhotosByFlag([], list)
+    expect(g.noGps).toBe(list) // identity-preserving — safe for memo
+    expect(g.total).toBe(2)
+  })
+
+  it('total is the sum across all four groups', () => {
+    const g = groupPhotosByFlag(
+      [
+        pm({ id: 'p', photoId: 'pid-p', flag: 'pick' }),
+        pm({ id: 'n1', photoId: 'pid-n1' }),
+        pm({ id: 'n2', photoId: 'pid-n2' }),
+        pm({ id: 'r', photoId: 'pid-r', flag: 'reject' }),
+      ],
+      [ng('pid-ngps')],
+    )
+    expect(g.total).toBe(5)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/handoffRoundTrip.test.ts
+++ b/frontend/map-corridors/src/__tests__/handoffRoundTrip.test.ts
@@ -1,0 +1,203 @@
+// Cross-app handoff integration test. Composes mapPicksWriter and
+// syncEditorPicksOnce against a shared in-memory storage, simulating
+// the photo-helper side by writing photo-helper-picks.json directly
+// (the photo-helper writer is unit-tested separately and would pull a
+// cross-package dependency into this app's vitest run).
+//
+// The CRITICAL bugs surfaced in PR #64 review live here:
+//  - The map-picks write effect used to fire with empty markers before
+//    the session loaded, blanking the file on cold load.
+//  - useEditorPicksSync used to capture setMarkers in a stale closure,
+//    overwriting the live session on visibilitychange.
+//  - mapPicksWriter swallowed write failures, so flushPendingMapPicks
+//    resolved even when the bytes never hit disk.
+//
+// This file exercises the round-trip end-to-end with no React.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import {
+  buildMapPicks,
+  flushPendingMapPicks,
+  scheduleWriteMapPicks,
+  _resetMapPicksWriterForTests,
+} from '../handoff/mapPicksWriter'
+import { syncEditorPicksOnce } from '../hooks/useEditorPicksSync'
+import type { PhotoMarker } from '../types/markers'
+
+// In-memory storage. Files are addressed by `${dir.path}::${name}`. Good
+// enough for round-trip checks and lightly mirrors the OPFS/Electron
+// layout. We only implement the methods the handoff code calls; throw
+// loudly for anything else so a future caller addition is caught.
+function makeStorage(): StorageInterface & { _files: Map<string, unknown>; _crash: boolean } {
+  const files = new Map<string, unknown>()
+  let crash = false
+  const notImpl = (name: string) => () => { throw new Error(`fakeStorage: ${name} not implemented`) }
+  const api = {
+    _files: files,
+    get _crash() { return crash },
+    set _crash(v: boolean) { crash = v },
+    async writeJSON(dir: DirectoryHandle, name: string, data: unknown) {
+      if (crash) throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' })
+      files.set(`${dir.path}::${name}`, data)
+    },
+    async readJSON<T>(dir: DirectoryHandle, name: string): Promise<T | null> {
+      const got = files.get(`${dir.path}::${name}`)
+      return (got as T | undefined) ?? null
+    },
+    init: notImpl('init') as never,
+    ensureSessionDirs: notImpl('ensureSessionDirs') as never,
+    savePhotoFile: notImpl('savePhotoFile') as never,
+    getPhotoBlob: notImpl('getPhotoBlob') as never,
+    deletePhotoFile: notImpl('deletePhotoFile') as never,
+    savePhotoThumb: notImpl('savePhotoThumb') as never,
+    getPhotoThumb: notImpl('getPhotoThumb') as never,
+    deletePhotoThumb: notImpl('deletePhotoThumb') as never,
+    clearDirectory: notImpl('clearDirectory') as never,
+    deleteSessionDir: notImpl('deleteSessionDir') as never,
+    getDirectoryHandle: notImpl('getDirectoryHandle') as never,
+    isAvailable: notImpl('isAvailable') as never,
+    getStorageEstimate: notImpl('getStorageEstimate') as never,
+    listDirectory: notImpl('listDirectory') as never,
+  }
+  return api as unknown as StorageInterface & { _files: Map<string, unknown>; _crash: boolean }
+}
+
+const compDir: DirectoryHandle = { path: '/competitions/comp-1' }
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: over.id ?? 'pm-x', lng: 14, lat: 50, name: 'photo.jpg', ...over } as PhotoMarker
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  _resetMapPicksWriterForTests()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  _resetMapPicksWriterForTests()
+})
+
+describe('cross-app round-trip — map writes, editor reads, editor writes back, map applies', () => {
+  it('map writes a pick → editor side can read it from map-picks.json', async () => {
+    const storage = makeStorage()
+    const markers: PhotoMarker[] = [
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', capturedAt: { lng: 14, lat: 50 } }),
+    ]
+    scheduleWriteMapPicks(storage, compDir, buildMapPicks(markers))
+    await flushPendingMapPicks()
+    const file = storage._files.get('/competitions/comp-1::map-picks.json') as { picks: Array<{ photoId: string; flag: string }> }
+    expect(file).toBeTruthy()
+    expect(file.picks).toHaveLength(1)
+    expect(file.picks[0]).toMatchObject({ photoId: 'pm-1', flag: 'pick' })
+  })
+
+  it('editor writes a label → map applies it via syncEditorPicksOnce (newer-wins)', async () => {
+    const storage = makeStorage()
+    // photo-helper writes its file directly (matches what editorPicksWriter
+    // produces). T2 is strictly newer than the local marker's T1.
+    await storage.writeJSON(compDir, 'photo-helper-picks.json', {
+      version: 1, updatedAt: 'now',
+      picks: [{ photoId: 'pm-1', label: 'B', labelUpdatedAt: '2025-02-01T00:00:00Z' }],
+    })
+    const markers: PhotoMarker[] = [
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
+    ]
+    let updated: PhotoMarker[] = markers
+    const setMarkers = async (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => {
+      updated = [...updater(updated)]
+    }
+    const result = await syncEditorPicksOnce(storage, compDir, setMarkers)
+    expect(result.updates).toBe(1)
+    expect(updated[0].label).toBe('B')
+    expect(updated[0].labelUpdatedAt).toBe('2025-02-01T00:00:00Z')
+  })
+
+  it('local edits in flight win on tie-break — editor file with EQUAL timestamp does not overwrite', async () => {
+    const storage = makeStorage()
+    const t = '2025-01-01T00:00:00Z'
+    await storage.writeJSON(compDir, 'photo-helper-picks.json', {
+      version: 1, updatedAt: 'now',
+      picks: [{ photoId: 'pm-1', label: 'remote', labelUpdatedAt: t }],
+    })
+    const markers: PhotoMarker[] = [
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'local' as never, labelUpdatedAt: t }),
+    ]
+    let updated: PhotoMarker[] = markers
+    const result = await syncEditorPicksOnce(
+      storage,
+      compDir,
+      async (updater) => { updated = [...updater(updated)] },
+    )
+    expect(result.updates).toBe(0)
+    expect(updated[0].label).toBe('local')
+  })
+
+  it('editor CLEAR (empty label) propagates to map when remote is newer', async () => {
+    const storage = makeStorage()
+    await storage.writeJSON(compDir, 'photo-helper-picks.json', {
+      version: 1, updatedAt: 'now',
+      picks: [{ photoId: 'pm-1', label: '', labelUpdatedAt: '2025-02-01T00:00:00Z' }],
+    })
+    const markers: PhotoMarker[] = [
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
+    ]
+    let updated: PhotoMarker[] = markers
+    await syncEditorPicksOnce(storage, compDir, async u => { updated = [...u(updated)] })
+    expect(updated[0].label).toBeUndefined()
+  })
+
+  it('editor file entries WITHOUT the pm- prefix are ignored (map owns the photo identity)', async () => {
+    const storage = makeStorage()
+    await storage.writeJSON(compDir, 'photo-helper-picks.json', {
+      version: 1, updatedAt: 'now',
+      picks: [
+        { photoId: 'editor-owned', label: 'X', labelUpdatedAt: '2025-02-01T00:00:00Z' },
+        { photoId: 'pm-1', label: 'Z', labelUpdatedAt: '2025-02-01T00:00:00Z' },
+      ],
+    })
+    const markers: PhotoMarker[] = [
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick' }),
+    ]
+    let updated: PhotoMarker[] = markers
+    const result = await syncEditorPicksOnce(storage, compDir, async u => { updated = [...u(updated)] })
+    expect(result.updates).toBe(1)
+    expect(updated[0].label).toBe('Z')
+  })
+})
+
+describe('cross-app round-trip — failure modes (silent in pre-fix code)', () => {
+  it('flushPendingMapPicks REJECTS on quota error (was: silently resolved → caller navigated to stale file)', async () => {
+    const storage = makeStorage()
+    storage._crash = true
+    scheduleWriteMapPicks(storage, compDir, [
+      { photoId: 'pm-1', filename: 'a.jpg', flag: 'pick' },
+    ])
+    await expect(flushPendingMapPicks()).rejects.toMatchObject({ name: 'QuotaExceededError' })
+    // …and the file genuinely never landed.
+    expect(storage._files.has('/competitions/comp-1::map-picks.json')).toBe(false)
+  })
+
+  it('syncEditorPicksOnce returns 0 updates for a missing editor file (absent ≠ empty)', async () => {
+    const storage = makeStorage()
+    const result = await syncEditorPicksOnce(storage, compDir, async () => undefined)
+    expect(result.updates).toBe(0)
+  })
+
+  it('competition switch: picks for competition A do not leak into competition B map-picks file', async () => {
+    const storage = makeStorage()
+    const compDirB: DirectoryHandle = { path: '/competitions/comp-2' }
+    scheduleWriteMapPicks(storage, compDir, [
+      { photoId: 'pm-A', filename: 'a.jpg', flag: 'pick' },
+    ])
+    scheduleWriteMapPicks(storage, compDirB, [
+      { photoId: 'pm-B', filename: 'b.jpg', flag: 'reject' },
+    ])
+    await vi.advanceTimersByTimeAsync(500)
+    const a = storage._files.get('/competitions/comp-1::map-picks.json') as { picks: Array<{ photoId: string }> }
+    const b = storage._files.get('/competitions/comp-2::map-picks.json') as { picks: Array<{ photoId: string }> }
+    expect(a.picks[0].photoId).toBe('pm-A')
+    expect(b.picks[0].photoId).toBe('pm-B')
+  })
+})

--- a/frontend/map-corridors/src/__tests__/importPhotoFiles.test.ts
+++ b/frontend/map-corridors/src/__tests__/importPhotoFiles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { Mock } from 'vitest'
 import { importPhotoFiles } from '../photoImport/importPhotoFiles'
 import { extractExif } from '../photoImport/extractExif'

--- a/frontend/map-corridors/src/__tests__/importPhotoFiles.test.ts
+++ b/frontend/map-corridors/src/__tests__/importPhotoFiles.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import { importPhotoFiles } from '../photoImport/importPhotoFiles'
+import { extractExif } from '../photoImport/extractExif'
+import { generateThumb } from '../photoImport/generateThumb'
+import { HeicNotSupportedError } from '../photoImport/types'
+
+vi.mock('../photoImport/extractExif', () => ({
+  extractExif: vi.fn(),
+}))
+vi.mock('../photoImport/generateThumb', () => ({
+  generateThumb: vi.fn(),
+}))
+
+const extractExifMock = extractExif as unknown as Mock
+const generateThumbMock = generateThumb as unknown as Mock
+
+beforeEach(() => {
+  // `mockReset` (not `clearAllMocks`) — the latter keeps queued
+  // `mockResolvedValueOnce`/`mockRejectedValueOnce` calls and they
+  // leak into the next test as silent surprise behaviour.
+  extractExifMock.mockReset()
+  generateThumbMock.mockReset()
+  extractExifMock.mockResolvedValue({})
+  generateThumbMock.mockResolvedValue(new Blob([new Uint8Array(64)], { type: 'image/jpeg' }))
+})
+
+function makeFile(name: string, type = 'image/jpeg', bytes = new Uint8Array(16)): File {
+  return new File([bytes], name, { type })
+}
+
+describe('importPhotoFiles — happy path', () => {
+  it('imports a single JPEG', async () => {
+    const result = await importPhotoFiles([makeFile('a.jpg')])
+    expect(result.ok).toHaveLength(1)
+    expect(result.failed).toHaveLength(0)
+    expect(result.ok[0].file.name).toBe('a.jpg')
+    expect(result.ok[0].photoId).toMatch(/^pm-/)
+    expect(result.ok[0].contentHash).toMatch(/^[0-9a-f]{40}$/)
+    expect(result.ok[0].thumbnail).toBeInstanceOf(Blob)
+  })
+
+  it('produces unique photoIds per file', async () => {
+    const result = await importPhotoFiles([
+      makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg'),
+    ])
+    const ids = result.ok.map(p => p.photoId)
+    expect(new Set(ids).size).toBe(3)
+    ids.forEach(id => expect(id).toMatch(/^pm-/))
+  })
+
+  it('produces stable contentHash per identical bytes, distinct per different', async () => {
+    const sameA = makeFile('same1.jpg', 'image/jpeg', new Uint8Array([1, 2, 3, 4]))
+    const sameB = makeFile('same2.jpg', 'image/jpeg', new Uint8Array([1, 2, 3, 4]))
+    const diff = makeFile('different.jpg', 'image/jpeg', new Uint8Array([9, 8, 7, 6]))
+    const result = await importPhotoFiles([sameA, sameB, diff])
+    const hashes = new Map(result.ok.map(p => [p.file.name, p.contentHash]))
+    expect(hashes.get('same1.jpg')).toBe(hashes.get('same2.jpg'))
+    expect(hashes.get('same1.jpg')).not.toBe(hashes.get('different.jpg'))
+  })
+
+  it('falls back to filename extension when file.type is empty', async () => {
+    const file = makeFile('photo.JPG', '', new Uint8Array(8))
+    const result = await importPhotoFiles([file])
+    expect(result.ok).toHaveLength(1)
+    expect(result.failed).toHaveLength(0)
+  })
+
+  it('accepts PNG', async () => {
+    const result = await importPhotoFiles([makeFile('a.png', 'image/png')])
+    expect(result.ok).toHaveLength(1)
+    expect(result.failed).toHaveLength(0)
+  })
+
+  it('attaches the ExifData returned by extractExif', async () => {
+    extractExifMock.mockResolvedValueOnce({
+      capturedAt: { lat: 50, lng: 14 },
+      timestamp: '2024-01-01T00:00:00.000Z',
+    })
+    const result = await importPhotoFiles([makeFile('a.jpg')])
+    expect(result.ok[0].exif).toEqual({
+      capturedAt: { lat: 50, lng: 14 },
+      timestamp: '2024-01-01T00:00:00.000Z',
+    })
+  })
+})
+
+describe('importPhotoFiles — rejection routing', () => {
+  it('routes HEIC to failed with reason="heic"', async () => {
+    extractExifMock.mockRejectedValueOnce(new HeicNotSupportedError('apple.heic'))
+    const result = await importPhotoFiles([makeFile('apple.heic', 'image/heic')])
+    // image/heic isn't in the supported list → "unsupported" wins before extractExif fires
+    expect(result.ok).toHaveLength(0)
+    expect(result.failed).toEqual([
+      expect.objectContaining({ filename: 'apple.heic', reason: 'unsupported' }),
+    ])
+  })
+
+  it('routes mislabeled HEIC (.jpg) to failed with reason="heic"', async () => {
+    // File passes MIME gate (image/jpeg) — extractExif then detects HEIC content and throws.
+    extractExifMock.mockRejectedValueOnce(new HeicNotSupportedError('photo.jpg'))
+    const result = await importPhotoFiles([makeFile('photo.jpg', 'image/jpeg')])
+    expect(result.ok).toHaveLength(0)
+    expect(result.failed).toEqual([
+      expect.objectContaining({ filename: 'photo.jpg', reason: 'heic' }),
+    ])
+  })
+
+  it('routes corrupt files to failed with reason="corrupt"', async () => {
+    generateThumbMock.mockRejectedValueOnce(new Error('decode failed'))
+    const result = await importPhotoFiles([makeFile('broken.jpg')])
+    expect(result.ok).toHaveLength(0)
+    expect(result.failed).toEqual([
+      expect.objectContaining({ filename: 'broken.jpg', reason: 'corrupt', message: 'decode failed' }),
+    ])
+  })
+
+  it('routes unsupported MIME types to failed with reason="unsupported"', async () => {
+    const result = await importPhotoFiles([
+      makeFile('doc.pdf', 'application/pdf'),
+      makeFile('arch.zip', 'application/zip'),
+      makeFile('note.txt', 'text/plain'),
+    ])
+    expect(result.ok).toHaveLength(0)
+    expect(result.failed).toHaveLength(3)
+    result.failed.forEach(f => expect(f.reason).toBe('unsupported'))
+    // extractExif/generateThumb never called for these
+    expect(extractExifMock).not.toHaveBeenCalled()
+    expect(generateThumbMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('importPhotoFiles — failure isolation (ADR-013)', () => {
+  it('one corrupt file does not abort the rest of the batch', async () => {
+    extractExifMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({})
+    const result = await importPhotoFiles([
+      makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg'),
+    ])
+    expect(result.ok.map(p => p.file.name).sort()).toEqual(['a.jpg', 'c.jpg'])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].filename).toBe('b.jpg')
+  })
+
+  it('mixes ok and failed in a single batch', async () => {
+    extractExifMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new HeicNotSupportedError('b.jpg'))
+    const result = await importPhotoFiles([makeFile('a.jpg'), makeFile('b.jpg')])
+    expect(result.ok).toHaveLength(1)
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].reason).toBe('heic')
+  })
+})
+
+describe('importPhotoFiles — concurrency (ADR-014)', () => {
+  // Tracks the maximum number of concurrently-pending extractExif calls
+  // to verify the worker pool respects `opts.concurrency`.
+  function buildConcurrencyTracker() {
+    let active = 0
+    let peak = 0
+    const tracker = vi.fn(async () => {
+      active++
+      if (active > peak) peak = active
+      await new Promise(r => setTimeout(r, 5))
+      active--
+      return {}
+    })
+    return { tracker, get peak() { return peak } }
+  }
+
+  it('caps active workers at the configured concurrency (default 8)', async () => {
+    const t = buildConcurrencyTracker()
+    extractExifMock.mockImplementation(t.tracker)
+    const files = Array.from({ length: 20 }, (_, i) => makeFile(`f${i}.jpg`))
+    await importPhotoFiles(files)
+    expect(t.peak).toBeLessThanOrEqual(8)
+    expect(t.peak).toBeGreaterThan(1)
+  })
+
+  it('respects an explicit concurrency: 3', async () => {
+    const t = buildConcurrencyTracker()
+    extractExifMock.mockImplementation(t.tracker)
+    const files = Array.from({ length: 10 }, (_, i) => makeFile(`f${i}.jpg`))
+    await importPhotoFiles(files, { concurrency: 3 })
+    expect(t.peak).toBeLessThanOrEqual(3)
+  })
+
+  it('processes ALL files regardless of concurrency cap', async () => {
+    const t = buildConcurrencyTracker()
+    extractExifMock.mockImplementation(t.tracker)
+    const files = Array.from({ length: 20 }, (_, i) => makeFile(`f${i}.jpg`))
+    const result = await importPhotoFiles(files, { concurrency: 4 })
+    expect(result.ok).toHaveLength(20)
+  })
+
+  it('treats concurrency < 1 as 1', async () => {
+    const files = [makeFile('a.jpg'), makeFile('b.jpg')]
+    const result = await importPhotoFiles(files, { concurrency: 0 })
+    expect(result.ok).toHaveLength(2)
+  })
+})
+
+describe('importPhotoFiles — progress callback', () => {
+  it('calls onProgress once per file with monotonically increasing done', async () => {
+    const onProgress = vi.fn()
+    const files = [makeFile('a.jpg'), makeFile('b.jpg'), makeFile('c.jpg')]
+    await importPhotoFiles(files, { onProgress })
+    expect(onProgress).toHaveBeenCalledTimes(3)
+    const dones = onProgress.mock.calls.map(c => c[0])
+    expect(dones).toEqual([1, 2, 3])
+    // Total is always the original count
+    onProgress.mock.calls.forEach(c => expect(c[1]).toBe(3))
+  })
+
+  it('reports progress for filtered (unsupported) files too', async () => {
+    const onProgress = vi.fn()
+    const files = [
+      makeFile('a.jpg'),
+      makeFile('doc.pdf', 'application/pdf'),
+      makeFile('b.jpg'),
+    ]
+    await importPhotoFiles(files, { onProgress })
+    expect(onProgress).toHaveBeenCalledTimes(3)
+  })
+
+  it('reports progress for failed files too', async () => {
+    const onProgress = vi.fn()
+    extractExifMock
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error('boom'))
+    await importPhotoFiles([makeFile('a.jpg'), makeFile('b.jpg')], { onProgress })
+    expect(onProgress).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('importPhotoFiles — edge cases', () => {
+  it('returns empty ok/failed for an empty input', async () => {
+    const result = await importPhotoFiles([])
+    expect(result.ok).toEqual([])
+    expect(result.failed).toEqual([])
+  })
+
+  it('runs extractExif, generateThumb, and the hash in parallel per file', async () => {
+    // We can't easily verify "started simultaneously" in jsdom, but we
+    // can verify they were all awaited (called) for each successful file.
+    await importPhotoFiles([makeFile('a.jpg')])
+    expect(extractExifMock).toHaveBeenCalledTimes(1)
+    expect(generateThumbMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/importPhotosToStorage.test.ts
+++ b/frontend/map-corridors/src/__tests__/importPhotosToStorage.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { importPhotosToStorage } from '../photoImport/importPhotosToStorage'
+import { importPhotoFiles } from '../photoImport/importPhotoFiles'
+import { HeicNotSupportedError } from '../photoImport/types'
+import type { ImportedPhoto, ImportResult } from '../photoImport/types'
+
+vi.mock('../photoImport/importPhotoFiles', () => ({
+  importPhotoFiles: vi.fn(),
+}))
+
+const importPhotoFilesMock = importPhotoFiles as unknown as Mock
+
+const photosDir: DirectoryHandle = { path: '/sessions/comp-1/photos' }
+
+function makeFile(name: string): File {
+  return new File([new Uint8Array(8)], name, { type: 'image/jpeg' })
+}
+
+function makePhoto(name: string): ImportedPhoto {
+  const file = makeFile(name)
+  return {
+    photoId: `pm-${name}`,
+    file,
+    thumbnail: new Blob([new Uint8Array(32)], { type: 'image/jpeg' }),
+    exif: {},
+    contentHash: '0'.repeat(40),
+  }
+}
+
+interface FakeStorage extends Pick<StorageInterface,
+  'savePhotoFile' | 'savePhotoThumb' | 'deletePhotoFile'> {
+  savePhotoFile: Mock
+  savePhotoThumb: Mock
+  deletePhotoFile: Mock
+}
+
+function fakeStorage(): FakeStorage {
+  return {
+    savePhotoFile: vi.fn().mockResolvedValue(undefined),
+    savePhotoThumb: vi.fn().mockResolvedValue(undefined),
+    deletePhotoFile: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+beforeEach(() => {
+  importPhotoFilesMock.mockReset()
+})
+
+describe('importPhotosToStorage — happy path', () => {
+  it('persists each photo: blob first, then thumb', async () => {
+    const photo = makePhoto('a.jpg')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+    )
+
+    expect(result.ok).toEqual([photo])
+    expect(result.failed).toEqual([])
+    expect(storage.savePhotoFile).toHaveBeenCalledWith(photosDir, 'pm-a.jpg', photo.file)
+    expect(storage.savePhotoThumb).toHaveBeenCalledWith(photosDir, 'pm-a.jpg', photo.thumbnail)
+    // Order: blob write must complete before thumb write
+    const blobCall = storage.savePhotoFile.mock.invocationCallOrder[0]
+    const thumbCall = storage.savePhotoThumb.mock.invocationCallOrder[0]
+    expect(blobCall).toBeLessThan(thumbCall)
+  })
+
+  it('processes multiple photos in parallel and preserves all on success', async () => {
+    const photos = [makePhoto('a.jpg'), makePhoto('b.jpg'), makePhoto('c.jpg')]
+    importPhotoFilesMock.mockResolvedValue({ ok: photos, failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      photos.map(p => p.file),
+    )
+
+    expect(result.ok).toHaveLength(3)
+    expect(storage.savePhotoFile).toHaveBeenCalledTimes(3)
+    expect(storage.savePhotoThumb).toHaveBeenCalledTimes(3)
+  })
+
+  it('forwards opts to importPhotoFiles', async () => {
+    importPhotoFilesMock.mockResolvedValue({ ok: [], failed: [] } as ImportResult)
+    const onProgress = vi.fn()
+    await importPhotosToStorage(
+      fakeStorage() as unknown as StorageInterface,
+      photosDir,
+      [],
+      { concurrency: 4, onProgress },
+    )
+    expect(importPhotoFilesMock).toHaveBeenCalledWith(
+      [],
+      { concurrency: 4, onProgress },
+    )
+  })
+
+  it('passes through pre-existing failures (HEIC, corrupt) without touching them', async () => {
+    importPhotoFilesMock.mockResolvedValue({
+      ok: [],
+      failed: [
+        { filename: 'apple.jpg', reason: 'heic', message: 'HEIC content' },
+        { filename: 'broken.jpg', reason: 'corrupt', message: 'decode failed' },
+      ],
+    } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [],
+    )
+
+    expect(result.ok).toEqual([])
+    expect(result.failed).toHaveLength(2)
+    expect(result.failed[0].reason).toBe('heic')
+    expect(result.failed[1].reason).toBe('corrupt')
+    expect(storage.savePhotoFile).not.toHaveBeenCalled()
+  })
+
+  it('skips storage round-trip entirely when no imports succeeded', async () => {
+    importPhotoFilesMock.mockResolvedValue({
+      ok: [],
+      failed: [{ filename: 'x.heic', reason: 'heic', message: '' }],
+    } as ImportResult)
+    const storage = fakeStorage()
+
+    await importPhotosToStorage(storage as unknown as StorageInterface, photosDir, [])
+
+    expect(storage.savePhotoFile).not.toHaveBeenCalled()
+    expect(storage.savePhotoThumb).not.toHaveBeenCalled()
+  })
+})
+
+describe('importPhotosToStorage — storage failures', () => {
+  it('demotes a photo to failed when savePhotoFile throws', async () => {
+    const photo = makePhoto('a.jpg')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+    storage.savePhotoFile.mockRejectedValueOnce(new Error('quota exceeded'))
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+    )
+
+    expect(result.ok).toEqual([])
+    expect(result.failed).toEqual([
+      expect.objectContaining({
+        filename: 'a.jpg',
+        reason: 'storage',
+        message: 'quota exceeded',
+      }),
+    ])
+    expect(storage.savePhotoThumb).not.toHaveBeenCalled()
+  })
+
+  it('rolls back the blob when savePhotoThumb fails (ADR-013 atomicity)', async () => {
+    const photo = makePhoto('a.jpg')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+    storage.savePhotoThumb.mockRejectedValueOnce(new Error('thumb write failed'))
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+    )
+
+    expect(result.ok).toEqual([])
+    expect(result.failed[0]).toEqual(expect.objectContaining({
+      filename: 'a.jpg',
+      reason: 'storage',
+      message: 'thumb write failed',
+    }))
+    // Rollback: the orphan blob should have been deleted.
+    expect(storage.deletePhotoFile).toHaveBeenCalledWith(photosDir, 'pm-a.jpg')
+  })
+
+  it('does not throw if rollback delete itself fails', async () => {
+    const photo = makePhoto('a.jpg')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+    storage.savePhotoThumb.mockRejectedValueOnce(new Error('thumb fail'))
+    storage.deletePhotoFile.mockRejectedValueOnce(new Error('delete also fail'))
+
+    // Should resolve, not reject — rollback is best-effort.
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+    )
+    expect(result.failed[0].message).toBe('thumb fail')
+  })
+
+  it('isolates per-photo storage failures: one fails, others still persist', async () => {
+    const photos = [makePhoto('a.jpg'), makePhoto('b.jpg'), makePhoto('c.jpg')]
+    importPhotoFilesMock.mockResolvedValue({ ok: photos, failed: [] } as ImportResult)
+    const storage = fakeStorage()
+    // Make middle photo's blob write fail
+    storage.savePhotoFile.mockImplementation(async (_dir, photoId) => {
+      if (photoId === 'pm-b.jpg') throw new Error('mid-batch fail')
+    })
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      photos.map(p => p.file),
+    )
+
+    expect(result.ok.map(p => p.file.name).sort()).toEqual(['a.jpg', 'c.jpg'])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].filename).toBe('b.jpg')
+  })
+
+  it('uses non-Error exception messages verbatim', async () => {
+    const photo = makePhoto('a.jpg')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+    storage.savePhotoFile.mockRejectedValueOnce('plain string thrown')
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+    )
+    expect(result.failed[0].message).toBe('plain string thrown')
+  })
+})
+
+describe('importPhotosToStorage — sanity', () => {
+  it('still distinguishes HEIC failures from storage failures', async () => {
+    // HEIC failure surfaces from importPhotoFiles (typed error); not
+    // affected by the storage layer. Round-tripped through unchanged.
+    importPhotoFilesMock.mockResolvedValue({
+      ok: [],
+      failed: [
+        {
+          filename: 'apple.jpg',
+          reason: 'heic',
+          message: new HeicNotSupportedError('apple.jpg').message,
+        },
+      ],
+    } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [],
+    )
+    expect(result.failed[0].reason).toBe('heic')
+  })
+})

--- a/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import {
+  buildMapPickEntry,
+  buildMapPicks,
+  scheduleWriteMapPicks,
+  flushPendingMapPicks,
+  _resetMapPicksWriterForTests,
+  type MapPicksFile,
+} from '../handoff/mapPicksWriter'
+import type { PhotoMarker } from '../types/markers'
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', ...over } as PhotoMarker
+}
+
+describe('buildMapPickEntry', () => {
+  it('returns null for KML markers (no photoId)', () => {
+    expect(buildMapPickEntry(pm({}))).toBeNull()
+  })
+
+  it('defaults absent flag to "neutral"', () => {
+    const e = buildMapPickEntry(pm({ photoId: 'pid' }))!
+    expect(e.flag).toBe('neutral')
+  })
+
+  it('preserves explicit pick/reject', () => {
+    expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'pick' }))!.flag).toBe('pick')
+    expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'reject' }))!.flag).toBe('reject')
+  })
+
+  it('forwards label when present', () => {
+    expect(buildMapPickEntry(pm({ photoId: 'pid', label: 'A' }))!.label).toBe('A')
+  })
+
+  it('omits label when absent (cleaner downstream diff)', () => {
+    expect(buildMapPickEntry(pm({ photoId: 'pid' }))!.label).toBeUndefined()
+  })
+
+  it('writes capturedAt to gps when EXIF GPS was present at import', () => {
+    const e = buildMapPickEntry(pm({
+      photoId: 'pid',
+      lng: 14, lat: 50,
+      capturedAt: { lng: 14, lat: 50, altitude: 350, timestamp: '2024-01-01T00:00:00Z' },
+    }))!
+    expect(e.gps?.capturedAt).toEqual({
+      lng: 14, lat: 50, altitude: 350, timestamp: '2024-01-01T00:00:00Z',
+    })
+  })
+
+  it('omits subjectAt when subject equals capture (no drag yet)', () => {
+    const e = buildMapPickEntry(pm({
+      photoId: 'pid',
+      lng: 14, lat: 50,
+      capturedAt: { lng: 14, lat: 50 },
+    }))!
+    expect(e.gps?.subjectAt).toBeUndefined()
+  })
+
+  it('writes subjectAt when subject moved away from capture (user dragged pin)', () => {
+    const e = buildMapPickEntry(pm({
+      photoId: 'pid',
+      lng: 14.5, lat: 50.5,
+      capturedAt: { lng: 14, lat: 50 },
+    }))!
+    expect(e.gps?.subjectAt).toEqual({ lng: 14.5, lat: 50.5 })
+  })
+
+  it('writes subjectAt for no-GPS picks (no capturedAt at all)', () => {
+    // Phase 6 places no-GPS photos at the drop coord. They have no
+    // capturedAt; subjectAt is the only coordinate the reader gets.
+    const e = buildMapPickEntry(pm({
+      photoId: 'pid',
+      lng: 14, lat: 50,
+      flag: 'pick',
+      // no capturedAt
+    }))!
+    expect(e.gps?.subjectAt).toEqual({ lng: 14, lat: 50 })
+    expect(e.gps?.capturedAt).toBeUndefined()
+  })
+
+  it('omits gps entirely when there is nothing to record (KML-style placement of a photo)', () => {
+    // Theoretical edge — photo marker without capturedAt and lng/lat
+    // matching capturedAt (which doesn't exist). subjectMoved=true via
+    // the !capturedAt branch — so this actually emits subjectAt. Test
+    // documents that subjectAt is always emitted for no-capture photos.
+    const e = buildMapPickEntry(pm({ photoId: 'pid', lng: 14, lat: 50 }))!
+    expect(e.gps).toEqual({ subjectAt: { lng: 14, lat: 50 } })
+  })
+})
+
+describe('buildMapPicks', () => {
+  it('skips KML markers and projects photo markers in order', () => {
+    const result = buildMapPicks([
+      pm({ id: 'kml', photoId: undefined }),
+      pm({ id: 'p1', photoId: 'pid-1', flag: 'pick' }),
+      pm({ id: 'p2', photoId: 'pid-2' }),
+    ])
+    expect(result.map(e => e.photoId)).toEqual(['pid-1', 'pid-2'])
+  })
+
+  it('returns [] for empty input', () => {
+    expect(buildMapPicks([])).toEqual([])
+  })
+})
+
+describe('scheduleWriteMapPicks — debounce + serialization', () => {
+  let storage: { writeJSON: Mock }
+  let dir: DirectoryHandle
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn().mockResolvedValue(undefined) }
+    dir = { path: '/competitions/comp-1' }
+    _resetMapPicksWriterForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetMapPicksWriterForTests()
+  })
+
+  it('does not write before the 300ms debounce', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(299)
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+  })
+
+  it('writes exactly once after the debounce settles', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces rapid scheduling — only the LATEST data is written', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'neutral' },
+    ])
+    await vi.advanceTimersByTimeAsync(100)
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    await vi.advanceTimersByTimeAsync(100)
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'reject' },
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+    const written = storage.writeJSON.mock.calls[0][2] as MapPicksFile
+    expect(written.picks[0].flag).toBe('reject')
+  })
+
+  it('writes to the {photosDir.path}/map-picks.json filename', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [])
+    await vi.advanceTimersByTimeAsync(300)
+    const [actualDir, actualName] = storage.writeJSON.mock.calls[0]
+    expect(actualDir).toBe(dir)
+    expect(actualName).toBe('map-picks.json')
+  })
+
+  it('emits MapPicksFile shape: version=1, ISO updatedAt, picks array', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    const file = storage.writeJSON.mock.calls[0][2] as MapPicksFile
+    expect(file.version).toBe(1)
+    expect(typeof file.updatedAt).toBe('string')
+    expect(() => new Date(file.updatedAt).toISOString()).not.toThrow()
+    expect(Array.isArray(file.picks)).toBe(true)
+  })
+})
+
+describe('flushPendingMapPicks', () => {
+  let storage: { writeJSON: Mock }
+  let dir: DirectoryHandle
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn().mockResolvedValue(undefined) }
+    dir = { path: '/competitions/comp-1' }
+    _resetMapPicksWriterForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetMapPicksWriterForTests()
+  })
+
+  it('executes the pending write immediately (no debounce wait)', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+    await flushPendingMapPicks()
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op (and resolves) when nothing is pending', async () => {
+    await expect(flushPendingMapPicks()).resolves.toBeUndefined()
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+  })
+
+  it('cancels the debounce timer — no second write fires later', async () => {
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    await flushPendingMapPicks()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
@@ -177,6 +177,109 @@ describe('scheduleWriteMapPicks — debounce + serialization', () => {
   })
 })
 
+describe('scheduleWriteMapPicks — competition switch (two-dir flush)', () => {
+  let storage: { writeJSON: Mock }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn().mockResolvedValue(undefined) }
+    _resetMapPicksWriterForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetMapPicksWriterForTests()
+  })
+
+  it('flushes pending picks to the OLD dir before scheduling against a NEW dir (no payload swap)', async () => {
+    const dirA: DirectoryHandle = { path: '/competitions/A' }
+    const dirB: DirectoryHandle = { path: '/competitions/B' }
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dirA, [
+      { photoId: 'pid-A', filename: 'a.jpg', flag: 'pick' },
+    ])
+    // Switch competition before the debounce fires:
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dirB, [
+      { photoId: 'pid-B', filename: 'b.jpg', flag: 'reject' },
+    ])
+    // Allow the immediately-scheduled flush + the debounced new write.
+    await vi.advanceTimersByTimeAsync(500)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(2)
+    const [firstCall, secondCall] = storage.writeJSON.mock.calls
+    // First call MUST be the OLD dir with OLD picks — the bug was that
+    // the old picks landed in the new dir (or were silently dropped).
+    expect(firstCall[0]).toBe(dirA)
+    expect((firstCall[2] as MapPicksFile).picks[0].photoId).toBe('pid-A')
+    expect(secondCall[0]).toBe(dirB)
+    expect((secondCall[2] as MapPicksFile).picks[0].photoId).toBe('pid-B')
+  })
+
+  it('does NOT flush when only the picks payload changes (same dir, same storage)', async () => {
+    const dir: DirectoryHandle = { path: '/competitions/A' }
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'reject' },
+    ])
+    await vi.advanceTimersByTimeAsync(50)
+    // Still nothing written yet (debounce coalesces; no flush triggered).
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+    expect((storage.writeJSON.mock.calls[0][2] as MapPicksFile).picks[0].flag).toBe('reject')
+  })
+})
+
+describe('flushPendingMapPicks — error propagation (was silently swallowed)', () => {
+  let storage: { writeJSON: Mock }
+  let dir: DirectoryHandle
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn() }
+    dir = { path: '/competitions/comp-1' }
+    _resetMapPicksWriterForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetMapPicksWriterForTests()
+  })
+
+  it('REJECTS when the underlying writeJSON rejects (was: silently resolved)', async () => {
+    const quotaErr = Object.assign(new Error('quota'), { name: 'QuotaExceededError' })
+    storage.writeJSON.mockRejectedValue(quotaErr)
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    await expect(flushPendingMapPicks()).rejects.toBe(quotaErr)
+  })
+
+  it("RESOLVES when there's nothing pending (no caller can be misled by a prior failure)", async () => {
+    storage.writeJSON.mockRejectedValue(new Error('boom'))
+    // No schedule → nothing pending → flush is a no-op even if a prior
+    // hypothetical write had failed. Callers asking "did MY flush land?"
+    // get a true answer: there was nothing of mine to land.
+    await expect(flushPendingMapPicks()).resolves.toBeUndefined()
+  })
+
+  it('does not break the queue: a failed write does not poison the next scheduled write', async () => {
+    storage.writeJSON
+      .mockRejectedValueOnce(new Error('first'))
+      .mockResolvedValueOnce(undefined)
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'pick' },
+    ])
+    // Catch the rejection so vitest doesn't flag it as unhandled.
+    await flushPendingMapPicks().catch(() => undefined)
+    scheduleWriteMapPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pid', filename: 'x.jpg', flag: 'reject' },
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('flushPendingMapPicks', () => {
   let storage: { writeJSON: Mock }
   let dir: DirectoryHandle

--- a/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
@@ -152,6 +152,27 @@ describe('isPhotoMarker — photoId', () => {
   })
 })
 
+describe('isPhotoMarker — flag', () => {
+  const base = { id: 'pm-1', lng: 14, lat: 50, name: 'Test' }
+
+  it.each(['pick', 'reject'])('accepts flag = %s', (flag) => {
+    expect(isPhotoMarker({ ...base, flag })).toBe(true)
+  })
+
+  it('accepts absent flag (neutral state)', () => {
+    expect(isPhotoMarker(base)).toBe(true)
+  })
+
+  it.each([
+    ['unknown string', { ...base, flag: 'something' }],
+    ['empty string', { ...base, flag: '' }],
+    ['number', { ...base, flag: 1 }],
+    ['null', { ...base, flag: null }],
+  ])('rejects %s', (_label, input) => {
+    expect(isPhotoMarker(input)).toBe(false)
+  })
+})
+
 describe('sanitizePhotoMarkers — round-trip of EXIF fields', () => {
   it('preserves capturedAt and photoId on valid markers', () => {
     const input = [{

--- a/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
@@ -104,3 +104,87 @@ describe('sanitizePhotoMarkers', () => {
     expect(result[0].id).toBe('pm-1')
   })
 })
+
+// EXIF photo-import fields (docs/photo-map-culling/implementation-plan.md Phase 0)
+describe('isPhotoMarker — capturedAt', () => {
+  const base = { id: 'pm-1', lng: 14, lat: 50, name: 'Test' }
+
+  it('accepts a marker with valid capturedAt', () => {
+    expect(isPhotoMarker({ ...base, capturedAt: { lng: 14.1, lat: 50.1 } })).toBe(true)
+  })
+
+  it('accepts capturedAt with optional altitude/timestamp', () => {
+    expect(isPhotoMarker({
+      ...base,
+      capturedAt: { lng: 14.1, lat: 50.1, altitude: 320, timestamp: '2026-05-14T08:00:00Z' },
+    })).toBe(true)
+  })
+
+  it.each([
+    ['non-object capturedAt', { ...base, capturedAt: 'not an object' }],
+    ['null capturedAt', { ...base, capturedAt: null }],
+    ['capturedAt missing coords', { ...base, capturedAt: {} }],
+    ['capturedAt with out-of-range lng', { ...base, capturedAt: { lng: 999, lat: 50 } }],
+    ['capturedAt with NaN lat', { ...base, capturedAt: { lng: 14, lat: NaN } }],
+    ['capturedAt with non-numeric altitude', { ...base, capturedAt: { lng: 14, lat: 50, altitude: 'high' } }],
+    ['capturedAt with non-string timestamp', { ...base, capturedAt: { lng: 14, lat: 50, timestamp: 1234 } }],
+  ])('rejects %s', (_label, input) => {
+    expect(isPhotoMarker(input)).toBe(false)
+  })
+})
+
+describe('isPhotoMarker — photoId', () => {
+  const base = { id: 'pm-1', lng: 14, lat: 50, name: 'Test' }
+
+  it('accepts non-empty photoId', () => {
+    expect(isPhotoMarker({ ...base, photoId: 'photo-abc-123' })).toBe(true)
+  })
+
+  it('accepts absent photoId', () => {
+    expect(isPhotoMarker(base)).toBe(true)
+  })
+
+  it.each([
+    ['empty photoId', { ...base, photoId: '' }],
+    ['non-string photoId', { ...base, photoId: 42 }],
+  ])('rejects %s', (_label, input) => {
+    expect(isPhotoMarker(input)).toBe(false)
+  })
+})
+
+describe('sanitizePhotoMarkers — round-trip of EXIF fields', () => {
+  it('preserves capturedAt and photoId on valid markers', () => {
+    const input = [{
+      id: 'pm-1',
+      lng: 14.5,
+      lat: 50.1,
+      name: 'IMG_001.JPG',
+      label: 'A',
+      capturedAt: { lng: 14.49, lat: 50.105, altitude: 280, timestamp: '2026-05-14T08:00:00Z' },
+      photoId: 'photo-abc',
+    }]
+    const result = sanitizePhotoMarkers(input)
+    expect(result).toHaveLength(1)
+    const m = result[0]
+    expect(m.capturedAt).toEqual({ lng: 14.49, lat: 50.105, altitude: 280, timestamp: '2026-05-14T08:00:00Z' })
+    expect(m.photoId).toBe('photo-abc')
+  })
+
+  it('drops markers whose EXIF fields are corrupted (fail-loud philosophy)', () => {
+    const input = [
+      { id: 'pm-1', lng: 14, lat: 50, name: 'good' },
+      { id: 'pm-2', lng: 14, lat: 50, name: 'bad-capturedAt', capturedAt: { lng: 999, lat: 50 } },
+      { id: 'pm-3', lng: 14, lat: 50, name: 'bad-photoId', photoId: '' },
+    ]
+    const result = sanitizePhotoMarkers(input)
+    expect(result.map(m => m.id)).toEqual(['pm-1'])
+  })
+
+  it('round-trips a pre-feature marker (v1 → v2 migration: missing fields stay missing)', () => {
+    const v1Marker = { id: 'pm-1', lng: 14, lat: 50, name: 'old-format' }
+    const result = sanitizePhotoMarkers([v1Marker])
+    expect(result).toHaveLength(1)
+    expect(result[0].capturedAt).toBeUndefined()
+    expect(result[0].photoId).toBeUndefined()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
@@ -3,8 +3,10 @@ import {
   DEFAULT_GROUND_MARKER_TYPE,
   GROUND_MARKER_TYPES,
   isGroundMarker,
+  isNoGpsPhoto,
   isPhotoMarker,
   sanitizeGroundMarkers,
+  sanitizeNoGpsPhotos,
   sanitizePhotoMarkers,
 } from '../types/markers'
 
@@ -207,5 +209,47 @@ describe('sanitizePhotoMarkers — round-trip of EXIF fields', () => {
     expect(result).toHaveLength(1)
     expect(result[0].capturedAt).toBeUndefined()
     expect(result[0].photoId).toBeUndefined()
+  })
+})
+
+// Phase 6 — no-GPS tray entries (ADR-012)
+describe('isNoGpsPhoto', () => {
+  const valid = { photoId: 'pm-abc', filename: 'IMG_0001.JPG' }
+
+  it('accepts a minimal valid entry', () => {
+    expect(isNoGpsPhoto(valid)).toBe(true)
+  })
+
+  it('accepts an entry with a timestamp', () => {
+    expect(isNoGpsPhoto({ ...valid, timestamp: '2024-01-01T00:00:00Z' })).toBe(true)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty photoId', { ...valid, photoId: '' }],
+    ['non-string photoId', { ...valid, photoId: 42 }],
+    ['missing filename', { photoId: 'pm-abc' }],
+    ['empty filename', { ...valid, filename: '' }],
+    ['non-string timestamp', { ...valid, timestamp: 1234 }],
+  ])('rejects %s', (_label, input) => {
+    expect(isNoGpsPhoto(input)).toBe(false)
+  })
+})
+
+describe('sanitizeNoGpsPhotos', () => {
+  it('returns [] for non-array input', () => {
+    expect(sanitizeNoGpsPhotos(undefined)).toEqual([])
+    expect(sanitizeNoGpsPhotos({})).toEqual([])
+  })
+
+  it('drops invalid entries, keeps valid ones', () => {
+    const result = sanitizeNoGpsPhotos([
+      { photoId: 'a', filename: 'a.jpg' },
+      { photoId: '', filename: 'b.jpg' },   // bad photoId
+      { photoId: 'c', filename: 'c.jpg', timestamp: '2024-01-01T00:00:00Z' },
+      'nope',
+    ])
+    expect(result.map(r => r.photoId)).toEqual(['a', 'c'])
   })
 })

--- a/frontend/map-corridors/src/__tests__/photoThumbs.test.ts
+++ b/frontend/map-corridors/src/__tests__/photoThumbs.test.ts
@@ -93,13 +93,13 @@ describe('getPhotoThumb', () => {
   })
 
   it('returns null when the thumbs subdirectory does not exist yet', async () => {
-    storage.getDirectoryHandle.mockRejectedValue(new Error('NotFoundError'))
+    storage.getDirectoryHandle.mockRejectedValue(Object.assign(new Error('not found'), { name: 'NotFoundError' }))
     expect(await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')).toBeNull()
     expect(storage.getPhotoBlob).not.toHaveBeenCalled()
   })
 
   it('returns null when the thumbs subdir exists but the file is missing', async () => {
-    storage.getPhotoBlob.mockRejectedValue(new Error('NotFoundError'))
+    storage.getPhotoBlob.mockRejectedValue(Object.assign(new Error('not found'), { name: 'NotFoundError' }))
     expect(await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-missing')).toBeNull()
   })
 
@@ -108,6 +108,14 @@ describe('getPhotoThumb', () => {
     await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
     const [, , opts] = storage.getDirectoryHandle.mock.calls[0]
     expect(opts).toEqual({ create: false })
+  })
+
+  it('PROPAGATES non-NotFoundError errors (degraded storage must surface, not silently → null)', async () => {
+    const denied = Object.assign(new Error('permission'), { name: 'SecurityError' })
+    storage.getPhotoBlob.mockRejectedValue(denied)
+    await expect(
+      getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-x'),
+    ).rejects.toBe(denied)
   })
 })
 
@@ -123,7 +131,7 @@ describe('deletePhotoThumb', () => {
   })
 
   it('is idempotent: missing thumbs subdir is NOT an error', async () => {
-    storage.getDirectoryHandle.mockRejectedValue(new Error('NotFoundError'))
+    storage.getDirectoryHandle.mockRejectedValue(Object.assign(new Error('not found'), { name: 'NotFoundError' }))
     await expect(
       deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc'),
     ).resolves.toBeUndefined()
@@ -131,7 +139,7 @@ describe('deletePhotoThumb', () => {
   })
 
   it('is idempotent: missing thumb file is NOT an error', async () => {
-    storage.deletePhotoFile.mockRejectedValue(new Error('NotFoundError'))
+    storage.deletePhotoFile.mockRejectedValue(Object.assign(new Error('not found'), { name: 'NotFoundError' }))
     await expect(
       deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-missing'),
     ).resolves.toBeUndefined()
@@ -141,6 +149,14 @@ describe('deletePhotoThumb', () => {
     await deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
     const [, , opts] = storage.getDirectoryHandle.mock.calls[0]
     expect(opts).toEqual({ create: false })
+  })
+
+  it('PROPAGATES non-NotFoundError errors on delete (quota / permission must not look idempotent)', async () => {
+    const quota = Object.assign(new Error('quota'), { name: 'QuotaExceededError' })
+    storage.deletePhotoFile.mockRejectedValue(quota)
+    await expect(
+      deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-x'),
+    ).rejects.toBe(quota)
   })
 })
 
@@ -157,11 +173,11 @@ describe('round-trip', () => {
       }),
       getPhotoBlob: vi.fn(async (_dir: DirectoryHandle, name: string) => {
         const file = fakeFs.get(name)
-        if (!file) throw new Error('NotFoundError')
+        if (!file) throw Object.assign(new Error('not found'), { name: 'NotFoundError' })
         return file
       }),
       deletePhotoFile: vi.fn(async (_dir: DirectoryHandle, name: string) => {
-        if (!fakeFs.delete(name)) throw new Error('NotFoundError')
+        if (!fakeFs.delete(name)) throw Object.assign(new Error('not found'), { name: 'NotFoundError' })
       }),
     } as unknown as StorageInterface
 

--- a/frontend/map-corridors/src/__tests__/photoThumbs.test.ts
+++ b/frontend/map-corridors/src/__tests__/photoThumbs.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Mock } from 'vitest'
+import {
+  savePhotoThumb,
+  getPhotoThumb,
+  deletePhotoThumb,
+  type StorageInterface,
+  type DirectoryHandle,
+} from '@airq/shared-storage'
+
+// Phase 2 of photo-map-culling (docs/photo-map-culling/implementation-plan.md).
+// The thumb helpers are pure wrappers — they delegate to existing
+// StorageInterface primitives, so testing them with a faked interface
+// proves the behaviour for BOTH OPFS and Electron backends in one place.
+
+const photosDir: DirectoryHandle = { path: '/sessions/comp-1/photos' }
+const thumbsDir: DirectoryHandle = { path: '/sessions/comp-1/photos/thumbs' }
+
+interface FakeStorage extends Pick<StorageInterface,
+  'getDirectoryHandle' | 'savePhotoFile' | 'getPhotoBlob' | 'deletePhotoFile'> {
+  getDirectoryHandle: Mock
+  savePhotoFile: Mock
+  getPhotoBlob: Mock
+  deletePhotoFile: Mock
+}
+
+function fakeStorage(): FakeStorage {
+  return {
+    getDirectoryHandle: vi.fn().mockResolvedValue(thumbsDir),
+    savePhotoFile: vi.fn().mockResolvedValue(undefined),
+    getPhotoBlob: vi.fn(),
+    deletePhotoFile: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('savePhotoThumb', () => {
+  let storage: FakeStorage
+
+  beforeEach(() => { storage = fakeStorage() })
+
+  it('creates the thumbs/ subdirectory on first save', async () => {
+    const blob = new Blob([new Uint8Array(64)], { type: 'image/jpeg' })
+    await savePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc', blob)
+    expect(storage.getDirectoryHandle).toHaveBeenCalledWith(photosDir, 'thumbs', { create: true })
+  })
+
+  it('writes the blob as {photoId}.jpg', async () => {
+    const blob = new Blob([new Uint8Array(64)], { type: 'image/jpeg' })
+    await savePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc', blob)
+    expect(storage.savePhotoFile).toHaveBeenCalledTimes(1)
+    const [actualDir, actualName, actualFile] = storage.savePhotoFile.mock.calls[0]
+    expect(actualDir).toBe(thumbsDir)
+    expect(actualName).toBe('pm-abc.jpg')
+    expect(actualFile).toBeInstanceOf(File)
+    expect(actualFile.name).toBe('pm-abc.jpg')
+  })
+
+  it('forwards the blob MIME type onto the File wrapper', async () => {
+    const blob = new Blob([new Uint8Array(64)], { type: 'image/png' })
+    await savePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc', blob)
+    const file = storage.savePhotoFile.mock.calls[0][2] as File
+    expect(file.type).toBe('image/png')
+  })
+
+  it('defaults to image/jpeg when the blob has no type', async () => {
+    const blob = new Blob([new Uint8Array(64)])
+    await savePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc', blob)
+    const file = storage.savePhotoFile.mock.calls[0][2] as File
+    expect(file.type).toBe('image/jpeg')
+  })
+
+  it('propagates errors from savePhotoFile (caller should know writes failed)', async () => {
+    storage.savePhotoFile.mockRejectedValue(new Error('disk full'))
+    const blob = new Blob([new Uint8Array(64)], { type: 'image/jpeg' })
+    await expect(
+      savePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc', blob),
+    ).rejects.toThrow('disk full')
+  })
+})
+
+describe('getPhotoThumb', () => {
+  let storage: FakeStorage
+
+  beforeEach(() => { storage = fakeStorage() })
+
+  it('returns the blob when the thumb exists', async () => {
+    const stored = new Blob([new Uint8Array(64)], { type: 'image/jpeg' })
+    storage.getPhotoBlob.mockResolvedValue(stored)
+    const result = await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
+    expect(result).toBe(stored)
+    expect(storage.getDirectoryHandle).toHaveBeenCalledWith(photosDir, 'thumbs', { create: false })
+    expect(storage.getPhotoBlob).toHaveBeenCalledWith(thumbsDir, 'pm-abc.jpg')
+  })
+
+  it('returns null when the thumbs subdirectory does not exist yet', async () => {
+    storage.getDirectoryHandle.mockRejectedValue(new Error('NotFoundError'))
+    expect(await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')).toBeNull()
+    expect(storage.getPhotoBlob).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the thumbs subdir exists but the file is missing', async () => {
+    storage.getPhotoBlob.mockRejectedValue(new Error('NotFoundError'))
+    expect(await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-missing')).toBeNull()
+  })
+
+  it('never auto-creates the thumbs subdir on read (avoid unintended side effects)', async () => {
+    storage.getPhotoBlob.mockResolvedValue(new Blob([]))
+    await getPhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
+    const [, , opts] = storage.getDirectoryHandle.mock.calls[0]
+    expect(opts).toEqual({ create: false })
+  })
+})
+
+describe('deletePhotoThumb', () => {
+  let storage: FakeStorage
+
+  beforeEach(() => { storage = fakeStorage() })
+
+  it('deletes the {photoId}.jpg file in thumbs/', async () => {
+    await deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
+    expect(storage.getDirectoryHandle).toHaveBeenCalledWith(photosDir, 'thumbs', { create: false })
+    expect(storage.deletePhotoFile).toHaveBeenCalledWith(thumbsDir, 'pm-abc.jpg')
+  })
+
+  it('is idempotent: missing thumbs subdir is NOT an error', async () => {
+    storage.getDirectoryHandle.mockRejectedValue(new Error('NotFoundError'))
+    await expect(
+      deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc'),
+    ).resolves.toBeUndefined()
+    expect(storage.deletePhotoFile).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: missing thumb file is NOT an error', async () => {
+    storage.deletePhotoFile.mockRejectedValue(new Error('NotFoundError'))
+    await expect(
+      deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-missing'),
+    ).resolves.toBeUndefined()
+  })
+
+  it('never auto-creates the thumbs subdir on delete', async () => {
+    await deletePhotoThumb(storage as unknown as StorageInterface, photosDir, 'pm-abc')
+    const [, , opts] = storage.getDirectoryHandle.mock.calls[0]
+    expect(opts).toEqual({ create: false })
+  })
+})
+
+describe('round-trip', () => {
+  it('save then get returns the same blob bytes', async () => {
+    // Simulate a tiny in-memory backend: writes land in a Map, reads serve
+    // from it. This proves the helpers wire the same photoId to the same
+    // storage key across the pair.
+    const fakeFs = new Map<string, File>()
+    const storage = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(thumbsDir),
+      savePhotoFile: vi.fn(async (_dir: DirectoryHandle, name: string, file: File) => {
+        fakeFs.set(name, file)
+      }),
+      getPhotoBlob: vi.fn(async (_dir: DirectoryHandle, name: string) => {
+        const file = fakeFs.get(name)
+        if (!file) throw new Error('NotFoundError')
+        return file
+      }),
+      deletePhotoFile: vi.fn(async (_dir: DirectoryHandle, name: string) => {
+        if (!fakeFs.delete(name)) throw new Error('NotFoundError')
+      }),
+    } as unknown as StorageInterface
+
+    const original = new Blob([new Uint8Array([1, 2, 3, 4, 5])], { type: 'image/jpeg' })
+    await savePhotoThumb(storage, photosDir, 'pm-rt', original)
+
+    const fetched = await getPhotoThumb(storage, photosDir, 'pm-rt')
+    expect(fetched).not.toBeNull()
+    expect(await fetched!.arrayBuffer()).toEqual(await original.arrayBuffer())
+
+    await deletePhotoThumb(storage, photosDir, 'pm-rt')
+    expect(await getPhotoThumb(storage, photosDir, 'pm-rt')).toBeNull()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/sessionMigration.test.ts
+++ b/frontend/map-corridors/src/__tests__/sessionMigration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { resolveMapStyleIdFromPersisted } from '../hooks/useCorridorSessionOPFS'
+import { resolveMapStyleIdFromPersisted, resolveNoGpsTrayOpen } from '../hooks/useCorridorSessionOPFS'
 
 /**
  * Session migration is the one piece of code in PR #42 that can permanently
@@ -72,5 +72,52 @@ describe('resolveMapStyleIdFromPersisted', () => {
     // via onChange — validating strings here would lose user preference.
     expect(resolveMapStyleIdFromPersisted({ mapStyleId: 'some-future-style' }, DEFAULT_ID))
       .toBe('some-future-style')
+  })
+})
+
+/**
+ * Phase 0 of photo-map-culling adds `noGpsTrayOpen` to CorridorsSession.
+ * Pre-feature sessions don't have the field — they must migrate cleanly to
+ * the default (open) without console warnings (US-9 acceptance: "Reload
+ * after a force-quit recovers cleanly").
+ */
+describe('resolveNoGpsTrayOpen', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns persisted true', () => {
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: true }, true)).toBe(true)
+  })
+
+  it('returns persisted false (user collapsed the tray)', () => {
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: false }, true)).toBe(false)
+  })
+
+  it('v1 migration: missing field → default, no warning', () => {
+    expect(resolveNoGpsTrayOpen({}, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen({ otherField: 'irrelevant' }, true)).toBe(true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns default for null/undefined/non-object record', () => {
+    expect(resolveNoGpsTrayOpen(null, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen(undefined, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen('not an object', true)).toBe(true)
+    expect(resolveNoGpsTrayOpen(42, false)).toBe(false)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('warns and falls back on non-boolean noGpsTrayOpen (corrupted session)', () => {
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: 'yes' }, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: 1 }, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: null }, true)).toBe(true)
+    expect(resolveNoGpsTrayOpen({ noGpsTrayOpen: {} }, false)).toBe(false)
+    expect(warnSpy).toHaveBeenCalled()
   })
 })

--- a/frontend/map-corridors/src/__tests__/useEditorPicksSync.test.ts
+++ b/frontend/map-corridors/src/__tests__/useEditorPicksSync.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Mock } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { syncEditorPicksOnce } from '../hooks/useEditorPicksSync'
+import type { PhotoMarker } from '../types/markers'
+
+const competitionDir: DirectoryHandle = { path: '/competitions/c-1' }
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', ...over } as PhotoMarker
+}
+
+interface FakeStorage { readJSON: Mock }
+function fakeStorage(): FakeStorage {
+  return { readJSON: vi.fn() }
+}
+
+function recordingSetMarkers() {
+  const calls: PhotoMarker[][] = []
+  let current: PhotoMarker[] = []
+  const setMarkers = vi.fn(async (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => {
+    current = [...updater(current)]
+    calls.push(current)
+  })
+  return {
+    setMarkers,
+    seed(markers: PhotoMarker[]) { current = [...markers] },
+    last(): readonly PhotoMarker[] { return current },
+    calls,
+  }
+}
+
+describe('syncEditorPicksOnce — file presence', () => {
+  it('no-op when file is absent', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue(null)
+    const session = recordingSetMarkers()
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+    expect(session.setMarkers).not.toHaveBeenCalled()
+  })
+
+  it('no-op when picks[] is missing/malformed', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({ version: 1, updatedAt: 'x' })
+    const session = recordingSetMarkers()
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+  })
+})
+
+describe('syncEditorPicksOnce — conflict resolution', () => {
+  it('applies remote label when remote is newer than local', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-1', label: 'A', labelUpdatedAt: '2024-02-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1', label: 'B', labelUpdatedAt: '2024-01-01T00:00:00Z' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(1)
+    const updated = session.last().find(m => m.id === 'pm-1')!
+    expect(updated.label).toBe('A')
+    expect(updated.labelUpdatedAt).toBe('2024-02-01T00:00:00Z')
+  })
+
+  it('keeps local label when local is newer (tie-break in-flight protection)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-1', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1', label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+    expect(session.last()[0].label).toBe('B')
+  })
+
+  it('equal timestamps → local wins (deterministic tie-break)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-1', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1', label: 'B', labelUpdatedAt: '2024-01-01T00:00:00Z' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+    expect(session.last()[0].label).toBe('B')
+  })
+
+  it('applies remote when local has no labelUpdatedAt (legacy data)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-1', label: 'C', labelUpdatedAt: '2024-01-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1', label: 'A' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(1)
+    expect(session.last()[0].label).toBe('C')
+  })
+
+  it('clears local label when remote is empty AND newer', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-1', label: '', labelUpdatedAt: '2024-02-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' })])
+    await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    const updated = session.last()[0]
+    expect(updated.label).toBeUndefined()
+    expect(updated.labelUpdatedAt).toBe('2024-02-01T00:00:00Z')
+  })
+})
+
+describe('syncEditorPicksOnce — never inserts', () => {
+  it('ignores remote entry for a photoId not present in local markers', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'pm-unknown', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+    expect(session.last().map(m => m.id)).toEqual(['pm-1'])
+  })
+
+  it('ignores non-pm- prefixed entries (editor-only photos)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1, updatedAt: 'x',
+      picks: [{ photoId: 'photo-helper-own', label: 'Z', labelUpdatedAt: '2024-02-01T00:00:00Z' }],
+    })
+    const session = recordingSetMarkers()
+    session.seed([pm({ id: 'pm-1', photoId: 'pm-1' })])
+    const result = await syncEditorPicksOnce(storage as unknown as StorageInterface, competitionDir, session.setMarkers)
+    expect(result.updates).toBe(0)
+  })
+})

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -15,6 +15,19 @@ import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 /** Drag type the map drop handler watches for. Public — MapProviderView imports this. */
 export const NO_GPS_PHOTO_DRAG_TYPE = 'application/x-airq-no-gps-photo'
 
+/**
+ * Sort comparator for no-GPS tray entries. EXIF timestamp ASC; entries
+ * without a timestamp sort to the end via the `'￿'` sentinel, then
+ * tie-break alphabetically by filename. Exported for unit testing — a
+ * typo flipping the order would otherwise ship silently.
+ */
+export function compareNoGpsPhotos(a: NoGpsPhoto, b: NoGpsPhoto): number {
+  const ta = a.timestamp ?? '￿'
+  const tb = b.timestamp ?? '￿'
+  if (ta !== tb) return ta < tb ? -1 : 1
+  return a.filename.localeCompare(b.filename)
+}
+
 const TRAY_HEIGHT_PX = 116        // 80px thumb + chrome, under the 120px ADR-012 cap
 const THUMB_WIDTH_PX = 96         // 4:3 thumbs in horizontal scroll
 const THUMB_HEIGHT_PX = 72
@@ -32,18 +45,7 @@ export function NoGpsTray(props: NoGpsTrayProps) {
   const { t } = useI18n()
   const { photos, open, onToggleOpen, storage, photosDir } = props
 
-  // Sort by EXIF timestamp ASC; entries without a timestamp settle at the
-  // end (assigned a max sort key), tie-broken alphabetically by filename.
-  const sorted = useMemo(() => {
-    const copy = [...photos]
-    copy.sort((a, b) => {
-      const ta = a.timestamp ?? '￿'
-      const tb = b.timestamp ?? '￿'
-      if (ta !== tb) return ta < tb ? -1 : 1
-      return a.filename.localeCompare(b.filename)
-    })
-    return copy
-  }, [photos])
+  const sorted = useMemo(() => [...photos].sort(compareNoGpsPhotos), [photos])
 
   // Auto-hide when nothing to show. Phase 6 acceptance: "Tray empty → collapses".
   // We hide entirely (vs. show empty chrome) — simpler, no chevron-with-nothing.

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -113,6 +113,8 @@ function NoGpsTrayThumb(props: {
     <Tooltip title={`${photo.filename} — ${dragHint}`} placement="top" enterDelay={300}>
       <Box
         draggable
+        role="img"
+        aria-label={`${photo.filename}. ${dragHint}.`}
         onDragStart={(e: React.DragEvent) => {
           e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
           e.dataTransfer.effectAllowed = 'move'

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -1,0 +1,151 @@
+// Phase 6 of photo-map-culling — ADR-012.
+// Off-map tray pinned to the bottom-left of the map view. Holds imported
+// photos that lack EXIF GPS, sorted by capture time. Each thumbnail is
+// HTML5-draggable; drop onto the map places it as a `'pick'` PhotoMarker
+// at the drop coordinates.
+
+import { useMemo } from 'react'
+import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material'
+import { ExpandLess, ExpandMore } from '@mui/icons-material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { NoGpsPhoto } from '../types/markers'
+import { useI18n } from '../contexts/I18nContext'
+import { usePhotoThumbUrl } from './usePhotoThumbUrl'
+
+/** Drag type the map drop handler watches for. Public — MapProviderView imports this. */
+export const NO_GPS_PHOTO_DRAG_TYPE = 'application/x-airq-no-gps-photo'
+
+const TRAY_HEIGHT_PX = 116        // 80px thumb + chrome, under the 120px ADR-012 cap
+const THUMB_WIDTH_PX = 96         // 4:3 thumbs in horizontal scroll
+const THUMB_HEIGHT_PX = 72
+const MAX_TRAY_WIDTH_VW = 20      // ADR-012 — never exceeds 20% of map width
+
+export interface NoGpsTrayProps {
+  photos: readonly NoGpsPhoto[]
+  open: boolean
+  onToggleOpen: () => void
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+}
+
+export function NoGpsTray(props: NoGpsTrayProps) {
+  const { t } = useI18n()
+  const { photos, open, onToggleOpen, storage, photosDir } = props
+
+  // Sort by EXIF timestamp ASC; entries without a timestamp settle at the
+  // end (assigned a max sort key), tie-broken alphabetically by filename.
+  const sorted = useMemo(() => {
+    const copy = [...photos]
+    copy.sort((a, b) => {
+      const ta = a.timestamp ?? '￿'
+      const tb = b.timestamp ?? '￿'
+      if (ta !== tb) return ta < tb ? -1 : 1
+      return a.filename.localeCompare(b.filename)
+    })
+    return copy
+  }, [photos])
+
+  // Auto-hide when nothing to show. Phase 6 acceptance: "Tray empty → collapses".
+  // We hide entirely (vs. show empty chrome) — simpler, no chevron-with-nothing.
+  if (sorted.length === 0) return null
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        position: 'absolute',
+        bottom: 12,
+        left: 12,
+        zIndex: 25,
+        maxWidth: `${MAX_TRAY_WIDTH_VW}vw`,
+        bgcolor: 'rgba(255,255,255,0.96)',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 1, py: 0.5, gap: 0.5 }}>
+        <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', flex: 1 }}>
+          {t('photo.tray.title', { count: sorted.length })}
+        </Typography>
+        <Tooltip title={open ? t('photo.tray.collapse') : t('photo.tray.expand')}>
+          <IconButton size="small" onClick={onToggleOpen} aria-label={open ? t('photo.tray.collapse') : t('photo.tray.expand')}>
+            {open ? <ExpandMore fontSize="small" /> : <ExpandLess fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+      {open && (
+        <Box
+          sx={{
+            height: TRAY_HEIGHT_PX - 32, // minus header chrome
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            display: 'flex',
+            gap: 1,
+            px: 1,
+            pb: 1,
+          }}
+        >
+          {sorted.map(p => (
+            <NoGpsTrayThumb
+              key={p.photoId}
+              photo={p}
+              storage={storage}
+              photosDir={photosDir}
+              dragHint={t('photo.tray.dragHint')}
+            />
+          ))}
+        </Box>
+      )}
+    </Paper>
+  )
+}
+
+function NoGpsTrayThumb(props: {
+  photo: NoGpsPhoto
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  dragHint: string
+}) {
+  const { photo, storage, photosDir, dragHint } = props
+  const { url, state } = usePhotoThumbUrl(storage, photosDir, photo.photoId)
+
+  return (
+    <Tooltip title={`${photo.filename} — ${dragHint}`} placement="top" enterDelay={300}>
+      <Box
+        draggable
+        onDragStart={(e: React.DragEvent) => {
+          e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
+          e.dataTransfer.effectAllowed = 'move'
+        }}
+        sx={{
+          width: THUMB_WIDTH_PX,
+          height: THUMB_HEIGHT_PX,
+          flexShrink: 0,
+          bgcolor: 'grey.100',
+          borderRadius: 0.5,
+          overflow: 'hidden',
+          cursor: 'grab',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          '&:active': { cursor: 'grabbing' },
+          '&:hover': { boxShadow: 1 },
+        }}
+      >
+        {state === 'ready' && url && (
+          <img
+            src={url}
+            alt={photo.filename}
+            draggable={false}
+            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', pointerEvents: 'none' }}
+          />
+        )}
+        {state !== 'ready' && (
+          <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10, px: 0.5, textAlign: 'center' }}>
+            {photo.filename}
+          </Typography>
+        )}
+      </Box>
+    </Tooltip>
+  )
+}

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -1,0 +1,228 @@
+// Phase 7 of photo-map-culling — right-side photo list panel.
+// Lists all imported photos grouped by flag. Click an item to fly the
+// map to its marker. Auto-hides when there are no photos.
+
+import { useMemo, useState } from 'react'
+import {
+  Badge,
+  Box,
+  Collapse,
+  IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { ChevronLeft, ChevronRight, ExpandLess, ExpandMore } from '@mui/icons-material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+import { useI18n } from '../contexts/I18nContext'
+import { usePhotoThumbUrl } from './usePhotoThumbUrl'
+import { groupPhotosByFlag } from './groupPhotosByFlag'
+
+const THUMB_W_PX = 40
+const THUMB_H_PX = 30
+
+export interface PhotoListPanelProps {
+  markers: readonly PhotoMarker[]
+  noGpsPhotos: readonly NoGpsPhoto[]
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  /** Called when the user clicks an item whose photo has a placed marker. */
+  onMarkerClick: (markerId: string) => void
+}
+
+type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
+
+const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps']
+
+export function PhotoListPanel(props: PhotoListPanelProps) {
+  const { t } = useI18n()
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick } = props
+  const [collapsedPanel, setCollapsedPanel] = useState(false)
+  const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
+    picks: false,
+    neutral: false,
+    rejects: true, // default-collapsed — usually fewer items the user revisits less often
+    noGps: false,
+  })
+
+  const groups = useMemo(() => groupPhotosByFlag(markers, noGpsPhotos), [markers, noGpsPhotos])
+  if (groups.total === 0) return null
+
+  const toggleGroup = (key: GroupKey) => {
+    setCollapsedGroups(prev => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  return (
+    <Paper
+      elevation={4}
+      sx={{
+        position: 'absolute',
+        top: 12,
+        right: 12,
+        bottom: 12,
+        zIndex: 25,
+        width: collapsedPanel ? 40 : 280,
+        maxWidth: '24vw',
+        bgcolor: 'rgba(255,255,255,0.97)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        transition: 'width 150ms ease',
+      }}
+    >
+      <Stack
+        direction="row"
+        alignItems="center"
+        spacing={0.5}
+        sx={{ px: collapsedPanel ? 0.5 : 1, py: 0.5, borderBottom: '1px solid', borderColor: 'divider' }}
+      >
+        <Tooltip title={collapsedPanel ? t('photo.list.expand') : t('photo.list.collapse')}>
+          <IconButton size="small" onClick={() => setCollapsedPanel(p => !p)} aria-label={collapsedPanel ? t('photo.list.expand') : t('photo.list.collapse')}>
+            {collapsedPanel ? <ChevronLeft fontSize="small" /> : <ChevronRight fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+        {!collapsedPanel && (
+          <>
+            <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', flex: 1 }}>
+              {t('photo.list.title')}
+            </Typography>
+            <Badge badgeContent={groups.total} color="primary" sx={{ '& .MuiBadge-badge': { position: 'static', transform: 'none' } }} />
+          </>
+        )}
+      </Stack>
+      {!collapsedPanel && (
+        <Box sx={{ flex: 1, overflowY: 'auto' }}>
+          {GROUP_ORDER.map(key => (
+            <GroupSection
+              key={key}
+              groupKey={key}
+              title={t(`photo.list.${key}`)}
+              count={groupCount(groups, key)}
+              collapsed={collapsedGroups[key]}
+              onToggle={() => toggleGroup(key)}
+              items={renderGroupItems(groups, key, { storage, photosDir, onMarkerClick })}
+            />
+          ))}
+        </Box>
+      )}
+    </Paper>
+  )
+}
+
+function groupCount(g: ReturnType<typeof groupPhotosByFlag>, key: GroupKey): number {
+  return g[key].length
+}
+
+function GroupSection(props: {
+  groupKey: GroupKey
+  title: string
+  count: number
+  collapsed: boolean
+  onToggle: () => void
+  items: React.ReactNode
+}) {
+  const { title, count, collapsed, onToggle, items } = props
+  return (
+    <Box>
+      <ListItemButton
+        onClick={onToggle}
+        sx={{ py: 0.5, bgcolor: 'grey.50' }}
+        aria-expanded={!collapsed}
+      >
+        <ListItemText
+          primaryTypographyProps={{ variant: 'body2', sx: { fontWeight: 600 } }}
+          primary={`${title} (${count})`}
+        />
+        {collapsed ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+      </ListItemButton>
+      <Collapse in={!collapsed}>
+        {count === 0 ? null : <List dense disablePadding>{items}</List>}
+      </Collapse>
+    </Box>
+  )
+}
+
+function renderGroupItems(
+  g: ReturnType<typeof groupPhotosByFlag>,
+  key: GroupKey,
+  ctx: {
+    storage: StorageInterface | null
+    photosDir: DirectoryHandle | null
+    onMarkerClick: (markerId: string) => void
+  },
+): React.ReactNode {
+  if (key === 'noGps') {
+    return g.noGps.map(p => (
+      <PhotoListItem
+        key={p.photoId}
+        photoId={p.photoId}
+        filename={p.filename}
+        storage={ctx.storage}
+        photosDir={ctx.photosDir}
+        // No marker yet — clicking is a no-op for v1. User drags from tray.
+        onClick={undefined}
+      />
+    ))
+  }
+  const list = g[key]
+  return list.map(m => (
+    <PhotoListItem
+      key={m.id}
+      photoId={m.photoId!}
+      filename={m.name}
+      storage={ctx.storage}
+      photosDir={ctx.photosDir}
+      onClick={() => ctx.onMarkerClick(m.id)}
+    />
+  ))
+}
+
+function PhotoListItem(props: {
+  photoId: string
+  filename: string
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  onClick: (() => void) | undefined
+}) {
+  const { photoId, filename, storage, photosDir, onClick } = props
+  const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
+  return (
+    <ListItemButton
+      onClick={onClick}
+      disabled={!onClick}
+      sx={{ py: 0.5, gap: 1 }}
+    >
+      <Box
+        sx={{
+          width: THUMB_W_PX,
+          height: THUMB_H_PX,
+          flexShrink: 0,
+          bgcolor: 'grey.100',
+          borderRadius: 0.5,
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {state === 'ready' && url && (
+          <img
+            src={url}
+            alt={filename}
+            draggable={false}
+            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+          />
+        )}
+      </Box>
+      <ListItemText
+        primary={filename}
+        primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
+      />
+    </ListItemButton>
+  )
+}

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from 'react'
 import {
   Badge,
   Box,
+  Button,
   Collapse,
   IconButton,
   List,
@@ -16,7 +17,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { ChevronLeft, ChevronRight, ExpandLess, ExpandMore } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
@@ -33,6 +34,13 @@ export interface PhotoListPanelProps {
   photosDir: DirectoryHandle | null
   /** Called when the user clicks an item whose photo has a placed marker. */
   onMarkerClick: (markerId: string) => void
+  /**
+   * Phase 9 — click handler for the "Send to editor" footer button.
+   * Undefined hides the button entirely (e.g., no active competition).
+   * The handler is expected to flush any pending map-picks write before
+   * navigating, per ADR-009.
+   */
+  onSendToEditor?: () => void | Promise<void>
 }
 
 type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
@@ -41,7 +49,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -108,6 +116,20 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               items={renderGroupItems(groups, key, { storage, photosDir, onMarkerClick })}
             />
           ))}
+        </Box>
+      )}
+      {!collapsedPanel && onSendToEditor && (
+        <Box sx={{ p: 1, borderTop: '1px solid', borderColor: 'divider' }}>
+          <Button
+            fullWidth
+            variant="contained"
+            size="small"
+            startIcon={<SendOutlined fontSize="small" />}
+            disabled={groups.picks.length === 0}
+            onClick={() => { void onSendToEditor() }}
+          >
+            {t('photo.list.sendToEditor', { count: groups.picks.length })}
+          </Button>
         </Box>
       )}
     </Paper>

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -1,0 +1,109 @@
+// Phase 5 of photo-map-culling: the popup shown when the user clicks a
+// capture dot (or, in Phase 7, when they pick an entry from the photo
+// list panel). Loads its own thumbnail via storage.getPhotoThumb — keeps
+// MapProviderView ignorant of storage.
+
+import { useEffect, useState } from 'react'
+import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { useI18n } from '../contexts/I18nContext'
+
+export interface PhotoMarkerPopupProps {
+  photoId: string
+  filename: string
+  /** ISO 8601 capture timestamp; rendered as-is. Empty/undefined hides the row. */
+  timestamp?: string
+  storage: StorageInterface
+  photosDir: DirectoryHandle
+  onInclude: () => void
+  onSkip: () => void
+  onReject: () => void
+}
+
+const THUMB_WIDTH_PX = 200
+const THUMB_HEIGHT_PX = 150
+
+export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
+  const { t } = useI18n()
+  const { photoId, filename, timestamp, storage, photosDir } = props
+  const [thumbUrl, setThumbUrl] = useState<string | null>(null)
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'missing'>('loading')
+
+  useEffect(() => {
+    let cancelled = false
+    let urlToRevoke: string | null = null
+    setLoadState('loading')
+    setThumbUrl(null)
+    void (async () => {
+      try {
+        const blob = await storage.getPhotoThumb(photosDir, photoId)
+        if (cancelled) return
+        if (!blob) {
+          setLoadState('missing')
+          return
+        }
+        const url = URL.createObjectURL(blob)
+        urlToRevoke = url
+        setThumbUrl(url)
+        setLoadState('ready')
+      } catch {
+        if (!cancelled) setLoadState('missing')
+      }
+    })()
+    return () => {
+      cancelled = true
+      if (urlToRevoke) URL.revokeObjectURL(urlToRevoke)
+    }
+  }, [photoId, photosDir, storage])
+
+  return (
+    <Box sx={{ minWidth: THUMB_WIDTH_PX + 16 }}>
+      <Box
+        sx={{
+          width: THUMB_WIDTH_PX,
+          height: THUMB_HEIGHT_PX,
+          bgcolor: 'grey.100',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          borderRadius: 1,
+          mb: 1,
+        }}
+      >
+        {loadState === 'loading' && <CircularProgress size={24} />}
+        {loadState === 'ready' && thumbUrl && (
+          <img
+            src={thumbUrl}
+            alt={filename}
+            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+          />
+        )}
+        {loadState === 'missing' && (
+          <Typography variant="caption" color="text.secondary">
+            {t('photo.popup.thumbMissing')}
+          </Typography>
+        )}
+      </Box>
+      <Typography variant="body2" sx={{ fontWeight: 600, wordBreak: 'break-all' }}>
+        {filename}
+      </Typography>
+      {timestamp && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+          {timestamp}
+        </Typography>
+      )}
+      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+        <Button size="small" variant="contained" onClick={props.onInclude}>
+          {t('photo.popup.include')}
+        </Button>
+        <Button size="small" variant="outlined" onClick={props.onSkip}>
+          {t('photo.popup.skip')}
+        </Button>
+        <Button size="small" variant="outlined" color="error" onClick={props.onReject}>
+          {t('photo.popup.reject')}
+        </Button>
+      </Stack>
+    </Box>
+  )
+}

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -7,6 +7,8 @@ import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
+import type { PhotoLabel } from '../types/markers'
+import { ALL_PHOTO_LABELS } from '../types/markers'
 
 export interface PhotoMarkerPopupProps {
   photoId: string
@@ -15,6 +17,15 @@ export interface PhotoMarkerPopupProps {
   timestamp?: string
   storage: StorageInterface
   photosDir: DirectoryHandle
+  // Label state — the popup is the single place to assign / clear the
+  // answer-sheet label on a photo marker (mirrors the KML popup pattern).
+  // Without this, picks have no path to a label and never appear in the
+  // answer sheet, breaking the locate → select → score flow.
+  label?: PhotoLabel
+  availableLabels?: readonly PhotoLabel[]
+  usedLabels?: readonly string[]
+  onLabelChange?: (label: PhotoLabel) => void
+  onLabelClear?: () => void
   onInclude: () => void
   onSkip: () => void
   onReject: () => void
@@ -76,6 +87,47 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
           {t('photo.popup.reject')}
         </Button>
       </Stack>
+      {props.onLabelChange && (
+        <Box sx={{ mt: 1.5 }}>
+          <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mb: 0.5 }}>
+            {t('photo.popup.label')}
+          </Typography>
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(10, 1fr)', gap: 0.5 }}>
+            {(props.availableLabels ?? ALL_PHOTO_LABELS).map((L) => {
+              const used = (props.usedLabels ?? []).includes(L)
+              const isCurrent = props.label === L
+              const disabled = used && !isCurrent
+              return (
+                <button
+                  key={L}
+                  type="button"
+                  onClick={() => {
+                    if (disabled) return
+                    if (isCurrent) {
+                      props.onLabelClear?.()
+                    } else {
+                      props.onLabelChange?.(L)
+                    }
+                  }}
+                  disabled={disabled}
+                  title={disabled ? t('photo.popup.labelUsed') : `${t('photo.popup.labelSet')} ${L}`}
+                  style={{
+                    padding: '2px 0',
+                    borderRadius: 4,
+                    border: '1px solid #cbd5e1',
+                    background: isCurrent ? '#facc15' : '#ffffff',
+                    color: isCurrent ? '#111827' : (disabled ? '#9ca3af' : '#111827'),
+                    cursor: disabled ? 'not-allowed' : 'pointer',
+                    fontWeight: 600,
+                    fontSize: 12,
+                    minWidth: 0,
+                  }}
+                >{L}</button>
+              )
+            })}
+          </Box>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -3,10 +3,10 @@
 // list panel). Loads its own thumbnail via storage.getPhotoThumb — keeps
 // MapProviderView ignorant of storage.
 
-import { useEffect, useState } from 'react'
 import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { useI18n } from '../contexts/I18nContext'
+import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 
 export interface PhotoMarkerPopupProps {
   photoId: string
@@ -26,35 +26,7 @@ const THUMB_HEIGHT_PX = 150
 export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   const { t } = useI18n()
   const { photoId, filename, timestamp, storage, photosDir } = props
-  const [thumbUrl, setThumbUrl] = useState<string | null>(null)
-  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'missing'>('loading')
-
-  useEffect(() => {
-    let cancelled = false
-    let urlToRevoke: string | null = null
-    setLoadState('loading')
-    setThumbUrl(null)
-    void (async () => {
-      try {
-        const blob = await storage.getPhotoThumb(photosDir, photoId)
-        if (cancelled) return
-        if (!blob) {
-          setLoadState('missing')
-          return
-        }
-        const url = URL.createObjectURL(blob)
-        urlToRevoke = url
-        setThumbUrl(url)
-        setLoadState('ready')
-      } catch {
-        if (!cancelled) setLoadState('missing')
-      }
-    })()
-    return () => {
-      cancelled = true
-      if (urlToRevoke) URL.revokeObjectURL(urlToRevoke)
-    }
-  }, [photoId, photosDir, storage])
+  const { url: thumbUrl, state: loadState } = usePhotoThumbUrl(storage, photosDir, photoId)
 
   return (
     <Box sx={{ minWidth: THUMB_WIDTH_PX + 16 }}>

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -34,6 +34,32 @@ export interface PhotoMarkerPopupProps {
 const THUMB_WIDTH_PX = 200
 const THUMB_HEIGHT_PX = 150
 
+/**
+ * Derive a label button's UX state from current/used/this-letter inputs.
+ *
+ * Rules (referenced by the picker click handler and the visual style):
+ *  - `disabled`: the letter is already used elsewhere AND this is not
+ *    the marker's current letter. Re-clicking the SAME letter must stay
+ *    enabled so the user can clear it.
+ *  - `intent`: 'clear' when clicking the current letter, 'set' when
+ *    clicking any other enabled letter.
+ *
+ * Exported for unit testing — a regression flipping the comparison
+ * (`isCurrent` vs `!isCurrent`) would otherwise silently disable the
+ * clear path and ship undetected.
+ */
+export function labelButtonState(input: {
+  thisLabel: string
+  currentLabel: string | undefined
+  usedLabels: readonly string[]
+}): { disabled: boolean; isCurrent: boolean; intent: 'set' | 'clear' | 'noop' } {
+  const isCurrent = input.currentLabel === input.thisLabel
+  const used = input.usedLabels.includes(input.thisLabel)
+  const disabled = used && !isCurrent
+  if (disabled) return { disabled: true, isCurrent, intent: 'noop' }
+  return { disabled: false, isCurrent, intent: isCurrent ? 'clear' : 'set' }
+}
+
 export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   const { t } = useI18n()
   const { photoId, filename, timestamp, storage, photosDir } = props
@@ -94,30 +120,32 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
           </Typography>
           <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(10, 1fr)', gap: 0.5 }}>
             {(props.availableLabels ?? ALL_PHOTO_LABELS).map((L) => {
-              const used = (props.usedLabels ?? []).includes(L)
-              const isCurrent = props.label === L
-              const disabled = used && !isCurrent
+              const state = labelButtonState({
+                thisLabel: L,
+                currentLabel: props.label,
+                usedLabels: props.usedLabels ?? [],
+              })
               return (
                 <button
                   key={L}
                   type="button"
                   onClick={() => {
-                    if (disabled) return
-                    if (isCurrent) {
+                    if (state.intent === 'noop') return
+                    if (state.intent === 'clear') {
                       props.onLabelClear?.()
                     } else {
                       props.onLabelChange?.(L)
                     }
                   }}
-                  disabled={disabled}
-                  title={disabled ? t('photo.popup.labelUsed') : `${t('photo.popup.labelSet')} ${L}`}
+                  disabled={state.disabled}
+                  title={state.disabled ? t('photo.popup.labelUsed') : `${t('photo.popup.labelSet')} ${L}`}
                   style={{
                     padding: '2px 0',
                     borderRadius: 4,
                     border: '1px solid #cbd5e1',
-                    background: isCurrent ? '#facc15' : '#ffffff',
-                    color: isCurrent ? '#111827' : (disabled ? '#9ca3af' : '#111827'),
-                    cursor: disabled ? 'not-allowed' : 'pointer',
+                    background: state.isCurrent ? '#facc15' : '#ffffff',
+                    color: state.isCurrent ? '#111827' : (state.disabled ? '#9ca3af' : '#111827'),
+                    cursor: state.disabled ? 'not-allowed' : 'pointer',
                     fontWeight: 600,
                     fontSize: 12,
                     minWidth: 0,

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -1,0 +1,45 @@
+// Phase 7 of photo-map-culling — grouping helper for the right-side panel.
+// Pure function so the component itself stays thin and the grouping logic
+// is testable without mounting React.
+
+import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+
+export interface GroupedPhotos {
+  /** Photo markers with `flag === 'pick'`. Includes label-less picks. */
+  picks: readonly PhotoMarker[]
+  /** Photo markers with no flag and no label. */
+  neutral: readonly PhotoMarker[]
+  /** Photo markers with `flag === 'reject'`. */
+  rejects: readonly PhotoMarker[]
+  /** Photos imported without GPS that haven't been placed yet (live in NoGpsTray). */
+  noGps: readonly NoGpsPhoto[]
+  /** Total count across all four groups — useful for the empty-panel test. */
+  total: number
+}
+
+/**
+ * Partition the in-memory photo set into the four flag groups the right-
+ * side panel shows. Excludes non-photo markers (KML/click-placed) by the
+ * `photoId` filter — they don't belong on the photo list.
+ */
+export function groupPhotosByFlag(
+  markers: readonly PhotoMarker[],
+  noGpsPhotos: readonly NoGpsPhoto[],
+): GroupedPhotos {
+  const picks: PhotoMarker[] = []
+  const neutral: PhotoMarker[] = []
+  const rejects: PhotoMarker[] = []
+  for (const m of markers) {
+    if (!m.photoId) continue // KML markers don't belong in the photo list
+    if (m.flag === 'pick') picks.push(m)
+    else if (m.flag === 'reject') rejects.push(m)
+    else neutral.push(m)
+  }
+  return {
+    picks,
+    neutral,
+    rejects,
+    noGps: noGpsPhotos,
+    total: picks.length + neutral.length + rejects.length + noGpsPhotos.length,
+  }
+}

--- a/frontend/map-corridors/src/components/usePhotoThumbUrl.ts
+++ b/frontend/map-corridors/src/components/usePhotoThumbUrl.ts
@@ -21,9 +21,12 @@ export function usePhotoThumbUrl(
   const [url, setUrl] = useState<string | null>(null)
   const [state, setState] = useState<ThumbState>('loading')
 
+  // Loader effect: resolves a blob URL and pushes it into React state.
+  // Intentionally does NOT revoke on cleanup — the revocation lives in
+  // the [url]-keyed effect below, so React-state and the live blob URL
+  // can never disagree (StrictMode dev double-invocation included).
   useEffect(() => {
     let cancelled = false
-    let urlToRevoke: string | null = null
     if (!storage || !photosDir) {
       setUrl(null)
       setState('missing')
@@ -40,18 +43,29 @@ export function usePhotoThumbUrl(
           return
         }
         const next = URL.createObjectURL(blob)
-        urlToRevoke = next
         setUrl(next)
         setState('ready')
-      } catch {
-        if (!cancelled) setState('missing')
+      } catch (err) {
+        // Log unexpected failures so a degraded storage state surfaces
+        // somewhere instead of silently rendering "missing" everywhere
+        // (e.g. permission revoked, OPFS InvalidStateError).
+        if (!cancelled) {
+          console.warn('[usePhotoThumbUrl] thumb load failed:', err)
+          setState('missing')
+        }
       }
     })()
-    return () => {
-      cancelled = true
-      if (urlToRevoke) URL.revokeObjectURL(urlToRevoke)
-    }
+    return () => { cancelled = true }
   }, [storage, photosDir, photoId])
+
+  // Revocation effect: revokes the previous URL whenever React state
+  // moves to a new one (or the component unmounts). Tying revocation to
+  // the URL state — not to the loader effect's cleanup — guarantees we
+  // never revoke a URL that is still rendered.
+  useEffect(() => {
+    if (!url) return
+    return () => { URL.revokeObjectURL(url) }
+  }, [url])
 
   return { url, state }
 }

--- a/frontend/map-corridors/src/components/usePhotoThumbUrl.ts
+++ b/frontend/map-corridors/src/components/usePhotoThumbUrl.ts
@@ -1,0 +1,57 @@
+// Shared thumbnail loader for photo-map-culling UI surfaces (popup, tray,
+// list panel). Owns the URL.createObjectURL lifecycle — revokes on unmount
+// and on every reload to avoid leaking blob URLs across rapid mounts (e.g.,
+// the user scrubbing through the tray's horizontal scroll).
+
+import { useEffect, useState } from 'react'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+
+export type ThumbState = 'loading' | 'ready' | 'missing'
+
+export interface UsePhotoThumbUrlResult {
+  url: string | null
+  state: ThumbState
+}
+
+export function usePhotoThumbUrl(
+  storage: StorageInterface | null,
+  photosDir: DirectoryHandle | null,
+  photoId: string,
+): UsePhotoThumbUrlResult {
+  const [url, setUrl] = useState<string | null>(null)
+  const [state, setState] = useState<ThumbState>('loading')
+
+  useEffect(() => {
+    let cancelled = false
+    let urlToRevoke: string | null = null
+    if (!storage || !photosDir) {
+      setUrl(null)
+      setState('missing')
+      return
+    }
+    setUrl(null)
+    setState('loading')
+    void (async () => {
+      try {
+        const blob = await storage.getPhotoThumb(photosDir, photoId)
+        if (cancelled) return
+        if (!blob) {
+          setState('missing')
+          return
+        }
+        const next = URL.createObjectURL(blob)
+        urlToRevoke = next
+        setUrl(next)
+        setState('ready')
+      } catch {
+        if (!cancelled) setState('missing')
+      }
+    })()
+    return () => {
+      cancelled = true
+      if (urlToRevoke) URL.revokeObjectURL(urlToRevoke)
+    }
+  }, [storage, photosDir, photoId])
+
+  return { url, state }
+}

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -92,8 +92,9 @@ export function buildMapPicks(markers: readonly PhotoMarker[]): MapPickEntry[] {
 }
 
 // Module-level scheduler state. Per spec there's exactly one writer in
-// the app (map-corridors). Different (storage, dir) pairs would be a
-// programming error — guarded with a console.warn if it happens.
+// the app (map-corridors). When the (storage, dir) pair changes mid-debounce
+// (competition switch), the pending write is flushed FIRST so its bytes
+// land in the correct directory before scheduling against the new one.
 type PendingState = {
   timer: ReturnType<typeof setTimeout>
   storage: StorageInterface
@@ -101,12 +102,16 @@ type PendingState = {
   picks: MapPickEntry[]
 }
 let pending: PendingState | null = null
+// Serializes writes so two debounce flushes can't interleave and produce
+// a torn JSON. The chain swallows errors from prior writes (`.catch`)
+// before continuing — each call's caller still sees its OWN write's
+// rejection via the returned `currentPromise` below.
 let inFlight: Promise<void> = Promise.resolve()
 
 /**
- * Run the actual storage write. Serialized — every write waits for the
- * previous one to settle so two debounce flushes can't interleave and
- * produce a torn JSON.
+ * Run the actual storage write. Returns a promise that resolves/rejects
+ * for THIS specific write — callers (`flushPendingMapPicks`) can await
+ * it to know whether THEIR bytes hit disk, independent of prior failures.
  */
 function executeWrite(
   storage: StorageInterface,
@@ -118,18 +123,24 @@ function executeWrite(
     updatedAt: new Date().toISOString(),
     picks,
   }
-  inFlight = inFlight.then(() =>
-    storage.writeJSON(dir, FILENAME, file).catch(err => {
-      console.error('[mapPicks] writeJSON failed:', err)
-    }),
-  )
-  return inFlight
+  // Schedule after any prior write settles (success OR failure — we don't
+  // want one failure to permanently break the queue), then return the
+  // per-call promise so the caller sees ITS own rejection.
+  const currentPromise = inFlight
+    .catch(() => undefined)
+    .then(() => storage.writeJSON(dir, FILENAME, file))
+  inFlight = currentPromise
+  return currentPromise
 }
 
 /**
  * Schedule a debounced write. Subsequent calls within 300ms replace
  * the pending data — the latest call wins. Useful for collapsing rapid
  * flag toggles into a single disk write.
+ *
+ * When the (storage, dir) pair differs from the pending one, the pending
+ * write is flushed immediately so its bytes land in the correct directory
+ * (covers the competition-switch race).
  */
 export function scheduleWriteMapPicks(
   storage: StorageInterface,
@@ -137,27 +148,42 @@ export function scheduleWriteMapPicks(
   picks: MapPickEntry[],
 ): void {
   if (pending) {
+    const dirChanged = pending.storage !== storage || pending.dir !== dir
     clearTimeout(pending.timer)
+    if (dirChanged) {
+      // Flush the pending write to its ORIGINAL dir before re-scheduling.
+      // Errors are swallowed here — there's no caller to surface them to
+      // and we must not block the new schedule.
+      const stale = pending
+      pending = null
+      void executeWrite(stale.storage, stale.dir, stale.picks).catch(err => {
+        console.error('[mapPicks] flush-on-dir-change failed:', err)
+      })
+    }
   }
   const timer = setTimeout(() => {
     const p = pending
     pending = null
     if (!p) return
-    void executeWrite(p.storage, p.dir, p.picks)
+    void executeWrite(p.storage, p.dir, p.picks).catch(err => {
+      console.error('[mapPicks] debounced writeJSON failed:', err)
+    })
   }, DEBOUNCE_MS)
   pending = { timer, storage, dir, picks }
 }
 
 /**
  * Cancel the debounce timer and execute the pending write immediately.
- * Returns a Promise resolving when the write has settled. Callers can
- * await it during explicit pre-nav flushes (Phase 9's "Send to editor"
- * button) — pagehide listeners fire and forget (best-effort).
+ * Returns a Promise resolving when the write has settled, OR rejecting
+ * if the underlying storage.writeJSON rejected — callers (Phase 9's
+ * "Send to editor" handler) MUST catch this so the user sees a snackbar
+ * before the nav, otherwise a quota/permission failure silently navigates
+ * the user to a stale handoff file.
  *
- * No-op if there's nothing pending.
+ * No-op (resolves) if there's nothing pending.
  */
 export function flushPendingMapPicks(): Promise<void> {
-  if (!pending) return inFlight
+  if (!pending) return Promise.resolve()
   const { timer, storage, dir, picks } = pending
   clearTimeout(timer)
   pending = null

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -1,0 +1,170 @@
+// Phase 8a of photo-map-culling — cross-app handoff writer.
+// See ADR-005 (one-way map-picks.json) + ADR-019 (upsert/delete) +
+// docs/photo-map-culling/implementation-plan.md Phase 8.
+//
+// Map-corridors writes its full picks snapshot to
+// `competitions/{compId}/map-picks.json`. Photo-helper reads it (Phase 8b,
+// not yet implemented) to project picks into its candidate tray.
+//
+// Single writer; rapid calls coalesce on a 300ms debounce. Pagehide /
+// pre-nav code paths call flushPendingMapPicks() to skip the wait.
+
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { PhotoLabel, PhotoMarker } from '../types/markers'
+
+const FILENAME = 'map-picks.json'
+const DEBOUNCE_MS = 300
+
+export interface MapPickEntry {
+  photoId: string
+  filename: string
+  // 'neutral' is materialized at write time (PhotoMarker stores flag only
+  // for 'pick'/'reject'; absent flag means neutral). Photo-helper reads
+  // the explicit value, simpler than branching on absence.
+  flag: 'pick' | 'neutral' | 'reject'
+  gps?: {
+    capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string }
+    subjectAt?: { lng: number; lat: number }
+  }
+  label?: PhotoLabel
+}
+
+export interface MapPicksFile {
+  version: 1
+  updatedAt: string
+  picks: MapPickEntry[]
+}
+
+/**
+ * Project a single PhotoMarker into a MapPickEntry. Pure helper —
+ * exported for unit testing. Returns null for non-photo markers
+ * (KML/click-placed have no photoId) so they don't leak into the
+ * handoff file.
+ */
+export function buildMapPickEntry(marker: PhotoMarker): MapPickEntry | null {
+  if (!marker.photoId) return null
+  const flag: MapPickEntry['flag'] = marker.flag ?? 'neutral'
+  const entry: MapPickEntry = {
+    photoId: marker.photoId,
+    filename: marker.name,
+    flag,
+  }
+  if (marker.label) entry.label = marker.label
+  // GPS — emit `capturedAt` for photos that had EXIF GPS; `subjectAt`
+  // only when the subject differs from the capture point (i.e., the
+  // user dragged the pin). Saves a few bytes and makes downstream
+  // diffs cleaner.
+  const gps: NonNullable<MapPickEntry['gps']> = {}
+  if (marker.capturedAt) {
+    const captured: NonNullable<NonNullable<MapPickEntry['gps']>['capturedAt']> = {
+      lng: marker.capturedAt.lng,
+      lat: marker.capturedAt.lat,
+    }
+    if (marker.capturedAt.altitude !== undefined) captured.altitude = marker.capturedAt.altitude
+    if (marker.capturedAt.timestamp) captured.timestamp = marker.capturedAt.timestamp
+    gps.capturedAt = captured
+  }
+  const subjectMoved = !marker.capturedAt ||
+    marker.lng !== marker.capturedAt.lng ||
+    marker.lat !== marker.capturedAt.lat
+  if (subjectMoved) {
+    gps.subjectAt = { lng: marker.lng, lat: marker.lat }
+  }
+  if (gps.capturedAt || gps.subjectAt) entry.gps = gps
+  return entry
+}
+
+/**
+ * Project an array of PhotoMarkers, skipping non-photo entries. Used by
+ * both App.tsx (scheduling writes) and tests.
+ */
+export function buildMapPicks(markers: readonly PhotoMarker[]): MapPickEntry[] {
+  const out: MapPickEntry[] = []
+  for (const m of markers) {
+    const entry = buildMapPickEntry(m)
+    if (entry) out.push(entry)
+  }
+  return out
+}
+
+// Module-level scheduler state. Per spec there's exactly one writer in
+// the app (map-corridors). Different (storage, dir) pairs would be a
+// programming error — guarded with a console.warn if it happens.
+type PendingState = {
+  timer: ReturnType<typeof setTimeout>
+  storage: StorageInterface
+  dir: DirectoryHandle
+  picks: MapPickEntry[]
+}
+let pending: PendingState | null = null
+let inFlight: Promise<void> = Promise.resolve()
+
+/**
+ * Run the actual storage write. Serialized — every write waits for the
+ * previous one to settle so two debounce flushes can't interleave and
+ * produce a torn JSON.
+ */
+function executeWrite(
+  storage: StorageInterface,
+  dir: DirectoryHandle,
+  picks: MapPickEntry[],
+): Promise<void> {
+  const file: MapPicksFile = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    picks,
+  }
+  inFlight = inFlight.then(() =>
+    storage.writeJSON(dir, FILENAME, file).catch(err => {
+      console.error('[mapPicks] writeJSON failed:', err)
+    }),
+  )
+  return inFlight
+}
+
+/**
+ * Schedule a debounced write. Subsequent calls within 300ms replace
+ * the pending data — the latest call wins. Useful for collapsing rapid
+ * flag toggles into a single disk write.
+ */
+export function scheduleWriteMapPicks(
+  storage: StorageInterface,
+  dir: DirectoryHandle,
+  picks: MapPickEntry[],
+): void {
+  if (pending) {
+    clearTimeout(pending.timer)
+  }
+  const timer = setTimeout(() => {
+    const p = pending
+    pending = null
+    if (!p) return
+    void executeWrite(p.storage, p.dir, p.picks)
+  }, DEBOUNCE_MS)
+  pending = { timer, storage, dir, picks }
+}
+
+/**
+ * Cancel the debounce timer and execute the pending write immediately.
+ * Returns a Promise resolving when the write has settled. Callers can
+ * await it during explicit pre-nav flushes (Phase 9's "Send to editor"
+ * button) — pagehide listeners fire and forget (best-effort).
+ *
+ * No-op if there's nothing pending.
+ */
+export function flushPendingMapPicks(): Promise<void> {
+  if (!pending) return inFlight
+  const { timer, storage, dir, picks } = pending
+  clearTimeout(timer)
+  pending = null
+  return executeWrite(storage, dir, picks)
+}
+
+/** Test-only — drains the module-level state between tests. */
+export function _resetMapPicksWriterForTests(): void {
+  if (pending) {
+    clearTimeout(pending.timer)
+    pending = null
+  }
+  inFlight = Promise.resolve()
+}

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -27,6 +27,9 @@ export interface MapPickEntry {
     subjectAt?: { lng: number; lat: number }
   }
   label?: PhotoLabel
+  // When label was last changed; drives bidirectional sync resolution.
+  // Absent if the marker never had a label set explicitly (legacy data).
+  labelUpdatedAt?: string
 }
 
 export interface MapPicksFile {
@@ -50,6 +53,7 @@ export function buildMapPickEntry(marker: PhotoMarker): MapPickEntry | null {
     flag,
   }
   if (marker.label) entry.label = marker.label
+  if (marker.labelUpdatedAt) entry.labelUpdatedAt = marker.labelUpdatedAt
   // GPS — emit `capturedAt` for photos that had EXIF GPS; `subjectAt`
   // only when the subject differs from the capture point (i.e., the
   // user dragged the pin). Saves a few bytes and makes downstream

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -144,6 +144,9 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   // target for imported photo bytes + thumbnails (see ADR-005 storage
   // layout: `competitions/{compId}/photos/`).
   const [photosDir, setPhotosDir] = useState<DirectoryHandle | null>(null)
+  // Parent of corridors/ and photos/. Where map-picks.json lands
+  // (Phase 8 cross-app handoff). Null in the legacy flat-session path.
+  const [competitionDir, setCompetitionDir] = useState<DirectoryHandle | null>(null)
 
   useEffect(() => {
     (async () => {
@@ -175,12 +178,14 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           corridorsDir = await storage.getDirectoryHandle(compDir, 'corridors', { create: true })
           const photos = await storage.getDirectoryHandle(compDir, 'photos', { create: true })
           setPhotosDir(photos)
+          setCompetitionDir(compDir)
         } else {
           // Legacy flat session
           id = loadOrCreateSessionId()
           const sessionsDir = await storage.getDirectoryHandle(handles.root, 'sessions', { create: true })
           corridorsDir = await storage.getDirectoryHandle(sessionsDir, id, { create: true })
           setPhotosDir(null)
+          setCompetitionDir(null)
         }
 
         sessionDirRef.current = corridorsDir
@@ -352,6 +357,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     backendAvailable: storageAvailable,
     storage: storageRef.current,
     photosDir,
+    competitionDir,
     // actions
     setMapStyleId,
     setDiscipline,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -132,6 +132,12 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
 
   const storageRef = useRef<StorageInterface | null>(null)
   const sessionDirRef = useRef<DirectoryHandle | null>(null)
+  // Photos directory for the active competition. Resolved alongside the
+  // corridors session dir during init when `competitionId` is provided —
+  // otherwise null. Phase 3 of photo-map-culling uses it as the write
+  // target for imported photo bytes + thumbnails (see ADR-005 storage
+  // layout: `competitions/{compId}/photos/`).
+  const [photosDir, setPhotosDir] = useState<DirectoryHandle | null>(null)
 
   useEffect(() => {
     (async () => {
@@ -156,16 +162,19 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
         let id: string
 
         if (competitionId) {
-          // Scope under competitions/{competitionId}/corridors/
+          // Scope under competitions/{competitionId}/{corridors,photos}/
           id = `corridors-${competitionId}`
           const competitionsDir = await storage.getDirectoryHandle(handles.root, 'competitions', { create: true })
           const compDir = await storage.getDirectoryHandle(competitionsDir, competitionId, { create: true })
           corridorsDir = await storage.getDirectoryHandle(compDir, 'corridors', { create: true })
+          const photos = await storage.getDirectoryHandle(compDir, 'photos', { create: true })
+          setPhotosDir(photos)
         } else {
           // Legacy flat session
           id = loadOrCreateSessionId()
           const sessionsDir = await storage.getDirectoryHandle(handles.root, 'sessions', { create: true })
           corridorsDir = await storage.getDirectoryHandle(sessionsDir, id, { create: true })
+          setPhotosDir(null)
         }
 
         sessionDirRef.current = corridorsDir
@@ -323,6 +332,8 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     sessionId,
     error,
     backendAvailable: storageAvailable,
+    storage: storageRef.current,
+    photosDir,
     // actions
     setMapStyleId,
     setDiscipline,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { GeoJSON } from 'geojson'
 import type { Discipline } from '../corridors/preciseCorridor'
-import type { PhotoMarker, GroundMarker } from '../types/markers'
-import { sanitizeGroundMarkers, sanitizePhotoMarkers } from '../types/markers'
+import type { NoGpsPhoto, PhotoMarker, GroundMarker } from '../types/markers'
+import { sanitizeGroundMarkers, sanitizeNoGpsPhotos, sanitizePhotoMarkers } from '../types/markers'
 import {
   initStorage,
   isStorageAvailable,
@@ -100,6 +100,11 @@ export type CorridorsSession = {
   // UI data
   markers: readonly PhotoMarker[]
   groundMarkers: readonly GroundMarker[]
+  // Photos imported without EXIF GPS (Phase 6 of photo-map-culling,
+  // ADR-012). Live here as candidate-pool entries until the user drags
+  // one onto the map; on drop, an entry is removed and a PhotoMarker
+  // is appended to `markers` with `flag: 'pick'` at the drop coord.
+  noGpsPhotos: readonly NoGpsPhoto[]
   // Persisted UI state for the no-GPS photo tray (ADR-012). `true` = open,
   // `false` = collapsed. Defaults open on first run + after migration.
   noGpsTrayOpen: boolean
@@ -121,6 +126,7 @@ const defaultSession = (id: string): CorridorsSession => ({
   exactPoints: null,
   markers: [],
   groundMarkers: [],
+  noGpsPhotos: [],
   noGpsTrayOpen: true,
 })
 
@@ -191,6 +197,8 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           const rawPm = asRec.markers
           const cleanGm = sanitizeGroundMarkers(rawGm)
           const cleanPm = sanitizePhotoMarkers(rawPm)
+          const rawNoGps = asRec.noGpsPhotos
+          const cleanNoGps = sanitizeNoGpsPhotos(rawNoGps)
           if (Array.isArray(rawGm) && cleanGm.length !== rawGm.length) {
             console.warn(`[session] Dropped ${rawGm.length - cleanGm.length} invalid ground marker(s) from persisted session`)
           } else if (rawGm !== undefined && !Array.isArray(rawGm)) {
@@ -213,6 +221,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
             discipline: (asRec.discipline as CorridorsSession['discipline']) || 'rally',
             markers: cleanPm,
             groundMarkers: cleanGm,
+            noGpsPhotos: cleanNoGps,
             noGpsTrayOpen,
           })
         } else {
@@ -282,6 +291,15 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     await persistSession(next)
   }, [session, persistSession])
 
+  // Setter for the no-GPS tray entries. Caller passes an updater (mirrors
+  // setMarkers) so atomic add/remove can read-modify-write in one shot
+  // without losing concurrent edits to siblings on the same session.
+  const setNoGpsPhotos = useCallback(async (updater: (prev: readonly NoGpsPhoto[]) => readonly NoGpsPhoto[]) => {
+    if (!session) return
+    const next: CorridorsSession = { ...session, noGpsPhotos: updater(session.noGpsPhotos || []), version: session.version + 1, updatedAt: new Date().toISOString() }
+    await persistSession(next)
+  }, [session, persistSession])
+
   const saveOriginalKmlText = useCallback(async (text: string | null) => {
     if (!session) return
     const storage = storageRef.current
@@ -340,6 +358,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     setUse1NmAfterSp,
     setMarkers,
     setGroundMarkers,
+    setNoGpsPhotos,
     setNoGpsTrayOpen,
     setComputedData,
     saveOriginalKmlText,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -138,6 +138,13 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
 
   const storageRef = useRef<StorageInterface | null>(null)
   const sessionDirRef = useRef<DirectoryHandle | null>(null)
+  // Mirror of `session` for stable setters. Closure-over-`session` would
+  // freeze the value seen by `setMarkers` etc. at the render where the
+  // setter was created, so a stale setter captured by a long-lived effect
+  // (e.g. visibilitychange in useEditorPicksSync) would overwrite the live
+  // session with the captured one and silently drop intermediate edits.
+  const sessionRef = useRef<CorridorsSession | null>(null)
+  useEffect(() => { sessionRef.current = session }, [session])
   // Photos directory for the active competition. Resolved alongside the
   // corridors session dir during init when `competitionId` is provided —
   // otherwise null. Phase 3 of photo-map-culling uses it as the write
@@ -169,6 +176,8 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
 
         let corridorsDir: DirectoryHandle
         let id: string
+        let resolvedPhotosDir: DirectoryHandle | null = null
+        let resolvedCompetitionDir: DirectoryHandle | null = null
 
         if (competitionId) {
           // Scope under competitions/{competitionId}/{corridors,photos}/
@@ -177,15 +186,13 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           const compDir = await storage.getDirectoryHandle(competitionsDir, competitionId, { create: true })
           corridorsDir = await storage.getDirectoryHandle(compDir, 'corridors', { create: true })
           const photos = await storage.getDirectoryHandle(compDir, 'photos', { create: true })
-          setPhotosDir(photos)
-          setCompetitionDir(compDir)
+          resolvedPhotosDir = photos
+          resolvedCompetitionDir = compDir
         } else {
           // Legacy flat session
           id = loadOrCreateSessionId()
           const sessionsDir = await storage.getDirectoryHandle(handles.root, 'sessions', { create: true })
           corridorsDir = await storage.getDirectoryHandle(sessionsDir, id, { create: true })
-          setPhotosDir(null)
-          setCompetitionDir(null)
         }
 
         sessionDirRef.current = corridorsDir
@@ -234,12 +241,21 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           await storage.writeJSON(corridorsDir, 'session.json', fresh)
           setSession(fresh)
         }
+        // Publish the per-competition dirs ONLY after the session is in
+        // place. Otherwise the App.tsx write effect (which gates on
+        // `competitionDir`) can fire with an empty `markers` array between
+        // dir-resolution and session-load, blanking map-picks.json on disk.
+        setPhotosDir(resolvedPhotosDir)
+        setCompetitionDir(resolvedCompetitionDir)
       } catch (e) {
         console.error('Failed to initialize corridors storage', e)
         setError('Failed to initialize storage')
         const id = competitionId ? `corridors-${competitionId}` : loadOrCreateSessionId()
         setSessionId(id)
         setSession(defaultSession(id))
+        // Leave photosDir/competitionDir at null — without working storage
+        // we don't want the handoff writer firing against partially-resolved
+        // handles. The user sees the error banner instead.
       }
     })()
   }, [competitionId])
@@ -258,55 +274,88 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     }
   }, [])
 
+  // All setters below read the live session from `sessionRef` rather than
+  // closing over `session`. This makes them stable across renders, which
+  // matters for long-lived effects that capture them (the bidirectional
+  // sync hooks fire on visibilitychange far after their mount-time
+  // closure was captured).
   const setMapStyleId = useCallback(async (mapStyleId: string) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, mapStyleId, version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, mapStyleId, version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   const setDiscipline = useCallback(async (discipline: Discipline) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, discipline, version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, discipline, version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   const setUse1NmAfterSp = useCallback(async (use1: boolean) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, use1NmAfterSp: use1, version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, use1NmAfterSp: use1, version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   // Updaters receive a readonly view so callers can't mutate in place (e.g. prev.push).
   // Returning the same reference (e.g. early-return `prev` on no-op) is also allowed.
   const setMarkers = useCallback(async (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, markers: updater(session.markers), version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, markers: updater(current.markers), version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   const setGroundMarkers = useCallback(async (updater: (prev: readonly GroundMarker[]) => readonly GroundMarker[]) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, groundMarkers: updater(session.groundMarkers || []), version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, groundMarkers: updater(current.groundMarkers || []), version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   const setNoGpsTrayOpen = useCallback(async (open: boolean) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, noGpsTrayOpen: open, version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, noGpsTrayOpen: open, version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
 
   // Setter for the no-GPS tray entries. Caller passes an updater (mirrors
   // setMarkers) so atomic add/remove can read-modify-write in one shot
   // without losing concurrent edits to siblings on the same session.
   const setNoGpsPhotos = useCallback(async (updater: (prev: readonly NoGpsPhoto[]) => readonly NoGpsPhoto[]) => {
-    if (!session) return
-    const next: CorridorsSession = { ...session, noGpsPhotos: updater(session.noGpsPhotos || []), version: session.version + 1, updatedAt: new Date().toISOString() }
-    await persistSession(next)
-  }, [session, persistSession])
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({ ...current, noGpsPhotos: updater(current.noGpsPhotos || []), version: current.version + 1, updatedAt: new Date().toISOString() })
+  }, [persistSession])
+
+  // Atomic placement of a no-GPS photo onto the map: in one persistSession
+  // call, append the new PhotoMarker AND remove the photo from noGpsPhotos.
+  // Replaces the previous two-await sequence which could leave the photo
+  // duplicated in both lists if the second write failed (quota, transient
+  // I/O). Returns true on success, false when the entry isn't found.
+  const placeNoGpsPhoto = useCallback(async (photoId: string, lng: number, lat: number): Promise<boolean> => {
+    const current = sessionRef.current
+    if (!current) return false
+    const entry = (current.noGpsPhotos || []).find(p => p.photoId === photoId)
+    if (!entry) return false
+    const marker: PhotoMarker = {
+      id: photoId,
+      photoId,
+      lng,
+      lat,
+      name: entry.filename,
+      flag: 'pick',
+    }
+    await persistSession({
+      ...current,
+      markers: [...current.markers, marker],
+      noGpsPhotos: (current.noGpsPhotos || []).filter(p => p.photoId !== photoId),
+      version: current.version + 1,
+      updatedAt: new Date().toISOString(),
+    })
+    return true
+  }, [persistSession])
 
   const saveOriginalKmlText = useCallback(async (text: string | null) => {
-    if (!session) return
+    if (!sessionRef.current) return
     const storage = storageRef.current
     const dir = sessionDirRef.current
     if (storage && dir) {
@@ -317,7 +366,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
         console.error('Failed to save original KML text', e)
       }
     }
-  }, [session])
+  }, [])
 
   const loadOriginalKmlText = useCallback(async (): Promise<string | null> => {
     const storage = storageRef.current
@@ -339,15 +388,15 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     points: GeoJSON | null
     exactPoints: GeoJSON | null
   }) => {
-    if (!session) return
-    const next: CorridorsSession = {
-      ...session,
+    const current = sessionRef.current
+    if (!current) return
+    await persistSession({
+      ...current,
       ...payload,
-      version: session.version + 1,
+      version: current.version + 1,
       updatedAt: new Date().toISOString(),
-    }
-    await persistSession(next)
-  }, [session, persistSession])
+    })
+  }, [persistSession])
 
   return {
     // state
@@ -366,6 +415,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     setGroundMarkers,
     setNoGpsPhotos,
     setNoGpsTrayOpen,
+    placeNoGpsPhoto,
     setComputedData,
     saveOriginalKmlText,
     loadOriginalKmlText,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -60,6 +60,22 @@ export function resolveMapStyleIdFromPersisted(record: unknown, defaultId: strin
   return defaultId
 }
 
+/**
+ * Resolve `noGpsTrayOpen` for a persisted session. Defaults to `true` for
+ * pre-feature sessions (no field present) so the no-GPS tray starts open
+ * after the user upgrades — they see the new feature surface immediately.
+ * Non-boolean values are logged and ignored. Exported for unit testing.
+ */
+export function resolveNoGpsTrayOpen(record: unknown, defaultValue: boolean): boolean {
+  const asRec = (record && typeof record === 'object') ? record as Record<string, unknown> : {}
+  const raw = asRec.noGpsTrayOpen
+  if (typeof raw === 'boolean') return raw
+  if (raw !== undefined) {
+    console.warn('[session] Persisted noGpsTrayOpen was not a boolean, resetting to default:', raw)
+  }
+  return defaultValue
+}
+
 export type CorridorsSession = {
   id: string
   version: number
@@ -84,6 +100,9 @@ export type CorridorsSession = {
   // UI data
   markers: readonly PhotoMarker[]
   groundMarkers: readonly GroundMarker[]
+  // Persisted UI state for the no-GPS photo tray (ADR-012). `true` = open,
+  // `false` = collapsed. Defaults open on first run + after migration.
+  noGpsTrayOpen: boolean
 }
 
 const defaultSession = (id: string): CorridorsSession => ({
@@ -102,6 +121,7 @@ const defaultSession = (id: string): CorridorsSession => ({
   exactPoints: null,
   markers: [],
   groundMarkers: [],
+  noGpsTrayOpen: true,
 })
 
 export function useCorridorSessionOPFS(competitionId?: string | null) {
@@ -176,6 +196,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
           // new `mapStyleId` field so users don't lose their current pick.
           // Logic extracted to `resolveMapStyleIdFromPersisted` for unit tests.
           const mapStyleId = resolveMapStyleIdFromPersisted(asRec, defaultSession(id).mapStyleId)
+          const noGpsTrayOpen = resolveNoGpsTrayOpen(asRec, defaultSession(id).noGpsTrayOpen)
           setSession({
             ...defaultSession(id),
             ...existing,
@@ -183,6 +204,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
             discipline: (asRec.discipline as CorridorsSession['discipline']) || 'rally',
             markers: cleanPm,
             groundMarkers: cleanGm,
+            noGpsTrayOpen,
           })
         } else {
           const fresh = defaultSession(id)
@@ -245,6 +267,12 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     await persistSession(next)
   }, [session, persistSession])
 
+  const setNoGpsTrayOpen = useCallback(async (open: boolean) => {
+    if (!session) return
+    const next: CorridorsSession = { ...session, noGpsTrayOpen: open, version: session.version + 1, updatedAt: new Date().toISOString() }
+    await persistSession(next)
+  }, [session, persistSession])
+
   const saveOriginalKmlText = useCallback(async (text: string | null) => {
     if (!session) return
     const storage = storageRef.current
@@ -301,6 +329,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     setUse1NmAfterSp,
     setMarkers,
     setGroundMarkers,
+    setNoGpsTrayOpen,
     setComputedData,
     saveOriginalKmlText,
     loadOriginalKmlText,

--- a/frontend/map-corridors/src/hooks/useEditorPicksSync.ts
+++ b/frontend/map-corridors/src/hooks/useEditorPicksSync.ts
@@ -73,14 +73,22 @@ export async function syncEditorPicksOnce(
 /**
  * React hook wrapper. Runs syncEditorPicksOnce when `competitionDir`
  * becomes available and on every `visibilitychange === 'visible'`.
- * `setMarkers` is intentionally NOT in the effect's dep array — it's a
- * setter from a session hook that re-creates each render, so including
- * it would re-fire the effect on every parent state change.
+ *
+ * `setMarkers` MUST be stable across renders — the session hook hands
+ * out stable setters (see `useCorridorSessionOPFS.setMarkers`, which
+ * reads `session` via a ref). Putting it in the dep array is now safe,
+ * which closes the prior stale-closure window where a visibility-change
+ * could overwrite the live session with a mount-time snapshot.
+ *
+ * `onError` is optional — surface sync failures (file read, JSON parse,
+ * setMarkers reject) to a UI toast instead of swallowing them. Called
+ * with the original error.
  */
 export function useEditorPicksSync(
   storage: StorageInterface | null,
   competitionDir: DirectoryHandle | null,
   setMarkers: (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => Promise<void> | void,
+  onError?: (err: unknown) => void,
 ): void {
   useEffect(() => {
     if (!storage || !competitionDir) return
@@ -90,7 +98,9 @@ export function useEditorPicksSync(
         if (cancelled) return
         await syncEditorPicksOnce(storage, competitionDir, setMarkers)
       } catch (err) {
-        if (!cancelled) console.warn('[useEditorPicksSync] failed:', err)
+        if (cancelled) return
+        console.warn('[useEditorPicksSync] failed:', err)
+        if (onError) onError(err)
       }
     }
     void run()
@@ -102,6 +112,5 @@ export function useEditorPicksSync(
       cancelled = true
       document.removeEventListener('visibilitychange', onVis)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storage, competitionDir])
+  }, [storage, competitionDir, setMarkers, onError])
 }

--- a/frontend/map-corridors/src/hooks/useEditorPicksSync.ts
+++ b/frontend/map-corridors/src/hooks/useEditorPicksSync.ts
@@ -1,0 +1,107 @@
+// Phase C of bidirectional label sync — map-corridors' reader for
+// the editor-side mirror file `photo-helper-picks.json`. Counterpart to
+// photo-helper's useMapPicksSync (which reads map-picks.json).
+//
+// On competition load + every `visibilitychange === 'visible'`, reads
+// the editor's outgoing labels and applies them to local PhotoMarker
+// state when the remote `labelUpdatedAt` is strictly newer than local.
+// Equal timestamps → local wins (deterministic tie-break that protects
+// in-flight edits on the map side).
+//
+// NEVER inserts markers — the editor file isn't a source of new photos.
+// Map-corridors is the authority for which photos exist; the editor
+// only annotates their labels.
+
+import { useEffect } from 'react'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { PhotoLabel, PhotoMarker } from '../types/markers'
+
+const FILENAME = 'photo-helper-picks.json'
+const PM_PREFIX = 'pm-'
+
+interface EditorPickEntry {
+  photoId: string
+  label: string
+  labelUpdatedAt: string
+}
+
+interface EditorPicksFile {
+  version: 1
+  updatedAt: string
+  picks: EditorPickEntry[]
+}
+
+/**
+ * Pure side-effect: read photo-helper-picks.json, apply newer-wins
+ * label updates to local markers. Exported for unit testing — the
+ * React hook below just runs it on the relevant trigger events.
+ *
+ * Returns the count of markers whose label was actually changed.
+ */
+export async function syncEditorPicksOnce(
+  storage: StorageInterface,
+  competitionDir: DirectoryHandle,
+  setMarkers: (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => Promise<void> | void,
+): Promise<{ updates: number }> {
+  const file = await storage.readJSON<EditorPicksFile>(competitionDir, FILENAME)
+  if (!file || !Array.isArray(file.picks)) return { updates: 0 }
+
+  const newer = new Map<string, EditorPickEntry>()
+  for (const entry of file.picks) {
+    if (!entry.photoId || !entry.photoId.startsWith(PM_PREFIX)) continue
+    if (!entry.labelUpdatedAt) continue
+    newer.set(entry.photoId, entry)
+  }
+  if (newer.size === 0) return { updates: 0 }
+
+  let updates = 0
+  await setMarkers(prev => prev.map(m => {
+    if (!m.photoId) return m
+    const entry = newer.get(m.photoId)
+    if (!entry) return m
+    const remoteIsNewer = !m.labelUpdatedAt || entry.labelUpdatedAt > m.labelUpdatedAt
+    if (!remoteIsNewer) return m
+    // Empty-string remote label means explicit clear.
+    const nextLabel = entry.label === '' ? undefined : entry.label as PhotoLabel
+    if (m.label === nextLabel && m.labelUpdatedAt === entry.labelUpdatedAt) return m
+    updates++
+    return { ...m, label: nextLabel, labelUpdatedAt: entry.labelUpdatedAt }
+  }))
+  return { updates }
+}
+
+/**
+ * React hook wrapper. Runs syncEditorPicksOnce when `competitionDir`
+ * becomes available and on every `visibilitychange === 'visible'`.
+ * `setMarkers` is intentionally NOT in the effect's dep array — it's a
+ * setter from a session hook that re-creates each render, so including
+ * it would re-fire the effect on every parent state change.
+ */
+export function useEditorPicksSync(
+  storage: StorageInterface | null,
+  competitionDir: DirectoryHandle | null,
+  setMarkers: (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => Promise<void> | void,
+): void {
+  useEffect(() => {
+    if (!storage || !competitionDir) return
+    let cancelled = false
+    const run = async () => {
+      try {
+        if (cancelled) return
+        await syncEditorPicksOnce(storage, competitionDir, setMarkers)
+      } catch (err) {
+        if (!cancelled) console.warn('[useEditorPicksSync] failed:', err)
+      }
+    }
+    void run()
+    const onVis = () => {
+      if (document.visibilityState === 'visible') void run()
+    }
+    document.addEventListener('visibilitychange', onVis)
+    return () => {
+      cancelled = true
+      document.removeEventListener('visibilitychange', onVis)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storage, competitionDir])
+}

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -46,6 +46,15 @@
       "dragHint": "Přetáhni na mapu pro umístění",
       "expand": "Zobrazit fotky bez GPS",
       "collapse": "Skrýt fotky bez GPS"
+    },
+    "list": {
+      "title": "Fotky",
+      "picks": "Vybrané",
+      "neutral": "Neutrální",
+      "rejects": "Odmítnuté",
+      "noGps": "Bez GPS",
+      "expand": "Zobrazit seznam fotek",
+      "collapse": "Skrýt seznam fotek"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -8,7 +8,7 @@
       "streets": "Mapa",
       "satellite": "Satelit"
     },
-    "dropHint": "Přetáhni KML pro načtení",
+    "dropHint": "Přetáhni KML nebo fotky",
     "answerSheet": "Zobrazit answer sheet",
     "dragToPlace": "Přetáhni pro umístění fotky",
     "use1NmAfterSp": "Koridor začíná 1 NM po SP",
@@ -19,6 +19,22 @@
     "printMap": "Tisk mapy",
     "dragToPlaceGround": "Přetáhni pro umístění znaku",
     "backToMenu": "Zpět do hlavního menu"
+  },
+  "photo": {
+    "import": {
+      "progress": "Importuji {{done}} z {{total}} fotek…",
+      "success": "Naimportováno {{count}} fotek",
+      "successOne": "Naimportována 1 fotka",
+      "partial": "Naimportováno {{ok}} z {{total}} — {{failed}} selhalo",
+      "failureHeic": "{{count}} fotek HEIC přeskočeno (nepodporováno)",
+      "failureHeicOne": "1 fotka HEIC přeskočena (nepodporováno)",
+      "failureCorrupt": "{{count}} fotek nelze přečíst",
+      "failureCorruptOne": "1 fotku nelze přečíst",
+      "failureStorage": "{{count}} fotek nelze uložit (úložiště)",
+      "failureStorageOne": "1 fotku nelze uložit (úložiště)",
+      "unsupported": "Nepodporovaný soubor: {{name}}",
+      "noCompetition": "Před importem fotek otevři soutěž z hlavního menu"
+    }
   },
   "groundPopup": {
     "type": "Typ znaku"

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -54,7 +54,8 @@
       "rejects": "Odmítnuté",
       "noGps": "Bez GPS",
       "expand": "Zobrazit seznam fotek",
-      "collapse": "Skrýt seznam fotek"
+      "collapse": "Skrýt seznam fotek",
+      "sendToEditor": "Poslat do editoru ({{count}})"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -40,6 +40,12 @@
       "skip": "Přeskočit",
       "reject": "Odmítnout",
       "thumbMissing": "Náhled není k dispozici"
+    },
+    "tray": {
+      "title": "Bez GPS ({{count}})",
+      "dragHint": "Přetáhni na mapu pro umístění",
+      "expand": "Zobrazit fotky bez GPS",
+      "collapse": "Skrýt fotky bez GPS"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -34,6 +34,12 @@
       "failureStorageOne": "1 fotku nelze uložit (úložiště)",
       "unsupported": "Nepodporovaný soubor: {{name}}",
       "noCompetition": "Před importem fotek otevři soutěž z hlavního menu"
+    },
+    "popup": {
+      "include": "Vybrat",
+      "skip": "Přeskočit",
+      "reject": "Odmítnout",
+      "thumbMissing": "Náhled není k dispozici"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -59,6 +59,10 @@
       "expand": "Zobrazit seznam fotek",
       "collapse": "Skrýt seznam fotek",
       "sendToEditor": "Poslat do editoru ({{count}})"
+    },
+    "handoff": {
+      "flushFailed": "Výběr se nepodařilo uložit před otevřením editoru. Zkontrolujte úložiště a zkuste to znovu.",
+      "editorSyncFailed": "Nepodařilo se použít nejnovější popisky z editoru."
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -39,7 +39,10 @@
       "include": "Vybrat",
       "skip": "Přeskočit",
       "reject": "Odmítnout",
-      "thumbMissing": "Náhled není k dispozici"
+      "thumbMissing": "Náhled není k dispozici",
+      "label": "Štítek",
+      "labelSet": "Přiřadit štítek",
+      "labelUsed": "Již použito"
     },
     "tray": {
       "title": "Bez GPS ({{count}})",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -40,6 +40,12 @@
       "skip": "Skip",
       "reject": "Reject",
       "thumbMissing": "Thumbnail unavailable"
+    },
+    "tray": {
+      "title": "No GPS ({{count}})",
+      "dragHint": "Drag onto the map to place",
+      "expand": "Show no-GPS photos",
+      "collapse": "Hide no-GPS photos"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -59,6 +59,10 @@
       "expand": "Show photo list",
       "collapse": "Hide photo list",
       "sendToEditor": "Send to editor ({{count}})"
+    },
+    "handoff": {
+      "flushFailed": "Couldn't save picks before opening the editor. Check storage and try again.",
+      "editorSyncFailed": "Couldn't apply latest labels from the editor."
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -34,6 +34,12 @@
       "failureStorageOne": "1 photo could not be saved (storage)",
       "unsupported": "Unsupported file: {{name}}",
       "noCompetition": "Open a competition from the launcher before importing photos"
+    },
+    "popup": {
+      "include": "Include",
+      "skip": "Skip",
+      "reject": "Reject",
+      "thumbMissing": "Thumbnail unavailable"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -8,7 +8,7 @@
       "streets": "Streets",
       "satellite": "Satellite"
     },
-    "dropHint": "Drop KML to load",
+    "dropHint": "Drop KML or photos",
     "answerSheet": "Show Answer Sheet",
     "dragToPlace": "Drag to place photo marker",
     "use1NmAfterSp": "Corridor 1 NM after start point",
@@ -19,6 +19,22 @@
     "printMap": "Print Map",
     "dragToPlaceGround": "Drag to place ground marker",
     "backToMenu": "Back to main menu"
+  },
+  "photo": {
+    "import": {
+      "progress": "Importing {{done}} of {{total}} photos…",
+      "success": "Imported {{count}} photos",
+      "successOne": "Imported 1 photo",
+      "partial": "Imported {{ok}} of {{total}} — {{failed}} failed",
+      "failureHeic": "{{count}} HEIC photos skipped (not supported)",
+      "failureHeicOne": "1 HEIC photo skipped (not supported)",
+      "failureCorrupt": "{{count}} photos could not be read",
+      "failureCorruptOne": "1 photo could not be read",
+      "failureStorage": "{{count}} photos could not be saved (storage)",
+      "failureStorageOne": "1 photo could not be saved (storage)",
+      "unsupported": "Unsupported file: {{name}}",
+      "noCompetition": "Open a competition from the launcher before importing photos"
+    }
   },
   "groundPopup": {
     "type": "Marker type"

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -46,6 +46,15 @@
       "dragHint": "Drag onto the map to place",
       "expand": "Show no-GPS photos",
       "collapse": "Hide no-GPS photos"
+    },
+    "list": {
+      "title": "Photos",
+      "picks": "Picks",
+      "neutral": "Neutral",
+      "rejects": "Rejects",
+      "noGps": "No GPS",
+      "expand": "Show photo list",
+      "collapse": "Hide photo list"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -39,7 +39,10 @@
       "include": "Include",
       "skip": "Skip",
       "reject": "Reject",
-      "thumbMissing": "Thumbnail unavailable"
+      "thumbMissing": "Thumbnail unavailable",
+      "label": "Label",
+      "labelSet": "Set label",
+      "labelUsed": "Already used"
     },
     "tray": {
       "title": "No GPS ({{count}})",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -54,7 +54,8 @@
       "rejects": "Rejects",
       "noGps": "No GPS",
       "expand": "Show photo list",
-      "collapse": "Hide photo list"
+      "collapse": "Hide photo list",
+      "sendToEditor": "Send to editor ({{count}})"
     }
   },
   "groundPopup": {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -852,8 +852,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const popupId = activePhotoMarkerId
         return (
           <Popup
-            longitude={marker.capturedAt.lng}
-            latitude={marker.capturedAt.lat}
+            longitude={marker.lng}
+            latitude={marker.lat}
             anchor="top"
             closeButton
             closeOnMove={false}

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -10,6 +10,8 @@ import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
+import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
 import {
   LIVE_GROUND_MARKER_ICON_PX,
@@ -67,6 +69,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   onMarkerLabelChange?: (id: string, label: PhotoLabel) => void
   onMarkerLabelClear?: (id: string) => void
   groundMarkerProps?: GroundMarkerCallbacks
+  // Phase 5 of photo-map-culling — popup wiring for capture dots.
+  // `storage` + `photosDir` let the popup load its thumbnail on demand.
+  // The three action callbacks mutate `marker.flag` in the parent.
+  // All five are optional so existing call sites (KML-only flows) don't
+  // have to touch them; absence simply means no photo popup is shown.
+  photoStorage?: StorageInterface | null
+  photoDir?: DirectoryHandle | null
+  onPhotoInclude?: (markerId: string) => void
+  onPhotoSkip?: (markerId: string) => void
+  onPhotoReject?: (markerId: string) => void
 }>(function MapProviderView(props, ref) {
   const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
 
@@ -75,6 +87,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   const mapRef = useRef<MapRef | null>(null)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
   const [confirmDeleteForId, setConfirmDeleteForId] = useState<string | null>(null)
+  // Phase 5: which photo marker has its popup open. Null = no photo popup.
+  const [activePhotoMarkerId, setActivePhotoMarkerId] = useState<string | null>(null)
   const dragStartLngLatRef = useRef<Map<string, { lng: number, lat: number }>>(new Map())
   const dragMovedPxRef = useRef<Map<string, number>>(new Map())
   // Attach native DnD listeners on the canvas to support custom marker drops
@@ -127,6 +141,42 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       canvas.removeEventListener('drop', onDrop)
     }
   }, [isMapLoaded, props.onMarkerAdd, props.groundMarkerProps])
+
+  // Phase 5 — click capture dot to open photo popup. Mapbox listeners
+  // need a string layer id matching CaptureDotsLayer's. Cursor changes
+  // on hover so users learn the dot is interactive.
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return
+    const map = mapRef.current.getMap()
+    const onClick = (e: { features?: Array<{ id?: string | number }> }) => {
+      const feature = e.features?.[0]
+      if (!feature) return
+      const id = feature.id
+      if (typeof id !== 'string') return
+      setActivePhotoMarkerId(id)
+    }
+    const onEnter = () => { map.getCanvas().style.cursor = 'pointer' }
+    const onLeave = () => { map.getCanvas().style.cursor = '' }
+    map.on('click', 'photo-capture-dots', onClick as never)
+    map.on('mouseenter', 'photo-capture-dots', onEnter)
+    map.on('mouseleave', 'photo-capture-dots', onLeave)
+    return () => {
+      map.off('click', 'photo-capture-dots', onClick as never)
+      map.off('mouseenter', 'photo-capture-dots', onEnter)
+      map.off('mouseleave', 'photo-capture-dots', onLeave)
+    }
+  }, [isMapLoaded])
+
+  // Close the photo popup if its marker disappears from the layer
+  // (e.g., user picked it via popup → marker promoted to subject pin →
+  // capture-dot layer filters it out; popup should follow).
+  useEffect(() => {
+    if (!activePhotoMarkerId) return
+    const stillCapture = props.markers?.some(m =>
+      m.id === activePhotoMarkerId && m.capturedAt && !m.label && m.flag !== 'pick'
+    )
+    if (!stillCapture) setActivePhotoMarkerId(null)
+  }, [props.markers, activePhotoMarkerId])
 
   const uploadedGeojson = useMemo(() => {
     return geojsonOverlays?.find((o) => o.id === 'uploaded-geojson')?.data
@@ -334,17 +384,18 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           ]}
         </Source>
       ))}
-      {/* Photo-import capture dots (Phase 4 of photo-map-culling).
-          Renders unlabelled photo markers (capturedAt present, no label
-          yet) as a flat GeoJSON layer instead of N <Marker> components —
-          keeps 100+ photo imports cheap. Labelled (picked) photo markers
-          fall through to the individual-<Marker> path below, where they
-          get the same draggable/clickable behaviour as KML markers. */}
+      {/* Photo-import capture dots (Phase 4 + 5 of photo-map-culling).
+          Renders neutral + rejected photo markers (capturedAt present,
+          no label, flag !== 'pick') as a flat GeoJSON layer instead of
+          N <Marker> components — keeps 100+ photo imports cheap. Click
+          on a dot opens the photo popup (Phase 5). Picked photos fall
+          through to the individual-<Marker> path so the user can drag
+          their subject pin. */}
       {props.markers && <CaptureDotsLayer markers={props.markers} />}
-      {/* Interactive markers — KML/click-placed AND labelled photo picks.
-          A photo marker that still has `capturedAt && !label` is filtered
-          out of this loop because it's already on the capture-dots layer. */}
-      {props.markers?.filter(m => !(m.capturedAt && !m.label)).map(m => (
+      {/* Interactive markers — KML/click-placed AND photo picks.
+          A neutral or rejected photo marker (capturedAt && !label &&
+          flag !== 'pick') is on the capture-dots layer; skip here. */}
+      {props.markers?.filter(m => !(m.capturedAt && !m.label && m.flag !== 'pick')).map(m => (
         <React.Fragment key={m.id}>
           <Marker
             longitude={m.lng}
@@ -683,6 +734,47 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           </React.Fragment>
         )
       })}
+      {/* Phase 5 photo-marker popup. Mounted only when a capture dot is
+          clicked AND the parent provides photo storage + handlers. */}
+      {(() => {
+        if (!activePhotoMarkerId) return null
+        if (!props.photoStorage || !props.photoDir) return null
+        if (!props.onPhotoInclude || !props.onPhotoSkip || !props.onPhotoReject) return null
+        const marker = props.markers?.find(m => m.id === activePhotoMarkerId)
+        if (!marker || !marker.capturedAt || !marker.photoId) return null
+        const popupId = activePhotoMarkerId
+        return (
+          <Popup
+            longitude={marker.capturedAt.lng}
+            latitude={marker.capturedAt.lat}
+            anchor="top"
+            closeButton
+            closeOnMove={false}
+            onClose={() => setActivePhotoMarkerId(null)}
+            maxWidth="240px"
+          >
+            <PhotoMarkerPopup
+              photoId={marker.photoId}
+              filename={marker.name}
+              timestamp={marker.capturedAt.timestamp}
+              storage={props.photoStorage}
+              photosDir={props.photoDir}
+              onInclude={() => {
+                props.onPhotoInclude?.(popupId)
+                setActivePhotoMarkerId(null)
+              }}
+              onSkip={() => {
+                props.onPhotoSkip?.(popupId)
+                setActivePhotoMarkerId(null)
+              }}
+              onReject={() => {
+                props.onPhotoReject?.(popupId)
+                setActivePhotoMarkerId(null)
+              }}
+            />
+          </Popup>
+        )
+      })()}
     </MapGL>
   )
 })

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -162,11 +162,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     }
   }, [isMapLoaded, props.onMarkerAdd, props.groundMarkerProps, props.onNoGpsPhotoPlaced])
 
-  // Phase 5 — click capture dot to open photo popup. Use react-map-gl's
-  // `interactiveLayerIds` + MapGL.onClick (below) instead of attaching
-  // listeners via map.on() in a useEffect — the latter races react-map-gl's
-  // own layer-lifecycle effects and the click silently drops.
-  const [mapCursor, setMapCursor] = useState<string>('')
+  // No MapGL.onClick / interactiveLayerIds needed in the
+  // "every-photo-is-a-Marker" model — clicks land directly on the
+  // <Marker> div, not on a GeoJSON layer feature.
 
   // Close the photo popup only when the marker disappears entirely
   // (deleted elsewhere). The Include/Skip/Reject handlers below call
@@ -368,23 +366,6 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       preserveDrawingBuffer
       initialViewState={{ longitude: 14.42076, latitude: 50.08804, zoom: 6 }}
       style={{ width: '100%', height: '100%' }}
-      cursor={mapCursor}
-      interactiveLayerIds={['photo-capture-dots']}
-      onMouseEnter={(e) => {
-        if (e.features?.some(f => f.layer?.id === 'photo-capture-dots')) setMapCursor('pointer')
-      }}
-      onMouseLeave={() => setMapCursor('')}
-      onClick={(e) => {
-        const hit = e.features?.find(f => f.layer?.id === 'photo-capture-dots')
-        if (!hit) return
-        // photoId is on properties (denormalized at projection time in
-        // captureFeatures.ts); use it to look up the marker by photoId
-        // rather than trusting feature.id round-tripping through Mapbox.
-        const photoId = hit.properties?.photoId as string | undefined
-        if (!photoId) return
-        const marker = props.markers?.find(m => m.photoId === photoId)
-        if (marker) setActivePhotoMarkerId(marker.id)
-      }}
       onLoad={() => setIsMapLoaded(true)}
       ref={mapRef}
     >
@@ -422,18 +403,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           ]}
         </Source>
       ))}
-      {/* Photo-import capture dots (Phase 4 + 5 of photo-map-culling).
-          Renders neutral + rejected photo markers (capturedAt present,
-          no label, flag !== 'pick') as a flat GeoJSON layer instead of
-          N <Marker> components — keeps 100+ photo imports cheap. Click
-          on a dot opens the photo popup (Phase 5). Picked photos fall
-          through to the individual-<Marker> path so the user can drag
-          their subject pin. */}
+      {/* Photo overlay layers: ghost dot at captured location + dashed
+          line back to the live subject pin. Both only emit features for
+          photos the user has dragged (capturedAt ≠ lng/lat). Unmoved
+          photos see only their live <Marker> pin. */}
       {props.markers && <CaptureDotsLayer markers={props.markers} />}
-      {/* Interactive markers — KML/click-placed AND photo picks.
-          A neutral or rejected photo marker (capturedAt && !label &&
-          flag !== 'pick') is on the capture-dots layer; skip here. */}
-      {props.markers?.filter(m => !(m.capturedAt && !m.label && m.flag !== 'pick')).map(m => (
+      {/* KML / click-placed markers — existing render path. Photo
+          markers (m.photoId !== undefined) are handled in the photo-
+          pin block below to keep the click + popup semantics distinct
+          (photo popup vs KML label picker). */}
+      {props.markers?.filter(m => !m.photoId).map(m => (
         <React.Fragment key={m.id}>
           <Marker
             longitude={m.lng}
@@ -638,6 +617,91 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           )}
         </React.Fragment>
       ))}
+      {/* Photo markers — every photo is draggable. Pin position is the
+          subject (m.lng/lat); fill is solid when the user has moved the
+          marker away from its EXIF capture spot (= processed), hollow
+          when still at the capture point (= awaiting placement).
+          Click → photo popup (Phase 5). Drag → onMarkerDragEnd updates
+          subject coords. The ghost dot + dashed line in
+          PhotoOverlayLayers render only for moved photos. */}
+      {props.markers?.filter(m => !!m.photoId).map(m => {
+        const moved = !!m.capturedAt && (m.lng !== m.capturedAt.lng || m.lat !== m.capturedAt.lat)
+        const flagColor = m.flag === 'pick' ? '#1976d2'
+          : m.flag === 'reject' ? '#d32f2f'
+          : '#616161'
+        const bg = moved ? flagColor : '#ffffff'
+        return (
+          <Marker
+            key={m.id}
+            longitude={m.lng}
+            latitude={m.lat}
+            draggable
+            onClick={(ev: MarkerEvent<MouseEvent>) => {
+              const movedPx = dragMovedPxRef.current.get(m.id) || 0
+              dragStartLngLatRef.current.delete(m.id)
+              dragMovedPxRef.current.delete(m.id)
+              if (movedPx < 8) {
+                ev.originalEvent?.stopPropagation?.()
+                setActivePhotoMarkerId(m.id)
+              }
+            }}
+            onDragStart={(ev: MarkerDragEvent) => {
+              const ll = ev.lngLat
+              dragStartLngLatRef.current.set(m.id, { lng: ll.lng, lat: ll.lat })
+              dragMovedPxRef.current.set(m.id, 0)
+            }}
+            onDrag={(ev: MarkerDragEvent) => {
+              const start = dragStartLngLatRef.current.get(m.id)
+              if (!start || !mapRef.current) return
+              const map = mapRef.current.getMap()
+              const p0 = map.project([start.lng, start.lat])
+              const p1 = map.project([ev.lngLat.lng, ev.lngLat.lat])
+              const dx = p1.x - p0.x
+              const dy = p1.y - p0.y
+              dragMovedPxRef.current.set(m.id, Math.sqrt(dx * dx + dy * dy))
+            }}
+            onDragEnd={(ev: MarkerDragEvent) => {
+              const movedPx = dragMovedPxRef.current.get(m.id) || 0
+              dragStartLngLatRef.current.delete(m.id)
+              dragMovedPxRef.current.delete(m.id)
+              if (movedPx < 8) {
+                // Treated as click — open photo popup without moving.
+                setActivePhotoMarkerId(m.id)
+              } else {
+                const ll = ev.lngLat
+                props.onMarkerDragEnd?.(m.id, ll.lng, ll.lat)
+                // Intentionally do NOT auto-open the photo popup after a
+                // real drag — the user has just placed the subject and
+                // doesn't need the popup interrupting their flow.
+              }
+            }}
+          >
+            <div style={{
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              background: bg,
+              border: `2px solid ${flagColor}`,
+              boxShadow: moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
+              cursor: 'pointer',
+            }} />
+            {m.label && (
+              <div style={{
+                position: 'absolute',
+                transform: 'translate(10px, -6px)',
+                background: 'rgba(255,255,255,0.85)',
+                borderRadius: 4,
+                padding: '1px 4px',
+                fontSize: 14,
+                lineHeight: '18px',
+                fontWeight: 600,
+                color: '#111',
+                border: '1px solid #e5e7eb',
+              }}>{m.label}</div>
+            )}
+          </Marker>
+        )
+      })}
       {/* Ground markers */}
       {props.groundMarkerProps?.groundMarkers.map(gm => {
         const gmp = props.groundMarkerProps!

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -32,6 +32,14 @@ type Overlay = {
 
 export type MapProviderViewHandle = {
   captureForPrint: () => Promise<PrintCaptureResult>
+  /**
+   * Phase 7 — fly the map to a photo marker's location. Uses subject
+   * coordinates for picks (`m.lng/lat`) and capture coordinates for
+   * neutral/reject (`m.capturedAt.lng/lat`) so the user lands on the
+   * dot they clicked in the side panel. No-op for unknown id or for
+   * markers without coordinates we can land on.
+   */
+  flyToPhotoMarker: (markerId: string) => void
 }
 
 export const MapProviderView = forwardRef<MapProviderViewHandle, {
@@ -299,7 +307,21 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         markers: printMarkers,
         groundMarkers: printGroundMarkers,
       })
-    }
+    },
+    flyToPhotoMarker(markerId: string) {
+      const marker = props.markers?.find(m => m.id === markerId)
+      if (!marker) return
+      const map = mapRef.current?.getMap()
+      if (!map) return
+      // Picks live at subject coords; neutral/reject live at capture
+      // coords. Both use lng/lat or capturedAt.lng/lat — subject is
+      // initialised to capturedAt on import (ADR-007), so for unmoved
+      // markers either works. Picks may have been dragged.
+      const center: [number, number] = marker.flag === 'pick'
+        ? [marker.lng, marker.lat]
+        : [marker.capturedAt?.lng ?? marker.lng, marker.capturedAt?.lat ?? marker.lat]
+      map.flyTo({ center, zoom: Math.max(map.getZoom(), 14), duration: 700 })
+    },
   }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken])
 
   if (needsToken) {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -626,10 +626,15 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           PhotoOverlayLayers render only for moved photos. */}
       {props.markers?.filter(m => !!m.photoId).map(m => {
         const moved = !!m.capturedAt && (m.lng !== m.capturedAt.lng || m.lat !== m.capturedAt.lat)
-        const flagColor = m.flag === 'pick' ? '#1976d2'
+        // Yellow = "labelled, answer-sheet ready" — matches the KML
+        // marker color so a user scanning the map sees one consistent
+        // visual for "this is going on the score sheet" regardless of
+        // origin. Unlabelled photos colour by flag.
+        const ringColor = m.label ? '#facc15'
+          : m.flag === 'pick' ? '#1976d2'
           : m.flag === 'reject' ? '#d32f2f'
           : '#616161'
-        const bg = moved ? flagColor : '#ffffff'
+        const bg = moved ? ringColor : '#ffffff'
         return (
           <Marker
             key={m.id}
@@ -681,7 +686,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               height: 14,
               borderRadius: '50%',
               background: bg,
-              border: `2px solid ${flagColor}`,
+              border: `2px solid ${ringColor}`,
               boxShadow: moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
               cursor: 'pointer',
             }} />
@@ -852,6 +857,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             anchor="top"
             closeButton
             closeOnMove={false}
+            // Default Mapbox Popup auto-closes on any map click, which
+            // races setActivePhotoMarkerId when the user clicks a
+            // different marker — net state ends up null and the popup
+            // appears stuck. closeOnClick=false lets the React state be
+            // the single source of truth for popup visibility.
+            closeOnClick={false}
             onClose={() => setActivePhotoMarkerId(null)}
             maxWidth="240px"
           >
@@ -861,9 +872,15 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               timestamp={marker.capturedAt.timestamp}
               storage={props.photoStorage}
               photosDir={props.photoDir}
+              label={marker.label}
+              availableLabels={props.availableLabels}
+              usedLabels={props.usedLabels}
+              onLabelChange={(L) => props.onMarkerLabelChange?.(popupId, L)}
+              onLabelClear={() => props.onMarkerLabelClear?.(popupId)}
               onInclude={() => {
                 props.onPhotoInclude?.(popupId)
-                setActivePhotoMarkerId(null)
+                // Keep the popup open after Include — user often wants
+                // to assign a label right after picking. Was: closed.
               }}
               onSkip={() => {
                 props.onPhotoSkip?.(popupId)

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -7,8 +7,9 @@ import 'mapbox-gl/dist/mapbox-gl.css'
 import { useI18n } from '../contexts/I18nContext'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
-import type { PhotoLabel, GroundMarkerCallbacks } from '../types/markers'
+import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
+import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
 import {
   LIVE_GROUND_MARKER_ICON_PX,
@@ -42,7 +43,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   /** Mapbox access token — required for `mapbox://` styles, optional otherwise. */
   mapboxAccessToken?: string
   geojsonOverlays?: Overlay[]
-  markers?: readonly { id: string; lng: number; lat: number; name: string; label?: PhotoLabel }[]
+  // Now `PhotoMarker[]` — the type gained optional `capturedAt`/`photoId`
+  // in Phase 0. Markers without `capturedAt` are KML/click-placed (today's
+  // behaviour); markers WITH `capturedAt` are EXIF-imported photos and
+  // render through the photo-layers path (CaptureDotsLayer for unlabelled,
+  // Phase 5 subject-pin for labelled).
+  markers?: readonly PhotoMarker[]
   activeMarkerId?: string | null
   usedLabels?: string[]
   /**
@@ -328,8 +334,17 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           ]}
         </Source>
       ))}
-      {/* Interactive markers */}
-      {props.markers?.map(m => (
+      {/* Photo-import capture dots (Phase 4 of photo-map-culling).
+          Renders unlabelled photo markers (capturedAt present, no label
+          yet) as a flat GeoJSON layer instead of N <Marker> components —
+          keeps 100+ photo imports cheap. Labelled (picked) photo markers
+          fall through to the individual-<Marker> path below, where they
+          get the same draggable/clickable behaviour as KML markers. */}
+      {props.markers && <CaptureDotsLayer markers={props.markers} />}
+      {/* Interactive markers — KML/click-placed AND labelled photo picks.
+          A photo marker that still has `capturedAt && !label` is filtered
+          out of this loop because it's already on the capture-dots layer. */}
+      {props.markers?.filter(m => !(m.capturedAt && !m.label)).map(m => (
         <React.Fragment key={m.id}>
           <Marker
             longitude={m.lng}

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -11,6 +11,7 @@ import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/ma
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
+import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
 import {
@@ -79,6 +80,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   onPhotoInclude?: (markerId: string) => void
   onPhotoSkip?: (markerId: string) => void
   onPhotoReject?: (markerId: string) => void
+  // Phase 6 — fires when a no-GPS thumbnail from NoGpsTray is dropped
+  // on the map. Receives the photoId and the unprojected drop coords.
+  onNoGpsPhotoPlaced?: (photoId: string, lng: number, lat: number) => void
 }>(function MapProviderView(props, ref) {
   const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
 
@@ -102,9 +106,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       const types = Array.from(dt.types)
       const wantsPhoto = types.includes('application/x-photo-marker') && !!props.onMarkerAdd
       const wantsGround = types.includes('application/x-ground-marker') && !!props.groundMarkerProps
-      if (wantsPhoto || wantsGround) {
+      const wantsNoGps = types.includes(NO_GPS_PHOTO_DRAG_TYPE) && !!props.onNoGpsPhotoPlaced
+      if (wantsPhoto || wantsGround || wantsNoGps) {
         e.preventDefault()
-        dt.dropEffect = 'copy'
+        dt.dropEffect = wantsNoGps ? 'move' : 'copy'
       }
     }
     const onDrop = (e: DragEvent) => {
@@ -132,6 +137,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         e.preventDefault()
         const lngLat = unprojectAt(e.clientX, e.clientY)
         props.groundMarkerProps.onGroundMarkerAdd(lngLat.lng, lngLat.lat)
+      } else if (types.includes(NO_GPS_PHOTO_DRAG_TYPE)) {
+        if (!props.onNoGpsPhotoPlaced) return
+        const photoId = dt.getData(NO_GPS_PHOTO_DRAG_TYPE)
+        if (!photoId) return
+        e.preventDefault()
+        const lngLat = unprojectAt(e.clientX, e.clientY)
+        props.onNoGpsPhotoPlaced(photoId, lngLat.lng, lngLat.lat)
       }
     }
     canvas.addEventListener('dragover', onDragOver)
@@ -140,7 +152,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       canvas.removeEventListener('dragover', onDragOver)
       canvas.removeEventListener('drop', onDrop)
     }
-  }, [isMapLoaded, props.onMarkerAdd, props.groundMarkerProps])
+  }, [isMapLoaded, props.onMarkerAdd, props.groundMarkerProps, props.onNoGpsPhotoPlaced])
 
   // Phase 5 — click capture dot to open photo popup. Mapbox listeners
   // need a string layer id matching CaptureDotsLayer's. Cursor changes

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -168,15 +168,15 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // own layer-lifecycle effects and the click silently drops.
   const [mapCursor, setMapCursor] = useState<string>('')
 
-  // Close the photo popup if its marker disappears from the layer
-  // (e.g., user picked it via popup → marker promoted to subject pin →
-  // capture-dot layer filters it out; popup should follow).
+  // Close the photo popup only when the marker disappears entirely
+  // (deleted elsewhere). The Include/Skip/Reject handlers below call
+  // setActivePhotoMarkerId(null) explicitly — that path doesn't need
+  // this effect. Previously this also closed on flag/label transitions,
+  // which broke re-opening picks/rejects from the side-panel click.
   useEffect(() => {
     if (!activePhotoMarkerId) return
-    const stillCapture = props.markers?.some(m =>
-      m.id === activePhotoMarkerId && m.capturedAt && !m.label && m.flag !== 'pick'
-    )
-    if (!stillCapture) setActivePhotoMarkerId(null)
+    const exists = props.markers?.some(m => m.id === activePhotoMarkerId)
+    if (!exists) setActivePhotoMarkerId(null)
   }, [props.markers, activePhotoMarkerId])
 
   const uploadedGeojson = useMemo(() => {
@@ -302,6 +302,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         ? [marker.lng, marker.lat]
         : [marker.capturedAt?.lng ?? marker.lng, marker.capturedAt?.lat ?? marker.lat]
       map.flyTo({ center, zoom: Math.max(map.getZoom(), 14), duration: 700 })
+      // Also open the photo popup so the panel click is a one-step
+      // action (fly + preview + actions). KML/click markers don't have
+      // a photo popup — guarded by photoId + capturedAt.
+      if (marker.photoId && marker.capturedAt) {
+        setActivePhotoMarkerId(markerId)
+      }
     },
   }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken])
 

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -162,30 +162,11 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     }
   }, [isMapLoaded, props.onMarkerAdd, props.groundMarkerProps, props.onNoGpsPhotoPlaced])
 
-  // Phase 5 — click capture dot to open photo popup. Mapbox listeners
-  // need a string layer id matching CaptureDotsLayer's. Cursor changes
-  // on hover so users learn the dot is interactive.
-  useEffect(() => {
-    if (!isMapLoaded || !mapRef.current) return
-    const map = mapRef.current.getMap()
-    const onClick = (e: { features?: Array<{ id?: string | number }> }) => {
-      const feature = e.features?.[0]
-      if (!feature) return
-      const id = feature.id
-      if (typeof id !== 'string') return
-      setActivePhotoMarkerId(id)
-    }
-    const onEnter = () => { map.getCanvas().style.cursor = 'pointer' }
-    const onLeave = () => { map.getCanvas().style.cursor = '' }
-    map.on('click', 'photo-capture-dots', onClick as never)
-    map.on('mouseenter', 'photo-capture-dots', onEnter)
-    map.on('mouseleave', 'photo-capture-dots', onLeave)
-    return () => {
-      map.off('click', 'photo-capture-dots', onClick as never)
-      map.off('mouseenter', 'photo-capture-dots', onEnter)
-      map.off('mouseleave', 'photo-capture-dots', onLeave)
-    }
-  }, [isMapLoaded])
+  // Phase 5 — click capture dot to open photo popup. Use react-map-gl's
+  // `interactiveLayerIds` + MapGL.onClick (below) instead of attaching
+  // listeners via map.on() in a useEffect — the latter races react-map-gl's
+  // own layer-lifecycle effects and the click silently drops.
+  const [mapCursor, setMapCursor] = useState<string>('')
 
   // Close the photo popup if its marker disappears from the layer
   // (e.g., user picked it via popup → marker promoted to subject pin →
@@ -381,6 +362,23 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       preserveDrawingBuffer
       initialViewState={{ longitude: 14.42076, latitude: 50.08804, zoom: 6 }}
       style={{ width: '100%', height: '100%' }}
+      cursor={mapCursor}
+      interactiveLayerIds={['photo-capture-dots']}
+      onMouseEnter={(e) => {
+        if (e.features?.some(f => f.layer?.id === 'photo-capture-dots')) setMapCursor('pointer')
+      }}
+      onMouseLeave={() => setMapCursor('')}
+      onClick={(e) => {
+        const hit = e.features?.find(f => f.layer?.id === 'photo-capture-dots')
+        if (!hit) return
+        // photoId is on properties (denormalized at projection time in
+        // captureFeatures.ts); use it to look up the marker by photoId
+        // rather than trusting feature.id round-tripping through Mapbox.
+        const photoId = hit.properties?.photoId as string | undefined
+        if (!photoId) return
+        const marker = props.markers?.find(m => m.photoId === photoId)
+        if (marker) setActivePhotoMarkerId(marker.id)
+      }}
       onLoad={() => setIsMapLoaded(true)}
       ref={mapRef}
     >

--- a/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
+++ b/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
@@ -1,0 +1,41 @@
+// Phase 4 of photo-map-culling: capture-dots map layer.
+// See docs/photo-map-culling/implementation-plan.md and ADR-016
+// (marker rendering split: GeoJSON layer for static dots, not individual
+// <Marker> components — keeps the React tree flat at any photo count).
+
+import { useMemo } from 'react'
+import { Layer, Source } from 'react-map-gl/mapbox'
+import type { PhotoMarker } from '../../types/markers'
+import { buildCaptureDotFeatures } from './captureFeatures'
+
+const SOURCE_ID = 'photo-capture-dots'
+const LAYER_ID = 'photo-capture-dots'
+
+interface Props {
+  markers: readonly PhotoMarker[]
+}
+
+export function CaptureDotsLayer({ markers }: Props) {
+  // Memoize the GeoJSON projection so MapboxGL doesn't re-diff the source
+  // every render — marker props change frequently during the import phase
+  // (one re-render per onProgress tick).
+  const data = useMemo(() => buildCaptureDotFeatures(markers), [markers])
+  if (data.features.length === 0) return null
+  return (
+    <Source id={SOURCE_ID} type="geojson" data={data}>
+      <Layer
+        id={LAYER_ID}
+        type="circle"
+        paint={{
+          'circle-radius': 5,
+          // Neutral grey — the user has not yet decided about this photo.
+          // Phase 5 will repaint the dot based on the flag stored in
+          // map-picks.json (ADR-017 denormalization at render time).
+          'circle-color': '#9e9e9e',
+          'circle-stroke-width': 1.5,
+          'circle-stroke-color': '#ffffff',
+        }}
+      />
+    </Source>
+  )
+}

--- a/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
+++ b/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
@@ -28,10 +28,20 @@ export function CaptureDotsLayer({ markers }: Props) {
         type="circle"
         paint={{
           'circle-radius': 5,
-          // Neutral grey — the user has not yet decided about this photo.
-          // Phase 5 will repaint the dot based on the flag stored in
-          // map-picks.json (ADR-017 denormalization at render time).
-          'circle-color': '#9e9e9e',
+          // Data-driven match on `flag` denormalized at projection time
+          // (see captureFeatures). Picks aren't in this layer at all.
+          'circle-color': [
+            'match',
+            ['get', 'flag'],
+            'reject', '#d32f2f', // red (MUI error.main)
+            '#9e9e9e',            // neutral grey (default)
+          ],
+          'circle-opacity': [
+            'match',
+            ['get', 'flag'],
+            'reject', 0.55, // visibly de-emphasized but not invisible
+            1,
+          ],
           'circle-stroke-width': 1.5,
           'circle-stroke-color': '#ffffff',
         }}

--- a/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
+++ b/frontend/map-corridors/src/map/photoLayers/CaptureDotsLayer.tsx
@@ -1,51 +1,69 @@
-// Phase 4 of photo-map-culling: capture-dots map layer.
-// See docs/photo-map-culling/implementation-plan.md and ADR-016
-// (marker rendering split: GeoJSON layer for static dots, not individual
-// <Marker> components — keeps the React tree flat at any photo count).
+// Phase 4/5 follow-up — passive overlay layers for photo markers.
+//
+// File kept under its original name (CaptureDotsLayer.tsx) to preserve
+// imports across the call sites. Renamed export `PhotoOverlayLayers`
+// mounts two GeoJSON layers:
+//   1. Dashed line from capturedAt → current subject (lng/lat).
+//   2. Ghost circle at capturedAt.
+//
+// Both layers only emit features for photos that have been MOVED
+// (subject coords ≠ capture coords). Unmoved photos show only the live
+// <Marker> pin in MapProviderView; the ghost would just overlap it.
 
 import { useMemo } from 'react'
 import { Layer, Source } from 'react-map-gl/mapbox'
 import type { PhotoMarker } from '../../types/markers'
-import { buildCaptureDotFeatures } from './captureFeatures'
+import { buildDashedLineFeatures, buildGhostFeatures } from './captureFeatures'
 
-const SOURCE_ID = 'photo-capture-dots'
-const LAYER_ID = 'photo-capture-dots'
+const GHOST_SOURCE_ID = 'photo-ghost-dots'
+const GHOST_LAYER_ID = 'photo-ghost-dots'
+const LINE_SOURCE_ID = 'photo-dashed-lines'
+const LINE_LAYER_ID = 'photo-dashed-lines'
 
 interface Props {
   markers: readonly PhotoMarker[]
 }
 
-export function CaptureDotsLayer({ markers }: Props) {
-  // Memoize the GeoJSON projection so MapboxGL doesn't re-diff the source
-  // every render — marker props change frequently during the import phase
-  // (one re-render per onProgress tick).
-  const data = useMemo(() => buildCaptureDotFeatures(markers), [markers])
-  if (data.features.length === 0) return null
+export function PhotoOverlayLayers({ markers }: Props) {
+  const ghostData = useMemo(() => buildGhostFeatures(markers), [markers])
+  const lineData = useMemo(() => buildDashedLineFeatures(markers), [markers])
+  if (ghostData.features.length === 0 && lineData.features.length === 0) return null
   return (
-    <Source id={SOURCE_ID} type="geojson" data={data}>
-      <Layer
-        id={LAYER_ID}
-        type="circle"
-        paint={{
-          'circle-radius': 5,
-          // Data-driven match on `flag` denormalized at projection time
-          // (see captureFeatures). Picks aren't in this layer at all.
-          'circle-color': [
-            'match',
-            ['get', 'flag'],
-            'reject', '#d32f2f', // red (MUI error.main)
-            '#9e9e9e',            // neutral grey (default)
-          ],
-          'circle-opacity': [
-            'match',
-            ['get', 'flag'],
-            'reject', 0.55, // visibly de-emphasized but not invisible
-            1,
-          ],
-          'circle-stroke-width': 1.5,
-          'circle-stroke-color': '#ffffff',
-        }}
-      />
-    </Source>
+    <>
+      {lineData.features.length > 0 && (
+        <Source id={LINE_SOURCE_ID} type="geojson" data={lineData}>
+          <Layer
+            id={LINE_LAYER_ID}
+            type="line"
+            paint={{
+              'line-color': '#9e9e9e',
+              'line-width': 1.5,
+              'line-dasharray': [2, 2],
+              'line-opacity': 0.8,
+            }}
+          />
+        </Source>
+      )}
+      {ghostData.features.length > 0 && (
+        <Source id={GHOST_SOURCE_ID} type="geojson" data={ghostData}>
+          <Layer
+            id={GHOST_LAYER_ID}
+            type="circle"
+            paint={{
+              'circle-radius': 4,
+              'circle-color': '#9e9e9e',
+              'circle-stroke-color': '#ffffff',
+              'circle-stroke-width': 1,
+              'circle-opacity': 0.5,
+            }}
+          />
+        </Source>
+      )}
+    </>
   )
 }
+
+// Re-export under the old name so existing imports still resolve while
+// the new model takes the same slot. Drop the alias once call sites are
+// updated.
+export const CaptureDotsLayer = PhotoOverlayLayers

--- a/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
+++ b/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
@@ -7,12 +7,19 @@
 // how many photos are imported (30..100 typical, 200+ edge case).
 
 import type { FeatureCollection, Point } from 'geojson'
-import type { PhotoMarker } from '../../types/markers'
+import type { PhotoFlag, PhotoMarker } from '../../types/markers'
+
+// `'neutral'` is denormalized at projection time so the Mapbox `match`
+// paint expression can branch on a single property — it's not stored on
+// the marker (absence of `flag` is the neutral state).
+export type CaptureDotFlag = PhotoFlag | 'neutral'
 
 export interface CaptureDotProperties {
   photoId: string
-  /** Filename — surfaced in hover tooltips downstream (Phase 5). */
+  /** Filename — surfaced in hover tooltips downstream. */
   name: string
+  /** Drives the data-driven paint expression in CaptureDotsLayer. */
+  flag: CaptureDotFlag
 }
 
 /**
@@ -21,13 +28,15 @@ export interface CaptureDotProperties {
  * A photo marker appears in the capture-dots layer when ALL hold:
  *   - `capturedAt` is set (EXIF GPS was extracted at import time)
  *   - `photoId` is set (otherwise it's a KML/click marker, not a photo)
- *   - `label` is unset (a labelled marker is a Phase-5 "pick" — those
- *     render as a draggable subject pin, not a static capture dot)
+ *   - `label` is unset (a labelled marker renders via the subject-pin
+ *     path, not a capture dot)
+ *   - `flag !== 'pick'` (picks render via the subject-pin path too,
+ *     even without a label yet — user can pick first, label later)
  *
- * The feature is positioned at `capturedAt.lng/lat` — the location where
- * the camera GPS recorded the photo. The marker's primary `lng/lat`
- * (subject location) is irrelevant for the capture layer; Phase 5's
- * subject-pin path uses that.
+ * The feature is positioned at `capturedAt.lng/lat` — where the camera
+ * GPS recorded the photo. The marker's primary `lng/lat` is the subject
+ * location; once the user drags the subject pin away, the capture dot
+ * must stay where the camera was. Test pins this invariant.
  */
 export function buildCaptureDotFeatures(
   markers: readonly PhotoMarker[],
@@ -37,11 +46,16 @@ export function buildCaptureDotFeatures(
     if (!m.capturedAt) continue
     if (!m.photoId) continue
     if (m.label) continue
+    if (m.flag === 'pick') continue
     features.push({
       type: 'Feature',
       id: m.id,
       geometry: { type: 'Point', coordinates: [m.capturedAt.lng, m.capturedAt.lat] },
-      properties: { photoId: m.photoId, name: m.name },
+      properties: {
+        photoId: m.photoId,
+        name: m.name,
+        flag: m.flag ?? 'neutral',
+      },
     })
   }
   return { type: 'FeatureCollection', features }

--- a/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
+++ b/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
@@ -1,61 +1,79 @@
-// Phase 4 of photo-map-culling: capture-dots GeoJSON projection.
-// See docs/photo-map-culling/implementation-plan.md and ADR-016
-// (marker rendering split: GeoJSON layer for static dots).
+// Phase 4/5 follow-up — projections for the photo overlay layers.
+// File kept under its original name (captureFeatures.ts) to preserve
+// imports; previously exported buildCaptureDotFeatures. Layers/exports
+// re-purposed once "drag every photo, not just picks" became the model:
 //
-// Pure projection — `PhotoMarker[]` → `FeatureCollection<Point>` — so the
-// expensive React tree only sees a single Source/Layer pair regardless of
-// how many photos are imported (30..100 typical, 200+ edge case).
+//   • Pins are individual <Marker> components for ALL photos (drag +
+//     click-to-popup).
+//   • Ghost dots + dashed lines are GeoJSON layers that ONLY render
+//     when a photo has been moved away from its EXIF capture point.
+//     "Moved" = the user has confirmed the subject location, so the
+//     ghost is the cue: "this photo is processed; here's where the
+//     camera was".
 
-import type { FeatureCollection, Point } from 'geojson'
-import type { PhotoFlag, PhotoMarker } from '../../types/markers'
+import type { FeatureCollection, LineString, Point } from 'geojson'
+import type { PhotoMarker } from '../../types/markers'
 
-// `'neutral'` is denormalized at projection time so the Mapbox `match`
-// paint expression can branch on a single property — it's not stored on
-// the marker (absence of `flag` is the neutral state).
-export type CaptureDotFlag = PhotoFlag | 'neutral'
+/** True when the marker's subject coords differ from its capture coords. */
+export function isPhotoMoved(m: PhotoMarker): boolean {
+  if (!m.capturedAt) return false
+  return m.lng !== m.capturedAt.lng || m.lat !== m.capturedAt.lat
+}
 
-export interface CaptureDotProperties {
+export interface GhostProperties {
   photoId: string
-  /** Filename — surfaced in hover tooltips downstream. */
-  name: string
-  /** Drives the data-driven paint expression in CaptureDotsLayer. */
-  flag: CaptureDotFlag
 }
 
 /**
- * Build the GeoJSON FeatureCollection for the capture-dots layer.
- *
- * A photo marker appears in the capture-dots layer when ALL hold:
- *   - `capturedAt` is set (EXIF GPS was extracted at import time)
- *   - `photoId` is set (otherwise it's a KML/click marker, not a photo)
- *   - `label` is unset (a labelled marker renders via the subject-pin
- *     path, not a capture dot)
- *   - `flag !== 'pick'` (picks render via the subject-pin path too,
- *     even without a label yet — user can pick first, label later)
- *
- * The feature is positioned at `capturedAt.lng/lat` — where the camera
- * GPS recorded the photo. The marker's primary `lng/lat` is the subject
- * location; once the user drags the subject pin away, the capture dot
- * must stay where the camera was. Test pins this invariant.
+ * Ghost points at the original EXIF capture location, rendered as a
+ * faded grey dot for every photo whose subject pin has been dragged
+ * away from where the camera recorded it. Skipped when subject ==
+ * capture (no need to show a ghost on top of the live pin).
  */
-export function buildCaptureDotFeatures(
+export function buildGhostFeatures(
   markers: readonly PhotoMarker[],
-): FeatureCollection<Point, CaptureDotProperties> {
-  const features: FeatureCollection<Point, CaptureDotProperties>['features'] = []
+): FeatureCollection<Point, GhostProperties> {
+  const features: FeatureCollection<Point, GhostProperties>['features'] = []
   for (const m of markers) {
-    if (!m.capturedAt) continue
-    if (!m.photoId) continue
-    if (m.label) continue
-    if (m.flag === 'pick') continue
+    if (!m.capturedAt || !m.photoId) continue
+    if (!isPhotoMoved(m)) continue
     features.push({
       type: 'Feature',
       id: m.id,
       geometry: { type: 'Point', coordinates: [m.capturedAt.lng, m.capturedAt.lat] },
-      properties: {
-        photoId: m.photoId,
-        name: m.name,
-        flag: m.flag ?? 'neutral',
+      properties: { photoId: m.photoId },
+    })
+  }
+  return { type: 'FeatureCollection', features }
+}
+
+export interface DashedLineProperties {
+  photoId: string
+}
+
+/**
+ * Dashed LineStrings linking each ghost (capturedAt) to its live subject
+ * pin (lng/lat). Same membership rule as buildGhostFeatures — only for
+ * moved photos.
+ */
+export function buildDashedLineFeatures(
+  markers: readonly PhotoMarker[],
+): FeatureCollection<LineString, DashedLineProperties> {
+  const features: FeatureCollection<LineString, DashedLineProperties>['features'] = []
+  for (const m of markers) {
+    if (!m.capturedAt || !m.photoId) continue
+    if (!isPhotoMoved(m)) continue
+    features.push({
+      type: 'Feature',
+      id: m.id,
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [m.capturedAt.lng, m.capturedAt.lat],
+          [m.lng, m.lat],
+        ],
       },
+      properties: { photoId: m.photoId },
     })
   }
   return { type: 'FeatureCollection', features }

--- a/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
+++ b/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
@@ -1,0 +1,48 @@
+// Phase 4 of photo-map-culling: capture-dots GeoJSON projection.
+// See docs/photo-map-culling/implementation-plan.md and ADR-016
+// (marker rendering split: GeoJSON layer for static dots).
+//
+// Pure projection — `PhotoMarker[]` → `FeatureCollection<Point>` — so the
+// expensive React tree only sees a single Source/Layer pair regardless of
+// how many photos are imported (30..100 typical, 200+ edge case).
+
+import type { FeatureCollection, Point } from 'geojson'
+import type { PhotoMarker } from '../../types/markers'
+
+export interface CaptureDotProperties {
+  photoId: string
+  /** Filename — surfaced in hover tooltips downstream (Phase 5). */
+  name: string
+}
+
+/**
+ * Build the GeoJSON FeatureCollection for the capture-dots layer.
+ *
+ * A photo marker appears in the capture-dots layer when ALL hold:
+ *   - `capturedAt` is set (EXIF GPS was extracted at import time)
+ *   - `photoId` is set (otherwise it's a KML/click marker, not a photo)
+ *   - `label` is unset (a labelled marker is a Phase-5 "pick" — those
+ *     render as a draggable subject pin, not a static capture dot)
+ *
+ * The feature is positioned at `capturedAt.lng/lat` — the location where
+ * the camera GPS recorded the photo. The marker's primary `lng/lat`
+ * (subject location) is irrelevant for the capture layer; Phase 5's
+ * subject-pin path uses that.
+ */
+export function buildCaptureDotFeatures(
+  markers: readonly PhotoMarker[],
+): FeatureCollection<Point, CaptureDotProperties> {
+  const features: FeatureCollection<Point, CaptureDotProperties>['features'] = []
+  for (const m of markers) {
+    if (!m.capturedAt) continue
+    if (!m.photoId) continue
+    if (m.label) continue
+    features.push({
+      type: 'Feature',
+      id: m.id,
+      geometry: { type: 'Point', coordinates: [m.capturedAt.lng, m.capturedAt.lat] },
+      properties: { photoId: m.photoId, name: m.name },
+    })
+  }
+  return { type: 'FeatureCollection', features }
+}

--- a/frontend/map-corridors/src/photoImport/extractExif.ts
+++ b/frontend/map-corridors/src/photoImport/extractExif.ts
@@ -1,0 +1,87 @@
+import exifr from 'exifr'
+import type { ExifData } from './types'
+import { HeicNotSupportedError } from './types'
+
+// ISO base-media-file-format brands that exifr/photo-helper cannot decode.
+// Apple HEIC, HEIF, and a handful of related codecs all share the `ftyp` box
+// layout. The list is kept conservative: only brands known to be HEIC-family.
+const HEIC_FTYP_BRANDS: ReadonlySet<string> = new Set([
+  'heic', 'heix', 'mif1', 'msf1', 'heim', 'heis', 'hevc', 'hevx',
+])
+
+// HEIC/HEIF detection by content (ADR-006). Filename extension is not
+// trusted — Apple Photos export sometimes writes `.jpg` over HEIC bytes.
+// Layout: bytes 0..3 = box size, 4..7 = "ftyp", 8..11 = brand.
+async function isHeicContent(file: File | Blob): Promise<boolean> {
+  if (file.size < 12) return false
+  const head = await file.slice(0, 12).arrayBuffer()
+  const b = new Uint8Array(head)
+  if (b[4] !== 0x66 || b[5] !== 0x74 || b[6] !== 0x79 || b[7] !== 0x70) return false
+  const brand = String.fromCharCode(b[8], b[9], b[10], b[11]).toLowerCase()
+  return HEIC_FTYP_BRANDS.has(brand)
+}
+
+// Reject the (0, 0) GPS sentinel — some cameras write zeros when GPS lock
+// fails. ADR-005 / Phase 1 test plan.
+function isValidGps(g: { latitude?: unknown; longitude?: unknown } | null | undefined):
+  g is { latitude: number; longitude: number } {
+  if (!g) return false
+  const { latitude, longitude } = g
+  if (typeof latitude !== 'number' || !Number.isFinite(latitude)) return false
+  if (typeof longitude !== 'number' || !Number.isFinite(longitude)) return false
+  if (latitude === 0 && longitude === 0) return false
+  if (latitude < -90 || latitude > 90) return false
+  if (longitude < -180 || longitude > 180) return false
+  return true
+}
+
+/**
+ * Extract a normalized subset of EXIF data: GPS subject coordinates,
+ * capture timestamp, and orientation. Pure function — no storage, no
+ * mutation, no UI.
+ *
+ * @throws HeicNotSupportedError if the file's content is HEIC/HEIF.
+ *   Any other parse failure (corrupt JPEG, missing EXIF) resolves to an
+ *   empty result so importPhotoFiles can keep going on the rest of the batch.
+ */
+export async function extractExif(file: File): Promise<ExifData> {
+  if (await isHeicContent(file)) {
+    throw new HeicNotSupportedError(file.name)
+  }
+
+  const result: ExifData = {}
+
+  const gps = await exifr.gps(file).catch(() => null)
+  // `translateValues: false` keeps Orientation as a 1..8 integer instead
+  // of exifr's human-readable string ("Horizontal (normal)" etc.).
+  const meta = await exifr.parse(file, {
+    pick: ['DateTimeOriginal', 'GPSAltitude', 'Orientation'],
+    translateValues: false,
+  }).catch(() => null) as Record<string, unknown> | null
+
+  if (isValidGps(gps)) {
+    const altitude = meta?.GPSAltitude
+    const hasAltitude = typeof altitude === 'number' && Number.isFinite(altitude)
+    result.capturedAt = {
+      lat: gps.latitude,
+      lng: gps.longitude,
+      ...(hasAltitude ? { altitude: altitude as number } : {}),
+    }
+  }
+
+  const dto = meta?.DateTimeOriginal
+  if (dto instanceof Date && !Number.isNaN(dto.getTime())) {
+    result.timestamp = dto.toISOString()
+  }
+
+  const orientation = meta?.Orientation
+  if (
+    typeof orientation === 'number' &&
+    Number.isInteger(orientation) &&
+    orientation >= 1 && orientation <= 8
+  ) {
+    result.orientation = orientation
+  }
+
+  return result
+}

--- a/frontend/map-corridors/src/photoImport/extractExif.ts
+++ b/frontend/map-corridors/src/photoImport/extractExif.ts
@@ -3,10 +3,13 @@ import type { ExifData } from './types'
 import { HeicNotSupportedError } from './types'
 
 // ISO base-media-file-format brands that exifr/photo-helper cannot decode.
-// Apple HEIC, HEIF, and a handful of related codecs all share the `ftyp` box
-// layout. The list is kept conservative: only brands known to be HEIC-family.
+// Apple HEIC and its HEVC-derived codec brands all share the `ftyp` box
+// layout. We deliberately do NOT include the generic `mif1`/`msf1` MIAF
+// brands here — many JPEG-encoded HEIF files use those brands and exifr
+// CAN parse them. Treating mif1 as HEIC produced false "HEIC not
+// supported" rejections on otherwise-valid images.
 const HEIC_FTYP_BRANDS: ReadonlySet<string> = new Set([
-  'heic', 'heix', 'mif1', 'msf1', 'heim', 'heis', 'hevc', 'hevx',
+  'heic', 'heix', 'heim', 'heis', 'hevc', 'hevx',
 ])
 
 // HEIC/HEIF detection by content (ADR-006). Filename extension is not

--- a/frontend/map-corridors/src/photoImport/generateThumb.ts
+++ b/frontend/map-corridors/src/photoImport/generateThumb.ts
@@ -1,0 +1,67 @@
+// Phase 1b of photo-map-culling: thumbnail synthesis.
+// See docs/photo-map-culling/implementation-plan.md.
+
+export interface GenerateThumbOpts {
+  /** Maximum thumbnail width in pixels. Default 200 (popup size). */
+  maxWidth?: number
+  /** Maximum thumbnail height in pixels. Default 150 (popup size). */
+  maxHeight?: number
+  /** JPEG quality 0..1. Default 0.7 (good for ~150-line popup thumbs). */
+  quality?: number
+}
+
+const DEFAULTS = { maxWidth: 200, maxHeight: 150, quality: 0.7 } as const
+
+/**
+ * Generate a small JPEG thumbnail from any image File the browser can
+ * decode. EXIF Orientation is applied automatically by the browser via
+ * `createImageBitmap({ imageOrientation: 'from-image' })` per ADR-015
+ * — no manual rotation logic, no Orientation=6/8 special-casing in our
+ * code. Aspect ratio is preserved (contain-fit inside maxWidth × maxHeight).
+ *
+ * Throws on corrupt input (createImageBitmap rejects), missing
+ * OffscreenCanvas 2D context, or convertToBlob failure. Callers in
+ * importPhotoFiles catch these and route to the per-photo failure list.
+ */
+export async function generateThumb(file: File, opts: GenerateThumbOpts = {}): Promise<Blob> {
+  const { maxWidth, maxHeight, quality } = { ...DEFAULTS, ...opts }
+  if (maxWidth <= 0 || maxHeight <= 0) {
+    throw new Error(`generateThumb: invalid bounds maxWidth=${maxWidth} maxHeight=${maxHeight}`)
+  }
+
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' })
+  try {
+    const { width: srcW, height: srcH } = bitmap
+    if (srcW <= 0 || srcH <= 0) {
+      throw new Error(`generateThumb: decoded bitmap has zero dimension (${srcW}x${srcH})`)
+    }
+    const { width: targetW, height: targetH } = fitWithin(srcW, srcH, maxWidth, maxHeight)
+    const canvas = new OffscreenCanvas(targetW, targetH)
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('generateThumb: OffscreenCanvas 2D context unavailable')
+    ctx.drawImage(bitmap, 0, 0, targetW, targetH)
+    return await canvas.convertToBlob({ type: 'image/jpeg', quality })
+  } finally {
+    bitmap.close()
+  }
+}
+
+/**
+ * Compute contain-fit dimensions: largest size that fits inside the bounds
+ * while preserving aspect ratio. Returns integer pixels (rounded down so we
+ * never exceed bounds). Exported for unit testing — pure math, no globals.
+ */
+export function fitWithin(
+  srcW: number,
+  srcH: number,
+  maxW: number,
+  maxH: number,
+): { width: number; height: number } {
+  const ratio = srcW / srcH
+  if (srcW <= maxW && srcH <= maxH) return { width: srcW, height: srcH }
+  const widthCappedH = maxW / ratio
+  if (widthCappedH <= maxH) {
+    return { width: maxW, height: Math.max(1, Math.floor(widthCappedH)) }
+  }
+  return { width: Math.max(1, Math.floor(maxH * ratio)), height: maxH }
+}

--- a/frontend/map-corridors/src/photoImport/importPhotoFiles.ts
+++ b/frontend/map-corridors/src/photoImport/importPhotoFiles.ts
@@ -1,0 +1,130 @@
+// Phase 1c of photo-map-culling: pipeline orchestrator.
+// See docs/photo-map-culling/implementation-plan.md.
+
+import { extractExif } from './extractExif'
+import { generateThumb } from './generateThumb'
+import type {
+  ImportedPhoto,
+  ImportFailure,
+  ImportResult,
+} from './types'
+import { HeicNotSupportedError } from './types'
+
+export interface ImportPhotoFilesOpts {
+  /** Max parallel files. Default 8 per ADR-014. */
+  concurrency?: number
+  /** Called after each file completes (success or failure). */
+  onProgress?: (done: number, total: number) => void
+}
+
+// Image MIME types we accept. PNG is included because some screenshot
+// pipelines write GPS as a sidecar; we still try to extract EXIF from
+// PNGs (some tools embed it in eXIf chunks).
+const SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png'])
+const SUPPORTED_EXT_RX = /\.(jpe?g|png)$/i
+
+function isSupportedImage(file: File): boolean {
+  if (SUPPORTED_MIMES.has(file.type)) return true
+  // Some drag-drop sources (older Electron, drag from a network share)
+  // surface files with empty `type`. Fall back to filename extension.
+  if (file.type === '' && SUPPORTED_EXT_RX.test(file.name)) return true
+  return false
+}
+
+function makePhotoId(): string {
+  // `pm-` prefix marks the photo as map-originated per ADR-005. Photo-helper
+  // uses the prefix to decide whose canonical record an entry belongs to.
+  return `pm-${crypto.randomUUID()}`
+}
+
+async function computeContentHash(file: File): Promise<string> {
+  const buf = await file.arrayBuffer()
+  const hash = await crypto.subtle.digest('SHA-1', buf)
+  const bytes = new Uint8Array(hash)
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, '0')
+  return hex
+}
+
+function classifyFailure(err: unknown): ImportFailure['reason'] {
+  if (err instanceof HeicNotSupportedError) return 'heic'
+  return 'corrupt'
+}
+
+/**
+ * Import a batch of files. Concurrency-limited at `opts.concurrency`
+ * (default 8). Failures are isolated per file — one corrupt JPEG does
+ * not abort the rest of the batch (ADR-013).
+ *
+ * Unsupported MIME types and HEIC content are reported as failures with
+ * distinct `reason` codes so the caller can show targeted toasts.
+ */
+export async function importPhotoFiles(
+  files: File[],
+  opts: ImportPhotoFilesOpts = {},
+): Promise<ImportResult> {
+  const concurrency = Math.max(1, opts.concurrency ?? 8)
+  const ok: ImportedPhoto[] = []
+  const failed: ImportFailure[] = []
+  let done = 0
+
+  const reportProgress = () => {
+    done++
+    opts.onProgress?.(done, files.length)
+  }
+
+  // Pre-filter — non-images never enter the worker pool.
+  const queue: File[] = []
+  for (const f of files) {
+    if (isSupportedImage(f)) {
+      queue.push(f)
+    } else {
+      failed.push({
+        filename: f.name,
+        reason: 'unsupported',
+        message: `Unsupported file type: ${f.type || f.name}`,
+      })
+      reportProgress()
+    }
+  }
+
+  // Cooperative worker pool. Each worker pulls the next index until the
+  // queue drains. JS single-threadedness makes `nextIdx++` atomic.
+  let nextIdx = 0
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = nextIdx++
+      if (idx >= queue.length) return
+      const file = queue[idx]
+      try {
+        const [exif, thumbnail, contentHash] = await Promise.all([
+          extractExif(file),
+          generateThumb(file),
+          computeContentHash(file),
+        ])
+        ok.push({
+          photoId: makePhotoId(),
+          file,
+          thumbnail,
+          exif,
+          contentHash,
+        })
+      } catch (err) {
+        failed.push({
+          filename: file.name,
+          reason: classifyFailure(err),
+          message: err instanceof Error ? err.message : String(err),
+        })
+      } finally {
+        reportProgress()
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, queue.length)
+  if (workerCount === 0) return { ok, failed }
+
+  const workers = Array.from({ length: workerCount }, () => worker())
+  await Promise.all(workers)
+  return { ok, failed }
+}

--- a/frontend/map-corridors/src/photoImport/importPhotosToStorage.ts
+++ b/frontend/map-corridors/src/photoImport/importPhotosToStorage.ts
@@ -1,0 +1,72 @@
+// Phase 3 of photo-map-culling: dropzone → storage orchestrator.
+// See docs/photo-map-culling/implementation-plan.md.
+//
+// Thin layer that composes Phase 1's pure import pipeline with Phase 2's
+// thumbnail-aware storage layer. The function takes a resolved
+// `photosDir` so the caller can decide where to write (per-competition).
+
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { importPhotoFiles } from './importPhotoFiles'
+import type { ImportPhotoFilesOpts } from './importPhotoFiles'
+import type { ImportResult } from './types'
+
+export type ImportPhotosToStorageOpts = ImportPhotoFilesOpts
+
+/**
+ * Run the Phase 1 import pipeline, then persist each successful import
+ * to OPFS/Electron storage:
+ *   - photosDir/{photoId}         ← original bytes
+ *   - photosDir/thumbs/{photoId}.jpg  ← generated thumbnail
+ *
+ * A photo whose blob+thumb both write OK stays in `result.ok`. Storage
+ * failures (quota, disk error) demote the photo to `result.failed` with
+ * `reason: 'storage'`. The thumbnail write is attempted only after the
+ * original bytes are safely on disk — partial thumb writes are cleaned
+ * up on original-write failure (rare, but matches the ADR-013
+ * atomic-per-photo guarantee).
+ */
+export async function importPhotosToStorage(
+  storage: StorageInterface,
+  photosDir: DirectoryHandle,
+  files: File[],
+  opts: ImportPhotosToStorageOpts = {},
+): Promise<ImportResult> {
+  const result = await importPhotoFiles(files, opts)
+  if (result.ok.length === 0) return result
+
+  const persisted = await Promise.all(result.ok.map(async (photo) => {
+    try {
+      await storage.savePhotoFile(photosDir, photo.photoId, photo.file)
+      try {
+        await storage.savePhotoThumb(photosDir, photo.photoId, photo.thumbnail)
+      } catch (thumbErr) {
+        // Original landed, thumb didn't. Roll back the original so the
+        // next import (or the user retrying) gets a clean state.
+        await storage.deletePhotoFile(photosDir, photo.photoId).catch(() => {})
+        throw thumbErr
+      }
+      return { ok: true as const, photo }
+    } catch (err) {
+      return {
+        ok: false as const,
+        photo,
+        message: err instanceof Error ? err.message : String(err),
+      }
+    }
+  }))
+
+  const newOk: ImportResult['ok'] = []
+  for (const r of persisted) {
+    if (r.ok) {
+      newOk.push(r.photo)
+    } else {
+      result.failed.push({
+        filename: r.photo.file.name,
+        reason: 'storage',
+        message: r.message,
+      })
+    }
+  }
+  result.ok = newOk
+  return result
+}

--- a/frontend/map-corridors/src/photoImport/types.ts
+++ b/frontend/map-corridors/src/photoImport/types.ts
@@ -27,6 +27,9 @@ export interface ImportedPhoto {
   file: File
   thumbnail: Blob
   exif: ExifData
+  // SHA-1 hex of the file bytes — used by importPhotoFiles for re-import
+  // dedup per ADR-020. Computed in parallel with EXIF + thumb generation.
+  contentHash: string
 }
 
 export type ImportFailureReason = 'heic' | 'corrupt' | 'unsupported'

--- a/frontend/map-corridors/src/photoImport/types.ts
+++ b/frontend/map-corridors/src/photoImport/types.ts
@@ -1,0 +1,43 @@
+// Photo-map-culling import-pipeline types (Phase 1).
+// See docs/photo-map-culling/implementation-plan.md.
+
+export interface ExifGps {
+  lng: number
+  lat: number
+  altitude?: number
+}
+
+export interface ExifData {
+  capturedAt?: ExifGps
+  timestamp?: string
+  orientation?: number
+}
+
+// Thrown by extractExif when the file's content magic bytes identify it as
+// HEIC/HEIF, regardless of filename extension. Per ADR-006 v1 rejects HEIC.
+export class HeicNotSupportedError extends Error {
+  override readonly name = 'HeicNotSupportedError'
+  constructor(filename?: string) {
+    super(filename ? `HEIC is not supported: ${filename}` : 'HEIC is not supported')
+  }
+}
+
+export interface ImportedPhoto {
+  photoId: string
+  file: File
+  thumbnail: Blob
+  exif: ExifData
+}
+
+export type ImportFailureReason = 'heic' | 'corrupt' | 'unsupported'
+
+export interface ImportFailure {
+  filename: string
+  reason: ImportFailureReason
+  message: string
+}
+
+export interface ImportResult {
+  ok: ImportedPhoto[]
+  failed: ImportFailure[]
+}

--- a/frontend/map-corridors/src/photoImport/types.ts
+++ b/frontend/map-corridors/src/photoImport/types.ts
@@ -32,7 +32,7 @@ export interface ImportedPhoto {
   contentHash: string
 }
 
-export type ImportFailureReason = 'heic' | 'corrupt' | 'unsupported'
+export type ImportFailureReason = 'heic' | 'corrupt' | 'unsupported' | 'storage'
 
 export interface ImportFailure {
   filename: string

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -14,12 +14,20 @@ export {
 } from '@airq/shared-discipline'
 export type { PhotoLabel } from '@airq/shared-discipline'
 
+// `lng/lat` is the subject (answer-sheet) location; `capturedAt` is the optional EXIF source. See docs/photo-map-culling/implementation-plan.md Phase 0.
 export type PhotoMarker = Readonly<{
   id: string
   lng: number
   lat: number
   name: string
   label?: PhotoLabel
+  capturedAt?: Readonly<{
+    lng: number
+    lat: number
+    altitude?: number
+    timestamp?: string
+  }>
+  photoId?: string
 }>
 
 // Ground marker types — FAI precision flying canvas shapes (12 letters + 14 symbols).
@@ -79,6 +87,16 @@ export function isGroundMarker(value: unknown): value is GroundMarker {
   )
 }
 
+function isValidCapturedAt(value: unknown): boolean {
+  if (value === undefined) return true
+  if (!value || typeof value !== 'object') return false
+  const c = value as Record<string, unknown>
+  if (!isValidLngLat(c.lng, c.lat)) return false
+  if (c.altitude !== undefined && !(typeof c.altitude === 'number' && Number.isFinite(c.altitude))) return false
+  if (c.timestamp !== undefined && typeof c.timestamp !== 'string') return false
+  return true
+}
+
 export function isPhotoMarker(value: unknown): value is PhotoMarker {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
@@ -86,7 +104,9 @@ export function isPhotoMarker(value: unknown): value is PhotoMarker {
     typeof v.id === 'string' && v.id.length > 0 &&
     isValidLngLat(v.lng, v.lat) &&
     typeof v.name === 'string' &&
-    (v.label === undefined || (typeof v.label === 'string' && PHOTO_LABEL_SET.has(v.label)))
+    (v.label === undefined || (typeof v.label === 'string' && PHOTO_LABEL_SET.has(v.label))) &&
+    isValidCapturedAt(v.capturedAt) &&
+    (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0))
   )
 }
 

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -15,6 +15,10 @@ export {
 export type { PhotoLabel } from '@airq/shared-discipline'
 
 // `lng/lat` is the subject (answer-sheet) location; `capturedAt` is the optional EXIF source. See docs/photo-map-culling/implementation-plan.md Phase 0.
+// `flag` is a Phase-5 intermediate — until Phase 8 (map-picks.json), the
+// flag persists on the marker. Phase 8 makes map-picks.json the source
+// of truth and the marker.flag becomes a render-time projection.
+export type PhotoFlag = 'pick' | 'reject'
 export type PhotoMarker = Readonly<{
   id: string
   lng: number
@@ -28,6 +32,7 @@ export type PhotoMarker = Readonly<{
     timestamp?: string
   }>
   photoId?: string
+  flag?: PhotoFlag
 }>
 
 // Ground marker types — FAI precision flying canvas shapes (12 letters + 14 symbols).
@@ -97,6 +102,8 @@ function isValidCapturedAt(value: unknown): boolean {
   return true
 }
 
+const PHOTO_FLAG_SET: ReadonlySet<string> = new Set<string>(['pick', 'reject'])
+
 export function isPhotoMarker(value: unknown): value is PhotoMarker {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
@@ -106,7 +113,8 @@ export function isPhotoMarker(value: unknown): value is PhotoMarker {
     typeof v.name === 'string' &&
     (v.label === undefined || (typeof v.label === 'string' && PHOTO_LABEL_SET.has(v.label))) &&
     isValidCapturedAt(v.capturedAt) &&
-    (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0))
+    (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0)) &&
+    (v.flag === undefined || (typeof v.flag === 'string' && PHOTO_FLAG_SET.has(v.flag)))
   )
 }
 

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -33,6 +33,10 @@ export type PhotoMarker = Readonly<{
   }>
   photoId?: string
   flag?: PhotoFlag
+  // Phase D of photo-map-culling — when the label was last set, ISO 8601.
+  // Drives the "newer wins" conflict resolution in `useEditorPicksSync`
+  // and `useMapPicksSync` (label may be set in either app now).
+  labelUpdatedAt?: string
 }>
 
 // Ground marker types — FAI precision flying canvas shapes (12 letters + 14 symbols).
@@ -114,7 +118,8 @@ export function isPhotoMarker(value: unknown): value is PhotoMarker {
     (v.label === undefined || (typeof v.label === 'string' && PHOTO_LABEL_SET.has(v.label))) &&
     isValidCapturedAt(v.capturedAt) &&
     (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0)) &&
-    (v.flag === undefined || (typeof v.flag === 'string' && PHOTO_FLAG_SET.has(v.flag)))
+    (v.flag === undefined || (typeof v.flag === 'string' && PHOTO_FLAG_SET.has(v.flag))) &&
+    (v.labelUpdatedAt === undefined || typeof v.labelUpdatedAt === 'string')
   )
 }
 

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -127,3 +127,30 @@ export function sanitizePhotoMarkers(input: unknown): PhotoMarker[] {
   if (!Array.isArray(input)) return []
   return input.filter(isPhotoMarker)
 }
+
+// Phase 6 of photo-map-culling — no-GPS photo tray entries.
+// These photos live in this list (not in `markers`) until the user drags
+// one onto the map, at which point a `PhotoMarker` is created at the drop
+// coords and the entry leaves this list. ADR-012 — they never receive
+// synthetic coordinates while in the tray.
+export type NoGpsPhoto = Readonly<{
+  photoId: string
+  filename: string
+  /** ISO 8601 EXIF DateTimeOriginal; used for tray sort order. Optional — some cameras don't set it. */
+  timestamp?: string
+}>
+
+export function isNoGpsPhoto(value: unknown): value is NoGpsPhoto {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.photoId === 'string' && v.photoId.length > 0 &&
+    typeof v.filename === 'string' && v.filename.length > 0 &&
+    (v.timestamp === undefined || typeof v.timestamp === 'string')
+  )
+}
+
+export function sanitizeNoGpsPhotos(input: unknown): NoGpsPhoto[] {
+  if (!Array.isArray(input)) return []
+  return input.filter(isNoGpsPhoto)
+}

--- a/frontend/map-corridors/test/fixtures/photos/README.md
+++ b/frontend/map-corridors/test/fixtures/photos/README.md
@@ -1,0 +1,47 @@
+# Photo test fixtures
+
+Synthetic JPEG fixtures for the photo-map-culling feature
+(see [docs/photo-map-culling/implementation-plan.md](../../../../../docs/photo-map-culling/implementation-plan.md)
+Phase 0–1).
+
+## Conventions
+
+- **Anonymized GPS only.** Never commit photos with real-world coordinates
+  of an organizer's home, workplace, or competition site. Phase 0's exit
+  criteria explicitly forbids this.
+- Base coordinate for the synthetic dataset: **(50.0, 14.0)** — open
+  countryside south of Mladá Boleslav, no addresses. Offsets in tenths/
+  hundredths of a degree are fine (e.g. `(50.01, 14.02)`).
+- Image content should be a tiny solid-color JPEG (~1 × 1 to 10 × 10 px)
+  to keep the repo small. Real photographic content is unnecessary —
+  the EXIF block is what tests exercise.
+- All fixtures live in this directory. Tests load them via relative
+  paths from `frontend/map-corridors/src/__tests__/`.
+
+## Planned fixtures (Phase 1 — `extractExif.test.ts`)
+
+| Filename | Purpose |
+|---|---|
+| `with-gps.jpg` | Valid GPS at (50.0, 14.0) — happy path |
+| `no-gps.jpg` | EXIF present but no GPS tags — must yield `gps === undefined` |
+| `gps-zero.jpg` | GPS = (0, 0) — must be treated as "no GPS" (camera GPS-lock failed) |
+| `orientation-6.jpg` | EXIF Orientation = 6 (rotated 90° CW) — exercises `createImageBitmap({ imageOrientation: 'from-image' })` |
+| `corrupt.jpg` | Truncated/invalid bytes — `extractExif` must reject gracefully |
+| `heic.heic` | Real HEIC — rejected at MIME-type gate ([ADR-006](../../../../../docs/photo-map-culling/decisions.md#adr-006--no-heic-support-in-v1)) |
+| `mislabeled.jpg` | HEIC bytes with a `.jpg` extension — rejected by content sniff, not extension |
+
+These are **not** generated yet. Phase 1 will create them as part of
+writing the `extractExif`/`generateThumb` tests, using a small Node
+generator script that writes valid EXIF segments into minimal JPEGs.
+Generator approach to evaluate:
+
+- `piexifjs` (write EXIF to existing JPEG)
+- Manual JPEG byte construction (no deps, fully reproducible)
+- Repurpose `exifr`'s own test fixtures (if license-compatible)
+
+## What NOT to put here
+
+- The sample `RIMG*.JPG` photos at repo root — they're real Czech GPS
+  coordinates, used only for one-off manual verification (see
+  `scripts/verify-exif.mjs`). They are intentionally untracked.
+- Anything with PII or copyright concerns.

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -36,6 +36,8 @@ import {
   Map,
 } from '@mui/icons-material';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
+import { useMapPicksSync } from './hooks/useMapPicksSync';
+import { getStorage, type DirectoryHandle } from '@airq/shared-storage';
 import { GridSizedDropZone } from './components/GridSizedDropZone';
 import { PhotoGridApi } from './components/PhotoGridApi';
 import { EditableHeading } from './components/EditableHeading';
@@ -98,6 +100,7 @@ function AppApi() {
     isDesktopManaged,
     // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
     addPhotosToCandidates,
+    addExistingCandidate,
     removeCandidate,
     promoteCandidateToSlot,
     demoteSlotToCandidate,
@@ -109,6 +112,47 @@ function AppApi() {
   // Candidate photos — derived from session for stable rendering. The pool
   // is optional on older sessions, so default to empty.
   const candidatePhotos: ApiPhoto[] = session?.candidates?.photos ?? [];
+
+  // Phase 8b of photo-map-culling — resolve the per-competition dirs
+  // and mount the map-picks sync hook. The dirs come from the OPFS
+  // layout `competitions/{compId}/{photos,}`; matches map-corridors'
+  // useCorridorSessionOPFS resolution, so the writer + reader agree
+  // on paths.
+  const [pmcCompetitionDir, setPmcCompetitionDir] = useState<DirectoryHandle | null>(null);
+  const [pmcPhotosDir, setPmcPhotosDir] = useState<DirectoryHandle | null>(null);
+  const pmcCompetitionId = currentCompetition?.id ?? null;
+  useEffect(() => {
+    let cancelled = false;
+    if (!pmcCompetitionId) {
+      setPmcCompetitionDir(null);
+      setPmcPhotosDir(null);
+      return;
+    }
+    void (async () => {
+      try {
+        const storage = getStorage();
+        const handles = await storage.init();
+        const competitionsDir = await storage.getDirectoryHandle(handles.root, 'competitions', { create: true });
+        const compDir = await storage.getDirectoryHandle(competitionsDir, pmcCompetitionId, { create: true });
+        const photosDir = await storage.getDirectoryHandle(compDir, 'photos', { create: true });
+        if (cancelled) return;
+        setPmcCompetitionDir(compDir);
+        setPmcPhotosDir(photosDir);
+      } catch (err) {
+        console.warn('[AppApi] failed to resolve photo-map-culling dirs:', err);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [pmcCompetitionId]);
+
+  const pmcSessionApi = useMemo(() => ({
+    candidates: candidatePhotos,
+    addCandidate: addExistingCandidate,
+    removeCandidate,
+    setCandidateFlag,
+  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag]);
+
+  useMapPicksSync(pmcCompetitionDir, pmcPhotosDir, pmcSessionApi);
 
   // Session identifiers and storage stats come from the OPFS-backed
   // useCompetitionSystem hook — no network round-trip, so availability is

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -37,6 +37,11 @@ import {
 } from '@mui/icons-material';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
 import { useMapPicksSync } from './hooks/useMapPicksSync';
+import {
+  buildEditorPicks,
+  flushPendingEditorPicks,
+  scheduleWriteEditorPicks,
+} from './handoff/editorPicksWriter';
 import { getStorage, type DirectoryHandle } from '@airq/shared-storage';
 import { GridSizedDropZone } from './components/GridSizedDropZone';
 import { PhotoGridApi } from './components/PhotoGridApi';
@@ -105,6 +110,7 @@ function AppApi() {
     promoteCandidateToSlot,
     demoteSlotToCandidate,
     setCandidateFlag,
+    setCandidateLabel,
     updateCandidatePhotoState,
     deleteCandidates,
   } = sessionHookResult;
@@ -150,9 +156,30 @@ function AppApi() {
     addCandidate: addExistingCandidate,
     removeCandidate,
     setCandidateFlag,
-  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag]);
+    setCandidateLabel,
+  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag, setCandidateLabel]);
 
   useMapPicksSync(pmcCompetitionDir, pmcPhotosDir, pmcSessionApi);
+
+  // Phase B — write photo-helper-picks.json on every candidate change so
+  // map-corridors picks up label edits made in this app. Debounced 300ms
+  // by the writer; pagehide flushes best-effort.
+  useEffect(() => {
+    if (!pmcCompetitionDir) return;
+    try {
+      const storage = getStorage();
+      const picks = buildEditorPicks(candidatePhotos);
+      scheduleWriteEditorPicks(storage, pmcCompetitionDir, picks);
+    } catch (err) {
+      console.warn('[AppApi] scheduleWriteEditorPicks failed:', err);
+    }
+  }, [candidatePhotos, pmcCompetitionDir]);
+
+  useEffect(() => {
+    const onPageHide = () => { void flushPendingEditorPicks(); };
+    window.addEventListener('pagehide', onPageHide);
+    return () => window.removeEventListener('pagehide', onPageHide);
+  }, []);
 
   // Session identifiers and storage stats come from the OPFS-backed
   // useCompetitionSystem hook — no network round-trip, so availability is

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -126,12 +126,18 @@ function AppApi() {
   // on paths.
   const [pmcCompetitionDir, setPmcCompetitionDir] = useState<DirectoryHandle | null>(null);
   const [pmcPhotosDir, setPmcPhotosDir] = useState<DirectoryHandle | null>(null);
+  // Sticky banner shown when cross-app dir resolution fails (OPFS unavailable,
+  // permission revoked, transient I/O during init). Without it the editor
+  // looks normal but the map → editor handoff is silently dead for the
+  // session.
+  const [pmcSyncUnavailable, setPmcSyncUnavailable] = useState(false);
   const pmcCompetitionId = currentCompetition?.id ?? null;
   useEffect(() => {
     let cancelled = false;
     if (!pmcCompetitionId) {
       setPmcCompetitionDir(null);
       setPmcPhotosDir(null);
+      setPmcSyncUnavailable(false);
       return;
     }
     void (async () => {
@@ -144,8 +150,10 @@ function AppApi() {
         if (cancelled) return;
         setPmcCompetitionDir(compDir);
         setPmcPhotosDir(photosDir);
+        setPmcSyncUnavailable(false);
       } catch (err) {
         console.warn('[AppApi] failed to resolve photo-map-culling dirs:', err);
+        if (!cancelled) setPmcSyncUnavailable(true);
       }
     })();
     return () => { cancelled = true; };
@@ -823,6 +831,15 @@ function AppApi() {
             }
           >
             {error}
+          </Alert>
+        )}
+
+        {/* Photo-map-culling handoff unavailable — surfaces the previously
+            silent dir-resolution failure (cross-app sync would otherwise
+            quietly miss every pick made in map-corridors). */}
+        {pmcSyncUnavailable && (
+          <Alert severity="warning" sx={{ mb: 3 }}>
+            {t('candidates.handoff.unavailable')}
           </Alert>
         )}
 

--- a/frontend/photo-helper/src/__tests__/editorPicksWriter.test.ts
+++ b/frontend/photo-helper/src/__tests__/editorPicksWriter.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { ApiPhoto } from '../types/api'
+import {
+  buildEditorPicks,
+  scheduleWriteEditorPicks,
+  flushPendingEditorPicks,
+  _resetEditorPicksWriterForTests,
+  type EditorPicksFile,
+} from '../handoff/editorPicksWriter'
+
+function photo(over: Partial<ApiPhoto> = {}): ApiPhoto {
+  return {
+    id: 'pm-1', sessionId: '', url: 'blob:x', filename: 'a.jpg',
+    canvasState: {
+      position: { x: 0, y: 0 }, scale: 1, brightness: 0, contrast: 1, sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    },
+    label: '',
+    ...over,
+  }
+}
+
+describe('buildEditorPicks', () => {
+  it('skips photos without pm- prefix (photo-helper-originated)', () => {
+    expect(buildEditorPicks([photo({ id: 'photo-helper-own', label: 'A', labelUpdatedAt: 'x' })])).toEqual([])
+  })
+
+  it('skips photos without labelUpdatedAt (can\'t resolve conflicts without a timestamp)', () => {
+    expect(buildEditorPicks([photo({ id: 'pm-abc', label: 'A' })])).toEqual([])
+  })
+
+  it('emits photoId, label, labelUpdatedAt for pm- photos that have been labelled', () => {
+    const result = buildEditorPicks([photo({
+      id: 'pm-abc', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
+    })])
+    expect(result).toEqual([{
+      photoId: 'pm-abc', label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
+    }])
+  })
+
+  it('treats empty-string label as a deliberate value (clear), still emits if labelUpdatedAt is set', () => {
+    const result = buildEditorPicks([photo({
+      id: 'pm-abc', label: '', labelUpdatedAt: '2024-01-01T00:00:00Z',
+    })])
+    expect(result).toEqual([{ photoId: 'pm-abc', label: '', labelUpdatedAt: '2024-01-01T00:00:00Z' }])
+  })
+})
+
+describe('scheduleWriteEditorPicks — debounce', () => {
+  let storage: { writeJSON: Mock }
+  let dir: DirectoryHandle
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn().mockResolvedValue(undefined) }
+    dir = { path: '/competitions/c-1' }
+    _resetEditorPicksWriterForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetEditorPicksWriterForTests()
+  })
+
+  it('does not write before 300 ms elapse', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [])
+    await vi.advanceTimersByTimeAsync(299)
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+  })
+
+  it('writes once after 300 ms', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces — latest data wins', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pm-1', label: 'A', labelUpdatedAt: 't1' },
+    ])
+    await vi.advanceTimersByTimeAsync(100)
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [
+      { photoId: 'pm-1', label: 'B', labelUpdatedAt: 't2' },
+    ])
+    await vi.advanceTimersByTimeAsync(300)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+    const file = storage.writeJSON.mock.calls[0][2] as EditorPicksFile
+    expect(file.picks[0].label).toBe('B')
+  })
+
+  it('writes to photo-helper-picks.json with version=1 + ISO updatedAt', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [])
+    await vi.advanceTimersByTimeAsync(300)
+    const [actualDir, actualName, file] = storage.writeJSON.mock.calls[0]
+    expect(actualDir).toBe(dir)
+    expect(actualName).toBe('photo-helper-picks.json')
+    expect((file as EditorPicksFile).version).toBe(1)
+    expect(typeof (file as EditorPicksFile).updatedAt).toBe('string')
+  })
+})
+
+describe('flushPendingEditorPicks', () => {
+  let storage: { writeJSON: Mock }
+  let dir: DirectoryHandle
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    storage = { writeJSON: vi.fn().mockResolvedValue(undefined) }
+    dir = { path: '/competitions/c-1' }
+    _resetEditorPicksWriterForTests()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    _resetEditorPicksWriterForTests()
+  })
+
+  it('executes the pending write immediately', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [])
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+    await flushPendingEditorPicks()
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op when nothing pending', async () => {
+    await expect(flushPendingEditorPicks()).resolves.toBeUndefined()
+    expect(storage.writeJSON).not.toHaveBeenCalled()
+  })
+
+  it('cancels the debounce timer — no second write fires', async () => {
+    scheduleWriteEditorPicks(storage as unknown as StorageInterface, dir, [])
+    await flushPendingEditorPicks()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(storage.writeJSON).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -37,6 +37,7 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   addCandidate: Mock
   removeCandidate: Mock
   setCandidateFlag: Mock
+  setCandidateLabel: Mock
 } {
   const candidates = [...initialCandidates]
   const api = {
@@ -50,8 +51,20 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
       const found = candidates.find(p => p.id === id)
       if (found) found.flag = flag
     }),
+    setCandidateLabel: vi.fn(async (id: string, label: string) => {
+      const found = candidates.find(p => p.id === id)
+      if (found) {
+        found.label = label
+        found.labelUpdatedAt = new Date().toISOString()
+      }
+    }),
   }
-  return api as MapPicksSyncSessionApi & { addCandidate: Mock; removeCandidate: Mock; setCandidateFlag: Mock }
+  return api as MapPicksSyncSessionApi & {
+    addCandidate: Mock
+    removeCandidate: Mock
+    setCandidateFlag: Mock
+    setCandidateLabel: Mock
+  }
 }
 
 function pmEntry(id: string, flag: 'pick' | 'neutral' | 'reject' = 'pick') {
@@ -199,6 +212,107 @@ describe('syncMapPicksOnce — update path', () => {
     const session = fakeSession([existing('pm-abc', 'pick')])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.addCandidate).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncMapPicksOnce — label sync (bidirectional)', () => {
+  it('propagates label on insert', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-new', filename: 'a.jpg', flag: 'pick',
+        label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
+      }],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
+    const session = fakeSession([])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.addCandidate).toHaveBeenCalledTimes(1)
+    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
+    expect(inserted.label).toBe('A')
+    expect(inserted.labelUpdatedAt).toBe('2024-01-01T00:00:00Z')
+  })
+
+  it('updates label when remote labelUpdatedAt is newer than local', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z',
+      }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const session = fakeSession([local])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', 'B')
+  })
+
+  it('keeps local label when local labelUpdatedAt is newer (local-wins on edits-in-flight)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
+      }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z' }
+    const session = fakeSession([local])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateLabel).not.toHaveBeenCalled()
+  })
+
+  it('tie-break: equal timestamps → local wins (no update)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
+      }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'B', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const session = fakeSession([local])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateLabel).not.toHaveBeenCalled()
+  })
+
+  it('applies remote label when local has no labelUpdatedAt (legacy data)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        label: 'C', labelUpdatedAt: '2024-01-01T00:00:00Z',
+      }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A' }
+    const session = fakeSession([local])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', 'C')
+  })
+
+  it('propagates a label CLEAR (empty string) when remote is newer', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        label: '', labelUpdatedAt: '2024-02-01T00:00:00Z',
+      }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const session = fakeSession([local])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', '')
   })
 })
 

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import {
+  syncMapPicksOnce,
+  type MapPicksSyncSessionApi,
+} from '../hooks/useMapPicksSync'
+import type { ApiPhoto } from '../types/api'
+
+// jsdom shim for URL.createObjectURL (used by syncMapPicksOnce on insert)
+beforeEach(() => {
+  if (!('createObjectURL' in URL)) {
+    (URL as unknown as { createObjectURL: () => string }).createObjectURL = () => 'blob:fake'
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+const competitionDir: DirectoryHandle = { path: '/competitions/comp-1' }
+const photosDir: DirectoryHandle = { path: '/competitions/comp-1/photos' }
+
+interface FakeStorage extends Pick<StorageInterface, 'readJSON' | 'getPhotoBlob'> {
+  readJSON: Mock
+  getPhotoBlob: Mock
+}
+
+function fakeStorage(): FakeStorage {
+  return {
+    readJSON: vi.fn(),
+    getPhotoBlob: vi.fn(),
+  }
+}
+
+function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi & {
+  addCandidate: Mock
+  removeCandidate: Mock
+  setCandidateFlag: Mock
+} {
+  const candidates = [...initialCandidates]
+  const api = {
+    candidates,
+    addCandidate: vi.fn(async (p: ApiPhoto) => { candidates.push(p) }),
+    removeCandidate: vi.fn(async (id: string) => {
+      const idx = candidates.findIndex(p => p.id === id)
+      if (idx >= 0) candidates.splice(idx, 1)
+    }),
+    setCandidateFlag: vi.fn(async (id: string, flag: ApiPhoto['flag']) => {
+      const found = candidates.find(p => p.id === id)
+      if (found) found.flag = flag
+    }),
+  }
+  return api as MapPicksSyncSessionApi & { addCandidate: Mock; removeCandidate: Mock; setCandidateFlag: Mock }
+}
+
+function pmEntry(id: string, flag: 'pick' | 'neutral' | 'reject' = 'pick') {
+  return { photoId: id, filename: `${id}.jpg`, flag }
+}
+
+function existing(id: string, flag: ApiPhoto['flag'] = 'neutral'): ApiPhoto {
+  return {
+    id,
+    sessionId: 's',
+    url: 'blob:existing',
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 },
+      scale: 1,
+      brightness: 0,
+      contrast: 1,
+      sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false },
+      labelPosition: 'bottom-left',
+    },
+    label: '',
+    flag,
+  }
+}
+
+describe('syncMapPicksOnce — file absence', () => {
+  it('returns zero counts when map-picks.json is missing', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue(null)
+    const session = fakeSession()
+    const result = await syncMapPicksOnce(
+      storage as unknown as StorageInterface,
+      competitionDir,
+      photosDir,
+      session,
+    )
+    expect(result).toEqual({ inserts: 0, updates: 0, deletes: 0 })
+    expect(session.addCandidate).not.toHaveBeenCalled()
+    expect(session.removeCandidate).not.toHaveBeenCalled()
+  })
+
+  it('does NOT delete pool entries when the file is missing (absence ≠ empty)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue(null)
+    const session = fakeSession([existing('pm-abc', 'pick')])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.removeCandidate).not.toHaveBeenCalled()
+  })
+
+  it('treats malformed payload (missing picks[]) as no-op', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({ version: 1, updatedAt: 'x' })
+    const session = fakeSession([existing('pm-abc')])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.deletes).toBe(0)
+  })
+})
+
+describe('syncMapPicksOnce — insert path', () => {
+  it('inserts a new pm- entry not yet in the pool', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-new', 'pick')],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(32)], { type: 'image/jpeg' }))
+    const session = fakeSession([])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(1)
+    expect(session.addCandidate).toHaveBeenCalledTimes(1)
+    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
+    expect(inserted.id).toBe('pm-new')
+    expect(inserted.filename).toBe('pm-new.jpg')
+    expect(inserted.flag).toBe('pick')
+    expect(inserted.canvasState.scale).toBe(1) // matches createDefaultCanvasState
+  })
+
+  it('skips insert when the photo blob is missing (orphan entry)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-orphan')],
+    })
+    storage.getPhotoBlob.mockRejectedValue(new Error('NotFoundError'))
+    const session = fakeSession([])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(0)
+    expect(session.addCandidate).not.toHaveBeenCalled()
+  })
+
+  it('ignores entries WITHOUT the pm- prefix (photo-helper-originated)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{ photoId: 'photo-from-helper', filename: 'a.jpg', flag: 'pick' as const }],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([]))
+    const session = fakeSession([])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(0)
+    expect(session.addCandidate).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncMapPicksOnce — update path', () => {
+  it('updates flag on a pm- entry already in the pool', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-abc', 'pick')],
+    })
+    const session = fakeSession([existing('pm-abc', 'neutral')])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.updates).toBe(1)
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick')
+  })
+
+  it('does NOT call setCandidateFlag when flag is unchanged', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-abc', 'pick')],
+    })
+    const session = fakeSession([existing('pm-abc', 'pick')])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.updates).toBe(0)
+    expect(session.setCandidateFlag).not.toHaveBeenCalled()
+  })
+
+  it('preserves photo-helper-owned fields on update (only flag is touched)', async () => {
+    // Verified indirectly: we only call setCandidateFlag, never addCandidate
+    // or any path that would clobber canvasState / label / url.
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-abc', 'reject')],
+    })
+    const session = fakeSession([existing('pm-abc', 'pick')])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.addCandidate).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
+  it('removes pool entries whose pm- photoId disappeared from the file', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [], // map-corridors has nothing left
+    })
+    const session = fakeSession([existing('pm-stale')])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.deletes).toBe(1)
+    expect(session.removeCandidate).toHaveBeenCalledWith('pm-stale')
+  })
+
+  it('NEVER removes photo-helper-originated entries (no pm- prefix)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({ version: 1, updatedAt: 'x', picks: [] })
+    const session = fakeSession([existing('photo-helper-owned')])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.removeCandidate).not.toHaveBeenCalled()
+  })
+
+  it('mixed: insert one, update one, delete one in a single pass', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [
+        pmEntry('pm-new', 'pick'),
+        pmEntry('pm-existing', 'reject'), // currently neutral
+        // 'pm-going-away' is in the pool but not here
+      ],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([]))
+    const session = fakeSession([
+      existing('pm-existing', 'neutral'),
+      existing('pm-going-away'),
+      existing('photo-helper-owned'), // must survive
+    ])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(1)
+    expect(result.updates).toBe(1)
+    expect(result.deletes).toBe(1)
+    expect(session.removeCandidate).toHaveBeenCalledWith('pm-going-away')
+    expect(session.removeCandidate).not.toHaveBeenCalledWith('photo-helper-owned')
+  })
+})

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -151,11 +151,34 @@ describe('syncMapPicksOnce — insert path', () => {
       updatedAt: 'x',
       picks: [pmEntry('pm-orphan')],
     })
-    storage.getPhotoBlob.mockRejectedValue(new Error('NotFoundError'))
+    const notFound = Object.assign(new Error('thumb gone'), { name: 'NotFoundError' })
+    storage.getPhotoBlob.mockRejectedValue(notFound)
     const session = fakeSession([])
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.inserts).toBe(0)
     expect(session.addCandidate).not.toHaveBeenCalled()
+  })
+
+  it('skips insert (no throw) when getPhotoBlob throws a NON-NotFoundError — degraded storage must not crash sync', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-deny'), pmEntry('pm-ok')],
+    })
+    const denied = Object.assign(new Error('permission denied'), { name: 'SecurityError' })
+    const okBlob = new Blob([new Uint8Array(8)], { type: 'image/jpeg' })
+    storage.getPhotoBlob
+      .mockRejectedValueOnce(denied)        // pm-deny
+      .mockResolvedValueOnce(okBlob)        // pm-ok still inserts
+    const session = fakeSession([])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(1)
+    expect(session.addCandidate).toHaveBeenCalledTimes(1)
+    expect(session.addCandidate.mock.calls[0][0].id).toBe('pm-ok')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 
   it('ignores entries WITHOUT the pm- prefix (photo-helper-originated)', async () => {
@@ -313,6 +336,64 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', '')
+  })
+})
+
+describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs fixed)', () => {
+  it('does NOT double-insert when the same pm-id appears twice in the file (one createObjectURL call only)', async () => {
+    // Defensive: a torn writer could repeat an entry. The local index must
+    // be updated as we insert so the second occurrence sees the existing
+    // photo and skips the createObjectURL path.
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-dup', 'pick'), pmEntry('pm-dup', 'pick')],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
+    let createUrlCount = 0
+    ;(URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL = () => {
+      createUrlCount++
+      return `blob:n${createUrlCount}`
+    }
+    const session = fakeSession([])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(1)
+    expect(session.addCandidate).toHaveBeenCalledTimes(1)
+    expect(createUrlCount).toBe(1)
+  })
+
+  it('does NOT delete a freshly-inserted entry in the same pass (cleanup iterates LIVE index, not the stale snapshot)', async () => {
+    // The cleanup pass used to iterate `session.candidates` — a snapshot
+    // captured at hook-call time. A pm- entry inserted earlier in the
+    // pass but absent from the snapshot would then be immediately deleted.
+    // Reproducible with a session whose `candidates` array does not
+    // reflect addCandidate calls synchronously.
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-new', 'pick')],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
+    // session.candidates frozen at [] — addCandidate does NOT append to it.
+    // This models the photo-helper React snapshot semantics where the live
+    // `candidates` array passed in is unchanged mid-pass.
+    const session = {
+      candidates: [] as readonly ApiPhoto[],
+      addCandidate: vi.fn(async () => undefined),
+      removeCandidate: vi.fn(async () => undefined),
+      setCandidateFlag: vi.fn(async () => undefined),
+      setCandidateLabel: vi.fn(async () => undefined),
+    }
+    const result = await syncMapPicksOnce(
+      storage as unknown as StorageInterface,
+      competitionDir, photosDir,
+      session as unknown as MapPicksSyncSessionApi,
+    )
+    expect(result.inserts).toBe(1)
+    expect(result.deletes).toBe(0)
+    expect(session.removeCandidate).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/photo-helper/src/handoff/editorPicksWriter.ts
+++ b/frontend/photo-helper/src/handoff/editorPicksWriter.ts
@@ -1,0 +1,117 @@
+// Phase B of bidirectional label sync — photo-helper's writer for
+// the `photo-helper-picks.json` mirror file. Symmetric to map-corridors'
+// mapPicksWriter.ts. Map-corridors reads this file on visibilitychange
+// via useEditorPicksSync.
+//
+// Single writer, 300 ms debounce, serialized I/O. Tracks label per
+// `pm-`-prefixed candidate so map-corridors' conflict resolution can
+// decide newer-wins.
+
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage';
+import type { ApiPhoto } from '../types/api';
+
+const FILENAME = 'photo-helper-picks.json';
+const DEBOUNCE_MS = 300;
+const PM_PREFIX = 'pm-';
+
+export interface EditorPickEntry {
+  photoId: string;
+  /** Empty string = explicit clear. Same idiom as ApiPhoto.label. */
+  label: string;
+  /** ISO 8601 — present when label has ever been set in either app. */
+  labelUpdatedAt: string;
+}
+
+export interface EditorPicksFile {
+  version: 1;
+  updatedAt: string;
+  picks: EditorPickEntry[];
+}
+
+/**
+ * Project the candidate pool into the cross-app file. Only `pm-`-prefixed
+ * photos appear — photo-helper-originated photos stay in the editor and
+ * never propagate to map-corridors. Photos without `labelUpdatedAt` are
+ * skipped — without the timestamp the map side can't resolve conflicts.
+ */
+export function buildEditorPicks(candidates: readonly ApiPhoto[]): EditorPickEntry[] {
+  const out: EditorPickEntry[] = [];
+  for (const p of candidates) {
+    if (!p.id.startsWith(PM_PREFIX)) continue;
+    if (!p.labelUpdatedAt) continue;
+    out.push({
+      photoId: p.id,
+      label: p.label ?? '',
+      labelUpdatedAt: p.labelUpdatedAt,
+    });
+  }
+  return out;
+}
+
+type Pending = {
+  timer: ReturnType<typeof setTimeout>;
+  storage: StorageInterface;
+  dir: DirectoryHandle;
+  picks: EditorPickEntry[];
+};
+let pending: Pending | null = null;
+let inFlight: Promise<void> = Promise.resolve();
+
+function executeWrite(
+  storage: StorageInterface,
+  dir: DirectoryHandle,
+  picks: EditorPickEntry[],
+): Promise<void> {
+  const file: EditorPicksFile = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    picks,
+  };
+  inFlight = inFlight.then(() =>
+    storage.writeJSON(dir, FILENAME, file).catch(err => {
+      console.error('[editorPicks] writeJSON failed:', err);
+    }),
+  );
+  return inFlight;
+}
+
+/**
+ * Schedule a debounced write. Latest call wins; rapid label edits
+ * (e.g., the user tabs through letters) coalesce into one disk write.
+ */
+export function scheduleWriteEditorPicks(
+  storage: StorageInterface,
+  dir: DirectoryHandle,
+  picks: EditorPickEntry[],
+): void {
+  if (pending) clearTimeout(pending.timer);
+  const timer = setTimeout(() => {
+    const p = pending;
+    pending = null;
+    if (!p) return;
+    void executeWrite(p.storage, p.dir, p.picks);
+  }, DEBOUNCE_MS);
+  pending = { timer, storage, dir, picks };
+}
+
+/**
+ * Cancel the debounce and execute the pending write immediately. Used
+ * by pagehide listeners and any "switching to map" pre-nav handler so a
+ * just-edited label is durable before the focus changes.
+ */
+export function flushPendingEditorPicks(): Promise<void> {
+  if (!pending) return inFlight;
+  const { timer, storage, dir, picks } = pending;
+  clearTimeout(timer);
+  pending = null;
+  return executeWrite(storage, dir, picks);
+}
+
+/** Test-only — drains the module-level state between tests. */
+export function _resetEditorPicksWriterForTests(): void {
+  if (pending) {
+    clearTimeout(pending.timer);
+    pending = null;
+  }
+  inFlight = Promise.resolve();
+}

--- a/frontend/photo-helper/src/handoff/editorPicksWriter.ts
+++ b/frontend/photo-helper/src/handoff/editorPicksWriter.ts
@@ -55,6 +55,8 @@ type Pending = {
   picks: EditorPickEntry[];
 };
 let pending: Pending | null = null;
+// See mapPicksWriter for the rationale on per-call promises + dir-change
+// flush; the two writers are symmetric.
 let inFlight: Promise<void> = Promise.resolve();
 
 function executeWrite(
@@ -67,40 +69,54 @@ function executeWrite(
     updatedAt: new Date().toISOString(),
     picks,
   };
-  inFlight = inFlight.then(() =>
-    storage.writeJSON(dir, FILENAME, file).catch(err => {
-      console.error('[editorPicks] writeJSON failed:', err);
-    }),
-  );
-  return inFlight;
+  const currentPromise = inFlight
+    .catch(() => undefined)
+    .then(() => storage.writeJSON(dir, FILENAME, file));
+  inFlight = currentPromise;
+  return currentPromise;
 }
 
 /**
  * Schedule a debounced write. Latest call wins; rapid label edits
  * (e.g., the user tabs through letters) coalesce into one disk write.
+ * On (storage, dir) change the pending write is flushed first so it
+ * lands in the correct competition dir.
  */
 export function scheduleWriteEditorPicks(
   storage: StorageInterface,
   dir: DirectoryHandle,
   picks: EditorPickEntry[],
 ): void {
-  if (pending) clearTimeout(pending.timer);
+  if (pending) {
+    const dirChanged = pending.storage !== storage || pending.dir !== dir;
+    clearTimeout(pending.timer);
+    if (dirChanged) {
+      const stale = pending;
+      pending = null;
+      void executeWrite(stale.storage, stale.dir, stale.picks).catch(err => {
+        console.error('[editorPicks] flush-on-dir-change failed:', err);
+      });
+    }
+  }
   const timer = setTimeout(() => {
     const p = pending;
     pending = null;
     if (!p) return;
-    void executeWrite(p.storage, p.dir, p.picks);
+    void executeWrite(p.storage, p.dir, p.picks).catch(err => {
+      console.error('[editorPicks] debounced writeJSON failed:', err);
+    });
   }, DEBOUNCE_MS);
   pending = { timer, storage, dir, picks };
 }
 
 /**
- * Cancel the debounce and execute the pending write immediately. Used
- * by pagehide listeners and any "switching to map" pre-nav handler so a
- * just-edited label is durable before the focus changes.
+ * Cancel the debounce and execute the pending write immediately. Returns
+ * a Promise resolving/rejecting for THIS write so callers (the symmetric
+ * pre-nav handler in AppApi) can surface a snackbar on failure instead
+ * of navigating away from a never-written file.
  */
 export function flushPendingEditorPicks(): Promise<void> {
-  if (!pending) return inFlight;
+  if (!pending) return Promise.resolve();
   const { timer, storage, dir, picks } = pending;
   clearTimeout(timer);
   pending = null;

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -80,6 +80,14 @@ export interface UseCompetitionSystemResult {
   promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
   demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
   setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void>;
+  /**
+   * Set or clear a candidate's label. Stamps `labelUpdatedAt = now()`
+   * so the cross-app sync can decide newer-wins against map-corridors'
+   * `map-picks.json`. Empty string is an explicit clear (vs. undefined
+   * which means "no change" — but the API uses the empty-string idiom
+   * to keep `ApiPhoto.label: string` non-nullable).
+   */
+  setCandidateLabel: (photoId: string, label: string) => Promise<void>;
   updateCandidatePhotoState: (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => Promise<void>;
   /**
    * Delete a specific subset of candidate ids — session entries removed AND
@@ -796,6 +804,19 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     await updateCurrentCompetition(session => setCandidateFlagPure(session, photoId, flag));
   }, [updateCurrentCompetition]);
 
+  // Phase A of bidirectional label sync. Stamps labelUpdatedAt so
+  // useEditorPicksSync on the map side can decide newer-wins against
+  // its own marker.labelUpdatedAt. Empty string = explicit clear.
+  const setCandidateLabel = useCallback(async (photoId: string, label: string) => {
+    await updateCurrentCompetition(session => {
+      const existing = session.candidates?.photos ?? [];
+      const next = existing.map(p => p.id === photoId
+        ? { ...p, label, labelUpdatedAt: new Date().toISOString() }
+        : p);
+      return { ...session, candidates: { photos: next } };
+    });
+  }, [updateCurrentCompetition]);
+
   const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     await updateCurrentCompetition(session => updateCandidateCanvasStatePure(session, photoId, canvasState));
   }, [updateCurrentCompetition]);
@@ -1322,6 +1343,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     promoteCandidateToSlot,
     demoteSlotToCandidate,
     setCandidateFlag,
+    setCandidateLabel,
     updateCandidatePhotoState,
     deleteCandidates,
     clearAllCandidates,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -68,6 +68,14 @@ export interface UseCompetitionSystemResult {
 
   // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
   addPhotosToCandidates: (files: File[]) => Promise<void>;
+  /**
+   * Insert a pre-built `ApiPhoto` (bytes + thumb already on disk).
+   * Used by `useMapPicksSync` (Phase 8b of photo-map-culling) to
+   * project map-corridors picks into the candidate pool without
+   * re-uploading. Idempotent — replaces if `photo.id` already exists
+   * to avoid duplicates on visibility-change re-syncs.
+   */
+  addExistingCandidate: (photo: ApiPhoto) => Promise<void>;
   removeCandidate: (photoId: string) => Promise<void>;
   promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
   demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
@@ -556,6 +564,30 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       };
     }, { updatePhotos: true });
   }, [updateCurrentCompetition, currentCompetition, filesToPhotos, t]);
+
+  /**
+   * Insert / replace a pre-built ApiPhoto. The bytes live in OPFS at
+   * `competitions/{compId}/photos/{photoId}` already (writer side is
+   * map-corridors' importPhotosToStorage). We only mutate the session
+   * JSON. Idempotent by `photo.id` so re-syncs from useMapPicksSync
+   * don't duplicate.
+   */
+  const addExistingCandidate = useCallback(async (photo: ApiPhoto) => {
+    if (!currentCompetition?.session) return;
+    await updateCurrentCompetition(session => {
+      const existing = session.candidates?.photos ?? [];
+      const filtered = existing.filter(p => p.id !== photo.id);
+      // Preserve sessionId so the photo is consistent with the rest of
+      // the pool (the caller often doesn't know it).
+      const normalized: ApiPhoto = { ...photo, sessionId: session.id };
+      return {
+        ...session,
+        version: session.version + 1,
+        updatedAt: new Date().toISOString(),
+        candidates: { photos: [...filtered, normalized] },
+      };
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition, currentCompetition]);
 
   const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2'): Promise<AddPhotosResult> => {
     if (!currentCompetition?.session) {
@@ -1285,6 +1317,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
 
     // Candidate pool surface
     addPhotosToCandidates,
+    addExistingCandidate,
     removeCandidate,
     promoteCandidateToSlot,
     demoteSlotToCandidate,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -584,6 +584,20 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     if (!currentCompetition?.session) return;
     await updateCurrentCompetition(session => {
       const existing = session.candidates?.photos ?? [];
+      // Revoke the displaced photo's blob URL before dropping its
+      // reference. Without this, every re-sync of the same id (the
+      // common case in the bidirectional handoff) leaks one URL per
+      // visibility-change. The check guards against same-URL reuse and
+      // non-blob URLs (data: / http: from older session shapes).
+      const previous = existing.find(p => p.id === photo.id);
+      if (
+        previous &&
+        previous.url &&
+        previous.url !== photo.url &&
+        previous.url.startsWith('blob:')
+      ) {
+        try { URL.revokeObjectURL(previous.url); } catch { /* best-effort */ }
+      }
       const filtered = existing.filter(p => p.id !== photo.id);
       // Preserve sessionId so the photo is consistent with the rest of
       // the pool (the caller often doesn't know it).

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -8,7 +8,7 @@
 // ADR-019 (upsert + delete semantics), ADR-020 (re-import dedup
 // via contentHash — not consumed here, just round-tripped).
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   getStorage,
   type DirectoryHandle,
@@ -88,6 +88,9 @@ export async function syncMapPicksOnce(
   }
 
   const remoteIds = new Set<string>();
+  // Local index of pm-prefixed candidates. Mutated as we insert so a
+  // second pass (or a duplicate entry in the file) sees the just-inserted
+  // photo and doesn't allocate a fresh blob URL for the same id.
   const localById = new Map<string, ApiPhoto>();
   for (const p of session.candidates) localById.set(p.id, p);
 
@@ -96,8 +99,21 @@ export async function syncMapPicksOnce(
     remoteIds.add(entry.photoId);
     const existing = localById.get(entry.photoId);
     if (!existing) {
-      const blob = await storage.getPhotoBlob(photosDir, entry.photoId).catch(() => null);
-      if (!blob) continue; // photo bytes missing; skip silently — re-import in map-corridors would have already failed
+      // Narrow the swallow to NotFoundError — other storage errors
+      // (permission revoked, InvalidStateError) shouldn't silently
+      // collapse into "photo missing".
+      let blob: Blob | null;
+      try {
+        blob = await storage.getPhotoBlob(photosDir, entry.photoId);
+      } catch (err) {
+        if (isNotFoundError(err)) {
+          blob = null;
+        } else {
+          console.warn('[useMapPicksSync] getPhotoBlob failed:', err);
+          continue;
+        }
+      }
+      if (!blob) continue;
       const url = URL.createObjectURL(blob);
       const photo: ApiPhoto = {
         id: entry.photoId,
@@ -110,6 +126,7 @@ export async function syncMapPicksOnce(
         ...(entry.labelUpdatedAt ? { labelUpdatedAt: entry.labelUpdatedAt } : {}),
       };
       await session.addCandidate(photo);
+      localById.set(entry.photoId, photo);
       inserts++;
     } else {
       let touched = false;
@@ -134,8 +151,11 @@ export async function syncMapPicksOnce(
   // Cleanup pass: pool entries with `pm-` prefix that are no longer
   // in the file have been deleted in map-corridors. Photo-helper-
   // originated entries (no prefix) are NEVER touched here — the user
-  // owns those independently.
-  for (const local of session.candidates) {
+  // owns those independently. Iterate the local index (which we've
+  // kept current with inserts) rather than the snapshot we were given,
+  // so a freshly-inserted photo isn't immediately deleted on the same
+  // pass.
+  for (const local of localById.values()) {
     if (!local.id.startsWith(PM_PREFIX)) continue;
     if (remoteIds.has(local.id)) continue;
     await session.removeCandidate(local.id);
@@ -143,6 +163,12 @@ export async function syncMapPicksOnce(
   }
 
   return { inserts, updates, deletes };
+}
+
+function isNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const name = (err as { name?: unknown }).name;
+  return name === 'NotFoundError';
 }
 
 /**
@@ -156,6 +182,15 @@ export function useMapPicksSync(
   photosDir: DirectoryHandle | null,
   session: MapPicksSyncSessionApi,
 ): void {
+  // Mirror `session` into a ref so the visibilitychange-triggered runs
+  // see the LIVE candidates + callbacks. Capturing `session` in the
+  // effect closure would freeze candidates at mount-time, making every
+  // re-sync misidentify already-inserted photos as new (one fresh blob
+  // URL per re-sync, leaking forever) and potentially deleting them in
+  // the cleanup pass.
+  const sessionRef = useRef(session);
+  useEffect(() => { sessionRef.current = session; }, [session]);
+
   useEffect(() => {
     if (!competitionDir || !photosDir) return;
     let cancelled = false;
@@ -163,7 +198,7 @@ export function useMapPicksSync(
       try {
         const storage = getStorage();
         if (cancelled) return;
-        await syncMapPicksOnce(storage, competitionDir, photosDir, session);
+        await syncMapPicksOnce(storage, competitionDir, photosDir, sessionRef.current);
       } catch (err) {
         if (!cancelled) console.warn('[useMapPicksSync] sync failed:', err);
       }
@@ -177,12 +212,5 @@ export function useMapPicksSync(
       cancelled = true;
       document.removeEventListener('visibilitychange', onVis);
     };
-    // `session` is intentionally NOT in the dep list — its members
-    // (candidates array, callbacks) churn every render, which would
-    // re-trigger the effect on every parent state change. The
-    // visibilitychange listener catches catching up on stale data; the
-    // initial run captures the load-time state. ADR-019 acknowledges
-    // last-write-wins reads are safe.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [competitionDir, photosDir]);
 }

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -1,0 +1,165 @@
+// Phase 8b of photo-map-culling — cross-app handoff reader.
+// Counterpart to map-corridors' mapPicksWriter. Reads
+// `competitions/{compId}/map-picks.json` on competition load and on
+// `visibilitychange === 'visible'`, then upserts/deletes the map-
+// originated entries (photoId prefixed `pm-`) in the candidate pool.
+//
+// ADR-005 (one-way file), ADR-017 (flag in map-picks.json only),
+// ADR-019 (upsert + delete semantics), ADR-020 (re-import dedup
+// via contentHash — not consumed here, just round-tripped).
+
+import { useEffect } from 'react';
+import {
+  getStorage,
+  type DirectoryHandle,
+  type StorageInterface,
+} from '@airq/shared-storage';
+import type { ApiPhoto, CandidateFlag } from '../types/api';
+import { createDefaultCanvasState } from './usePhotoSessionOPFS';
+
+const MAP_PICKS_FILENAME = 'map-picks.json';
+
+/** Shape map-corridors writes; mirrored here so we don't depend on map-corridors symbols. */
+export interface MapPickEntry {
+  photoId: string;
+  filename: string;
+  flag: 'pick' | 'neutral' | 'reject';
+  gps?: {
+    capturedAt?: { lng: number; lat: number; altitude?: number; timestamp?: string };
+    subjectAt?: { lng: number; lat: number };
+  };
+  label?: string;
+}
+
+interface MapPicksFile {
+  version: 1;
+  updatedAt: string;
+  picks: MapPickEntry[];
+}
+
+/**
+ * Minimal session contract this hook needs to mutate the candidate
+ * pool. AppApi provides an adapter wrapping the active session hook;
+ * the indirection keeps useMapPicksSync agnostic to which photo-helper
+ * session impl (useCompetitionSystem vs usePhotoSessionOPFS) is wired.
+ */
+export interface MapPicksSyncSessionApi {
+  candidates: readonly ApiPhoto[];
+  /** Insert a pre-built ApiPhoto. Called for `pm-` entries not yet in the pool. */
+  addCandidate: (photo: ApiPhoto) => Promise<void> | void;
+  /** Remove a candidate by id. Called when a `pm-` entry disappears from map-picks.json. */
+  removeCandidate: (photoId: string) => Promise<void> | void;
+  /** Update flag in place; preserves canvasState + photo-helper-owned fields. */
+  setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void> | void;
+}
+
+const PM_PREFIX = 'pm-';
+
+/**
+ * Reusable side-effect: read map-picks.json, project entries into the
+ * candidate pool. Exported (not just the hook) so tests + a future
+ * one-shot integration can call it without React. Returns the number
+ * of writes performed (inserts + updates + deletes) — useful for
+ * progress/debug logging.
+ */
+export async function syncMapPicksOnce(
+  storage: StorageInterface,
+  competitionDir: DirectoryHandle,
+  photosDir: DirectoryHandle,
+  session: MapPicksSyncSessionApi,
+): Promise<{ inserts: number; updates: number; deletes: number }> {
+  let inserts = 0;
+  let updates = 0;
+  let deletes = 0;
+
+  const file = await storage.readJSON<MapPicksFile>(competitionDir, MAP_PICKS_FILENAME);
+  if (!file || !Array.isArray(file.picks)) {
+    // Absent or malformed file → nothing to sync. Don't delete pool
+    // entries either; an absent file is "no info", not "no picks".
+    return { inserts, updates, deletes };
+  }
+
+  const remoteIds = new Set<string>();
+  const localById = new Map<string, ApiPhoto>();
+  for (const p of session.candidates) localById.set(p.id, p);
+
+  for (const entry of file.picks) {
+    if (!entry.photoId || !entry.photoId.startsWith(PM_PREFIX)) continue;
+    remoteIds.add(entry.photoId);
+    const existing = localById.get(entry.photoId);
+    if (!existing) {
+      const blob = await storage.getPhotoBlob(photosDir, entry.photoId).catch(() => null);
+      if (!blob) continue; // photo bytes missing; skip silently — re-import in map-corridors would have already failed
+      const url = URL.createObjectURL(blob);
+      const photo: ApiPhoto = {
+        id: entry.photoId,
+        sessionId: '', // populated lazily by session hook on next persist
+        url,
+        filename: entry.filename,
+        canvasState: createDefaultCanvasState(),
+        label: '',
+        flag: entry.flag,
+      };
+      await session.addCandidate(photo);
+      inserts++;
+    } else if (existing.flag !== entry.flag) {
+      await session.setCandidateFlag(entry.photoId, entry.flag);
+      updates++;
+    }
+  }
+
+  // Cleanup pass: pool entries with `pm-` prefix that are no longer
+  // in the file have been deleted in map-corridors. Photo-helper-
+  // originated entries (no prefix) are NEVER touched here — the user
+  // owns those independently.
+  for (const local of session.candidates) {
+    if (!local.id.startsWith(PM_PREFIX)) continue;
+    if (remoteIds.has(local.id)) continue;
+    await session.removeCandidate(local.id);
+    deletes++;
+  }
+
+  return { inserts, updates, deletes };
+}
+
+/**
+ * React hook wrapper. Runs `syncMapPicksOnce` when the
+ * `(competitionDir, photosDir)` pair becomes available and every time
+ * the page becomes visible again — covers the "user switched to
+ * photo-helper after picking in map-corridors" path without any IPC.
+ */
+export function useMapPicksSync(
+  competitionDir: DirectoryHandle | null,
+  photosDir: DirectoryHandle | null,
+  session: MapPicksSyncSessionApi,
+): void {
+  useEffect(() => {
+    if (!competitionDir || !photosDir) return;
+    let cancelled = false;
+    const run = async () => {
+      try {
+        const storage = getStorage();
+        if (cancelled) return;
+        await syncMapPicksOnce(storage, competitionDir, photosDir, session);
+      } catch (err) {
+        if (!cancelled) console.warn('[useMapPicksSync] sync failed:', err);
+      }
+    };
+    void run();
+    const onVis = () => {
+      if (document.visibilityState === 'visible') void run();
+    };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVis);
+    };
+    // `session` is intentionally NOT in the dep list — its members
+    // (candidates array, callbacks) churn every render, which would
+    // re-trigger the effect on every parent state change. The
+    // visibilitychange listener catches catching up on stale data; the
+    // initial run captures the load-time state. ADR-019 acknowledges
+    // last-write-wins reads are safe.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [competitionDir, photosDir]);
+}

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -29,6 +29,8 @@ export interface MapPickEntry {
     subjectAt?: { lng: number; lat: number };
   };
   label?: string;
+  /** ISO 8601 — when label was last set in map-corridors. */
+  labelUpdatedAt?: string;
 }
 
 interface MapPicksFile {
@@ -51,6 +53,12 @@ export interface MapPicksSyncSessionApi {
   removeCandidate: (photoId: string) => Promise<void> | void;
   /** Update flag in place; preserves canvasState + photo-helper-owned fields. */
   setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void> | void;
+  /**
+   * Update label in place (bidirectional label sync, Phase A).
+   * Called when remote `entry.labelUpdatedAt` is newer than the local
+   * `labelUpdatedAt`. Empty string = explicit clear.
+   */
+  setCandidateLabel: (photoId: string, label: string) => Promise<void> | void;
 }
 
 const PM_PREFIX = 'pm-';
@@ -97,14 +105,29 @@ export async function syncMapPicksOnce(
         url,
         filename: entry.filename,
         canvasState: createDefaultCanvasState(),
-        label: '',
+        label: entry.label ?? '',
         flag: entry.flag,
+        ...(entry.labelUpdatedAt ? { labelUpdatedAt: entry.labelUpdatedAt } : {}),
       };
       await session.addCandidate(photo);
       inserts++;
-    } else if (existing.flag !== entry.flag) {
-      await session.setCandidateFlag(entry.photoId, entry.flag);
-      updates++;
+    } else {
+      let touched = false;
+      if (existing.flag !== entry.flag) {
+        await session.setCandidateFlag(entry.photoId, entry.flag);
+        touched = true;
+      }
+      // Bidirectional label sync — newer wins. Equal timestamps → local
+      // wins (deterministic tie-break for in-flight edits).
+      const remoteLabel = entry.label ?? '';
+      const remoteAt = entry.labelUpdatedAt;
+      const localAt = existing.labelUpdatedAt;
+      const remoteIsNewer = remoteAt && (!localAt || remoteAt > localAt);
+      if (remoteIsNewer && existing.label !== remoteLabel) {
+        await session.setCandidateLabel(entry.photoId, remoteLabel);
+        touched = true;
+      }
+      if (touched) updates++;
     }
   }
 

--- a/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
+++ b/frontend/photo-helper/src/hooks/usePhotoSessionOPFS.ts
@@ -23,6 +23,25 @@ import {
 
 type LayoutMode = 'landscape' | 'portrait';
 
+/**
+ * Default canvas state for a newly-imported photo. Extracted from
+ * `buildPhotoFromFile` so that `useMapPicksSync` (Phase 8b of
+ * photo-map-culling) can build identical ApiPhoto records when it
+ * projects map-originated picks into the candidate pool — keeps the
+ * two code paths from drifting on the editor's initial appearance.
+ */
+export function createDefaultCanvasState(): ApiPhoto['canvasState'] {
+  return {
+    position: { x: 0, y: 0 },
+    scale: 1,
+    brightness: 0,
+    contrast: 1,
+    sharpness: 0,
+    whiteBalance: { temperature: 0, tint: 0, auto: false },
+    labelPosition: 'bottom-left',
+  };
+}
+
 const defaultSession = (id: string): ApiPhotoSession => ({
   id,
   version: 1,
@@ -232,15 +251,7 @@ export function usePhotoSessionOPFS() {
       sessionId: session?.id ?? '',
       url,
       filename: file.name,
-      canvasState: {
-        position: { x: 0, y: 0 },
-        scale: 1,
-        brightness: 0,
-        contrast: 1,
-        sharpness: 0,
-        whiteBalance: { temperature: 0, tint: 0, auto: false },
-        labelPosition: 'bottom-left',
-      },
+      canvasState: createDefaultCanvasState(),
       label: '',
       ...(flag !== undefined ? { flag } : {}),
     };

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -303,6 +303,9 @@
       "delete": "Smazat {{count}} kandidátů",
       "error": "Smazání kandidátů selhalo. Některé soubory mohou stále zabírat úložiště.",
       "allPromoted": "Žádný z {{count}} kandidátů nebyl smazán — všechny byly před potvrzením přesunuty do sad."
+    },
+    "handoff": {
+      "unavailable": "Synchronizace s mapou není k dispozici — výběry provedené v mapě se zde neobjeví, dokud nebude úložiště obnoveno."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -304,6 +304,9 @@
       "delete": "Delete {{count}} candidates",
       "error": "Failed to delete candidates. Some files may still occupy storage.",
       "allPromoted": "None of the {{count}} candidates were deleted — they were moved to slots before confirm."
+    },
+    "handoff": {
+      "unavailable": "Cross-app sync with the map view is unavailable — picks made in the map won't appear here until storage is restored."
     }
   },
   "pdf": {

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -41,6 +41,14 @@ export interface ApiPhoto {
    */
   flag?: CandidateFlag;
   gps?: ApiPhotoGps;
+  /**
+   * ISO 8601 stamp of when `label` was last set, in EITHER app
+   * (set by photo-helper directly OR by useMapPicksSync mirroring a
+   * map-corridors edit). Drives the cross-app "newer wins" tie-break
+   * in `useEditorPicksSync` (map side) and `useMapPicksSync` (editor
+   * side). Absent on legacy data.
+   */
+  labelUpdatedAt?: string;
 }
 
 export interface ApiPhotoSet {

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -19,6 +19,13 @@ export type AddPhotosResult =
   | { kind: 'ok'; routedTo: 'slot' | 'tray'; count: number }
   | { kind: 'err'; reason: 'no-competition' | 'over-capacity' | 'unknown'; message: string };
 
+// `capturedAt` is the EXIF source; `subjectAt` is the user-placed marker coord that flows to the answer sheet. See docs/photo-map-culling/implementation-plan.md Phase 0.
+export interface ApiPhotoGps {
+  capturedAt?: { lng: number; lat: number; altitude?: number };
+  subjectAt?: { lng: number; lat: number };
+  timestamp?: string;
+}
+
 export interface ApiPhoto {
   id: string;
   sessionId: string; // Required for image cache and API consistency
@@ -33,6 +40,7 @@ export interface ApiPhoto {
    * from a slot back to the tray. See docs/CANDIDATE_PHOTOS.md.
    */
   flag?: CandidateFlag;
+  gps?: ApiPhotoGps;
 }
 
 export interface ApiPhotoSet {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@vis.gl/react-maplibre':
         specifier: ^8.0.4
         version: 8.1.0(maplibre-gl@5.19.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      exifr:
+        specifier: 7.1.3
+        version: 7.1.3
       mapbox-gl:
         specifier: ^3.17.0
         version: 3.19.1
@@ -2423,6 +2426,9 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  exifr@7.1.3:
+    resolution: {integrity: sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -7212,6 +7218,8 @@ snapshots:
   esutils@2.0.3: {}
 
   events@3.3.0: {}
+
+  exifr@7.1.3: {}
 
   expect-type@1.3.0: {}
 

--- a/frontend/shared-storage/src/electronStorage.ts
+++ b/frontend/shared-storage/src/electronStorage.ts
@@ -9,6 +9,11 @@ import type {
   StorageHandles,
   SessionDirectoryHandles,
 } from './types';
+import {
+  savePhotoThumb as savePhotoThumbImpl,
+  getPhotoThumb as getPhotoThumbImpl,
+  deletePhotoThumb as deletePhotoThumbImpl,
+} from './photoThumbs';
 
 /**
  * Create a DirectoryHandle from a path string (Electron)
@@ -115,6 +120,18 @@ export class ElectronStorage implements StorageInterface {
   async deletePhotoFile(photosDir: DirectoryHandle, photoId: string): Promise<void> {
     const api = getElectronAPI();
     await api.deletePhotoFile(photosDir.path, photoId);
+  }
+
+  async savePhotoThumb(photosDir: DirectoryHandle, photoId: string, blob: Blob): Promise<void> {
+    return savePhotoThumbImpl(this, photosDir, photoId, blob);
+  }
+
+  async getPhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<Blob | null> {
+    return getPhotoThumbImpl(this, photosDir, photoId);
+  }
+
+  async deletePhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<void> {
+    return deletePhotoThumbImpl(this, photosDir, photoId);
   }
 
   async clearDirectory(dir: DirectoryHandle): Promise<void> {

--- a/frontend/shared-storage/src/index.ts
+++ b/frontend/shared-storage/src/index.ts
@@ -28,6 +28,13 @@ export type {
 export { dirnameOf } from './pathUtils';
 export { slugifyForFilename } from './slugify';
 
+// Photo-thumb helpers — implementation primitives behind
+// `StorageInterface.savePhotoThumb`/`getPhotoThumb`/`deletePhotoThumb`.
+// App code should prefer the interface methods; these are exported so
+// tests can exercise the wrapper logic with a faked StorageInterface
+// without instantiating an OPFS/Electron backend.
+export { savePhotoThumb, getPhotoThumb, deletePhotoThumb } from './photoThumbs';
+
 import type { StorageInterface, StorageType } from './types';
 import { OPFSStorage, opfsStorage } from './opfsStorage';
 import { ElectronStorage, electronStorage } from './electronStorage';

--- a/frontend/shared-storage/src/opfsStorage.ts
+++ b/frontend/shared-storage/src/opfsStorage.ts
@@ -9,6 +9,11 @@ import type {
   StorageHandles,
   SessionDirectoryHandles,
 } from './types';
+import {
+  savePhotoThumb as savePhotoThumbImpl,
+  getPhotoThumb as getPhotoThumbImpl,
+  deletePhotoThumb as deletePhotoThumbImpl,
+} from './photoThumbs';
 
 /**
  * Sanitize filename to prevent path traversal and invalid characters
@@ -133,6 +138,18 @@ export class OPFSStorage implements StorageInterface {
       console.warn(`Sanitized photoId for delete: '${photoId}' -> '${safeId}'`);
     }
     await opfsDir.removeEntry(safeId);
+  }
+
+  async savePhotoThumb(photosDir: DirectoryHandle, photoId: string, blob: Blob): Promise<void> {
+    return savePhotoThumbImpl(this, photosDir, photoId, blob);
+  }
+
+  async getPhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<Blob | null> {
+    return getPhotoThumbImpl(this, photosDir, photoId);
+  }
+
+  async deletePhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<void> {
+    return deletePhotoThumbImpl(this, photosDir, photoId);
   }
 
   async clearDirectory(dir: DirectoryHandle): Promise<void> {

--- a/frontend/shared-storage/src/photoThumbs.ts
+++ b/frontend/shared-storage/src/photoThumbs.ts
@@ -1,0 +1,68 @@
+// Phase 2 of photo-map-culling: thumbnail storage helpers.
+// See docs/photo-map-culling/implementation-plan.md.
+//
+// These functions encapsulate the "thumbs are just photos in a subdir"
+// pattern so both OPFSStorage and ElectronStorage delegate to identical
+// behaviour without duplicating the subdir-navigation + filename rules.
+
+import type { StorageInterface, DirectoryHandle } from './types';
+
+/** Filename inside `thumbs/`. `.jpg` extension matches the generated MIME. */
+function thumbFilename(photoId: string): string {
+  return `${photoId}.jpg`;
+}
+
+/**
+ * Save a thumbnail blob into the `thumbs/` subdirectory of the photos
+ * directory. The subdirectory is created on demand.
+ */
+export async function savePhotoThumb(
+  storage: StorageInterface,
+  photosDir: DirectoryHandle,
+  photoId: string,
+  blob: Blob,
+): Promise<void> {
+  const thumbsDir = await storage.getDirectoryHandle(photosDir, 'thumbs', { create: true });
+  const filename = thumbFilename(photoId);
+  // savePhotoFile takes a File; wrap the Blob. Default to image/jpeg
+  // because generateThumb always emits JPEG and an empty MIME on the
+  // Blob would surface as application/octet-stream in some callers.
+  const file = new File([blob], filename, { type: blob.type || 'image/jpeg' });
+  await storage.savePhotoFile(thumbsDir, filename, file);
+}
+
+/**
+ * Read a thumbnail blob. Returns null when the `thumbs/` subdirectory
+ * does not exist OR when the specific thumb file is missing — callers
+ * regenerate from the original photo on miss.
+ */
+export async function getPhotoThumb(
+  storage: StorageInterface,
+  photosDir: DirectoryHandle,
+  photoId: string,
+): Promise<Blob | null> {
+  try {
+    const thumbsDir = await storage.getDirectoryHandle(photosDir, 'thumbs', { create: false });
+    return await storage.getPhotoBlob(thumbsDir, thumbFilename(photoId));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete a thumbnail. Idempotent — does NOT throw when the thumb or the
+ * `thumbs/` subdirectory does not exist. Cleanup paths (failed import,
+ * photo rejection) shouldn't fail on already-deleted state.
+ */
+export async function deletePhotoThumb(
+  storage: StorageInterface,
+  photosDir: DirectoryHandle,
+  photoId: string,
+): Promise<void> {
+  try {
+    const thumbsDir = await storage.getDirectoryHandle(photosDir, 'thumbs', { create: false });
+    await storage.deletePhotoFile(thumbsDir, thumbFilename(photoId));
+  } catch {
+    // No thumbs dir or thumb missing — silent.
+  }
+}

--- a/frontend/shared-storage/src/photoThumbs.ts
+++ b/frontend/shared-storage/src/photoThumbs.ts
@@ -31,10 +31,20 @@ export async function savePhotoThumb(
   await storage.savePhotoFile(thumbsDir, filename, file);
 }
 
+// NotFoundError is the only "absence" condition that should silently
+// resolve to null/undefined; anything else (permission revoked, OPFS
+// InvalidStateError, quota issues, type errors) is a real failure and
+// must surface so callers can react.
+function isNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const name = (err as { name?: unknown }).name;
+  return name === 'NotFoundError';
+}
+
 /**
  * Read a thumbnail blob. Returns null when the `thumbs/` subdirectory
  * does not exist OR when the specific thumb file is missing — callers
- * regenerate from the original photo on miss.
+ * regenerate from the original photo on miss. Other errors propagate.
  */
 export async function getPhotoThumb(
   storage: StorageInterface,
@@ -44,15 +54,17 @@ export async function getPhotoThumb(
   try {
     const thumbsDir = await storage.getDirectoryHandle(photosDir, 'thumbs', { create: false });
     return await storage.getPhotoBlob(thumbsDir, thumbFilename(photoId));
-  } catch {
-    return null;
+  } catch (err) {
+    if (isNotFoundError(err)) return null;
+    throw err;
   }
 }
 
 /**
- * Delete a thumbnail. Idempotent — does NOT throw when the thumb or the
- * `thumbs/` subdirectory does not exist. Cleanup paths (failed import,
- * photo rejection) shouldn't fail on already-deleted state.
+ * Delete a thumbnail. Idempotent for "already gone" — does NOT throw
+ * when the thumb or the `thumbs/` subdirectory does not exist. Cleanup
+ * paths (failed import, photo rejection) shouldn't fail on already-
+ * deleted state. Other errors propagate.
  */
 export async function deletePhotoThumb(
   storage: StorageInterface,
@@ -62,7 +74,8 @@ export async function deletePhotoThumb(
   try {
     const thumbsDir = await storage.getDirectoryHandle(photosDir, 'thumbs', { create: false });
     await storage.deletePhotoFile(thumbsDir, thumbFilename(photoId));
-  } catch {
-    // No thumbs dir or thumb missing — silent.
+  } catch (err) {
+    if (isNotFoundError(err)) return;
+    throw err;
   }
 }

--- a/frontend/shared-storage/src/types.ts
+++ b/frontend/shared-storage/src/types.ts
@@ -93,6 +93,30 @@ export interface StorageInterface {
   deletePhotoFile(photosDir: DirectoryHandle, photoId: string): Promise<void>;
 
   /**
+   * Save a thumbnail blob into `photosDir/thumbs/{photoId}.jpg`.
+   * The `thumbs` subdirectory is created on demand. Photo-map-culling
+   * Phase 2 — see docs/photo-map-culling/implementation-plan.md.
+   * @param photosDir - Directory handle for photos (NOT the thumbs dir)
+   * @param photoId - Unique identifier for the source photo
+   * @param blob - The thumbnail bytes (typically image/jpeg, ~200x150)
+   */
+  savePhotoThumb(photosDir: DirectoryHandle, photoId: string, blob: Blob): Promise<void>;
+
+  /**
+   * Read a thumbnail blob from `photosDir/thumbs/{photoId}.jpg`.
+   * Returns null if the thumbs subdirectory or the specific thumb file
+   * is missing — callers regenerate from the original on miss.
+   */
+  getPhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<Blob | null>;
+
+  /**
+   * Delete a thumbnail. Idempotent — silent if the thumb or the thumbs
+   * subdirectory does not exist (cleanup paths shouldn't fail on
+   * already-deleted state).
+   */
+  deletePhotoThumb(photosDir: DirectoryHandle, photoId: string): Promise<void>;
+
+  /**
    * Clear all contents of a directory
    * @param dir - Directory handle to clear
    */


### PR DESCRIPTION
## Summary

Implements the **photo-map-culling** feature across `map-corridors` and `photo-helper` apps:

- EXIF extraction + thumbnail generation pipeline (Phases 1a/1b/1c)
- OPFS thumbnail storage layer (Phase 2)
- Dropzone routing and storage wiring (Phase 3)
- Capture-dots map layer with marker persistence (Phase 4)
- Photo popup with Include / Skip / Reject controls (Phase 5)
- No-GPS tray with drag-onto-map (Phase 6)
- Right-side photo list panel (Phase 7)
- Bidirectional label sync between map-corridors and photo-helper via two mirror JSON files, newer-wins (Phase 8a/8b)
- Send-to-editor button (Phase 9)
- A11y polish (Phase 10)
- Drag every photo with ghost line for moved markers
- Popup follows pin; label picker; yellow-when-labelled state
- Two-mirror file label-sync design doc + updated guide

## Scope
- 51 files changed, ~5800 lines added
- New tests: extractExif, generateThumb, importPhotoFiles, importPhotosToStorage, photoThumbs, captureFeatures, groupPhotosByFlag, mapPicksWriter, editorPicksWriter, useMapPicksSync, useEditorPicksSync, markerSanitize

## Test plan
- [ ] Import photos in map-corridors → markers + thumbnails appear
- [ ] Label a photo in map-corridors → photo-helper picks it up
- [ ] Label in photo-helper → map-corridors mirrors it (newer-wins)
- [ ] Drag a photo marker → ghost dashed line, sanitize on save
- [ ] Send-to-editor button hands off correctly
- [ ] No-GPS tray drag-onto-map works