### PR TITLE
feat(photo-helper): clipboard paste + visible delete button #minor

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -97,6 +97,23 @@ surface in code review / release notes.
 - **Effort:** ~5 min.
 - **Tags:** `correctness`, `hygiene`
 
+### 8. macOS multi-file clipboard paste (`NSFilenamesPboardType`)
+- **Why:** `frontend/desktop/main.js` `readClipboardFilePaths` only reads
+  `public.file-url` on macOS, which is a single file. A multi-file Finder
+  copy (⌘-click multi-select → ⌘C) populates `NSFilenamesPboardType` — a
+  binary or XML property-list array of paths — and would currently paste
+  only the first file. Acceptable today because we ship Windows-only (see
+  "Signed Windows .exe" below), but the moment we add a macOS build the
+  paste UX silently regresses for power users.
+- **Action:** When macOS distribution lands, add a plist parser
+  (`simple-plist` or a hand-rolled `<array><string>…</string></array>`
+  XML reader, since the structure is fixed) and a third branch in
+  `readClipboardFilePaths` that calls `clipboard.readBuffer('NSFilenamesPboardType')`
+  before the `public.file-url` fallback. Re-add `NSFilenamesPboardType`
+  to the format-availability check at the same time.
+- **Effort:** ~1–2 hours (parser + tests + a Finder-tested QA pass).
+- **Tags:** `mac`, `ux`, `clipboard`
+
 ---
 
 ## Deferred (documented but not scheduled)

--- a/frontend/desktop/__tests__/clipboardParse.test.js
+++ b/frontend/desktop/__tests__/clipboardParse.test.js
@@ -1,0 +1,280 @@
+// Regression suite for the clipboard-payload parsers. These are the only
+// pieces of `read-clipboard-photos` that decode untrusted binary data
+// directly from the OS clipboard — anything any other process on the
+// machine can write lands here. A regression in either function lets a
+// hostile clipboard payload either silently drop legitimate paths
+// (DoS-of-paste) or escape the UNC-path security gate (NTLM hash leak).
+//
+// The helpers live in `lib/clipboardParse.js` (pure CommonJS) so they can
+// be exercised without spinning up Electron — vitest is enough.
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { parseDropfiles, fileUriToPath } = require('../lib/clipboardParse');
+
+// ---------------------------------------------------------------------------
+// Test-only DROPFILES builder. Mirrors the Windows struct layout exactly:
+//   pFiles  (DWORD, LE)  — offset where the path data starts (default 20)
+//   pt      (POINT)      — drop point, 8 zero bytes for our purposes
+//   fNC     (BOOL)       — drop in non-client area, 0
+//   fWide   (BOOL)       — 1 for UTF-16LE paths, 0 for latin1
+// Followed by the concatenated NUL-terminated path strings and a final
+// extra NUL/00 00 sentinel (unless an `omitFinalTerminator` test wants to
+// drop it to exercise the "no-trailing-sentinel" branch).
+function buildDropfiles({
+  paths,
+  wide = true,
+  offset = 20,
+  omitFinalTerminator = false,
+  extraPaddingBeforeBody = 0,
+}) {
+  const header = Buffer.alloc(20);
+  header.writeUInt32LE(offset, 0); // pFiles
+  // bytes 4..15 are POINT.x, POINT.y, fNC — all zero
+  header.writeUInt32LE(wide ? 1 : 0, 16); // fWide
+
+  const enc = wide ? 'utf16le' : 'latin1';
+  const sep = wide ? Buffer.from([0, 0]) : Buffer.from([0]);
+
+  const bodyChunks = [];
+  for (const p of paths) {
+    bodyChunks.push(Buffer.from(p, enc));
+    bodyChunks.push(sep);
+  }
+  if (!omitFinalTerminator) {
+    bodyChunks.push(sep);
+  }
+  const body = Buffer.concat(bodyChunks);
+
+  const padding = Buffer.alloc(extraPaddingBeforeBody);
+  return Buffer.concat([header, padding, body]);
+}
+
+// ---------------------------------------------------------------------------
+
+describe('parseDropfiles — defensive bounds', () => {
+  it('returns [] for null / undefined / empty input', () => {
+    // Don't crash on garbage from a clipboard race or a `clipboard.readBuffer`
+    // that returned an empty Buffer.
+    expect(parseDropfiles(null)).toEqual([]);
+    expect(parseDropfiles(undefined)).toEqual([]);
+    expect(parseDropfiles(Buffer.alloc(0))).toEqual([]);
+  });
+
+  it('returns [] when the buffer is shorter than the 20-byte DROPFILES header', () => {
+    // Reading UInt32LE at offset 16 on a 19-byte buffer would throw — the
+    // length guard catches that before the reads happen.
+    expect(parseDropfiles(Buffer.alloc(19))).toEqual([]);
+  });
+
+  it('returns [] when `pFiles` points before the header or past EOF', () => {
+    // offset = 19 — before the header ends, malicious truncation.
+    const tooSmall = Buffer.alloc(40);
+    tooSmall.writeUInt32LE(19, 0);
+    tooSmall.writeUInt32LE(1, 16);
+    expect(parseDropfiles(tooSmall)).toEqual([]);
+
+    // offset = 0xFFFFFFFF — past EOF, attacker overflow attempt.
+    const tooBig = Buffer.alloc(40);
+    tooBig.writeUInt32LE(0xFFFFFFFF, 0);
+    tooBig.writeUInt32LE(1, 16);
+    expect(parseDropfiles(tooBig)).toEqual([]);
+
+    // offset = buf.length — points exactly at EOF, no data to read.
+    const atEnd = Buffer.alloc(20);
+    atEnd.writeUInt32LE(20, 0);
+    atEnd.writeUInt32LE(1, 16);
+    expect(parseDropfiles(atEnd)).toEqual([]);
+  });
+
+  it('rejects odd-offset wide-mode buffers (2-byte alignment required)', () => {
+    // UTF-16LE code units are 2 bytes; starting at an odd offset would
+    // shift every code unit by a byte and produce garbage decodes.
+    const buf = buildDropfiles({
+      paths: ['C:\\foo.jpg'],
+      wide: true,
+      offset: 21,
+      extraPaddingBeforeBody: 1, // shift body by 1 byte so offset 21 lands on data
+    });
+    expect(parseDropfiles(buf)).toEqual([]);
+  });
+});
+
+describe('parseDropfiles — wide (UTF-16LE)', () => {
+  it('decodes a single well-formed path', () => {
+    const buf = buildDropfiles({ paths: ['C:\\Users\\photo.jpg'], wide: true });
+    expect(parseDropfiles(buf)).toEqual(['C:\\Users\\photo.jpg']);
+  });
+
+  it('decodes multiple paths in order', () => {
+    const buf = buildDropfiles({
+      paths: ['C:\\a.jpg', 'C:\\b.png', 'D:\\nested\\c.jpeg'],
+      wide: true,
+    });
+    expect(parseDropfiles(buf)).toEqual([
+      'C:\\a.jpg',
+      'C:\\b.png',
+      'D:\\nested\\c.jpeg',
+    ]);
+  });
+
+  it('decodes non-ASCII paths (Czech diacritics)', () => {
+    // Total Commander on a Czech Windows produces UTF-16LE with full
+    // Unicode — must round-trip cleanly.
+    const buf = buildDropfiles({
+      paths: ['C:\\Užívatel\\fotografie\\přípravná.jpg'],
+      wide: true,
+    });
+    expect(parseDropfiles(buf)).toEqual([
+      'C:\\Užívatel\\fotografie\\přípravná.jpg',
+    ]);
+  });
+
+  it('returns [] when the body is just the empty-sentinel double-NUL', () => {
+    // Body = 00 00. The loop sees i === start at i=0 and breaks
+    // immediately — no paths to decode.
+    const buf = buildDropfiles({ paths: [], wide: true });
+    expect(parseDropfiles(buf)).toEqual([]);
+  });
+
+  it('decodes the trailing path when the producer omits the final double-NUL sentinel', () => {
+    // Some shell extensions ship CF_HDROP without the trailing terminator.
+    // Pre-fix: the loop fell off the end with the last path still in
+    // `start..tail.length` and silently dropped it. The 5-file paste
+    // arrived as 4. Regression-pin the trailing-decode branch.
+    const buf = buildDropfiles({
+      paths: ['C:\\a.jpg', 'C:\\trailing.jpg'],
+      wide: true,
+      omitFinalTerminator: true,
+    });
+    expect(parseDropfiles(buf)).toEqual(['C:\\a.jpg', 'C:\\trailing.jpg']);
+  });
+
+  it('strips a trailing odd byte before UTF-16 decode of the unterminated remainder', () => {
+    // A 5-byte tail (e.g. `0061 0062 80`) in wide mode would otherwise
+    // produce garbage if decoded as 6 bytes; the parser must shave the
+    // odd byte off before `toString('utf16le')`.
+    const header = Buffer.alloc(20);
+    header.writeUInt32LE(20, 0);
+    header.writeUInt32LE(1, 16);
+    // 'a' 'b' then a stray byte, no terminator. utf16le decode of [0x61,0x00,0x62,0x00] = 'ab'.
+    const oddTail = Buffer.concat([
+      Buffer.from('ab', 'utf16le'),
+      Buffer.from([0x80]),
+    ]);
+    const buf = Buffer.concat([header, oddTail]);
+    expect(parseDropfiles(buf)).toEqual(['ab']);
+  });
+});
+
+describe('parseDropfiles — narrow (latin1)', () => {
+  it('decodes a single well-formed path', () => {
+    const buf = buildDropfiles({ paths: ['C:\\Users\\photo.jpg'], wide: false });
+    expect(parseDropfiles(buf)).toEqual(['C:\\Users\\photo.jpg']);
+  });
+
+  it('decodes multiple paths in order', () => {
+    const buf = buildDropfiles({
+      paths: ['C:\\a.jpg', 'C:\\b.png'],
+      wide: false,
+    });
+    expect(parseDropfiles(buf)).toEqual(['C:\\a.jpg', 'C:\\b.png']);
+  });
+
+  it('decodes the trailing path when the producer omits the final NUL sentinel', () => {
+    const buf = buildDropfiles({
+      paths: ['C:\\a.jpg', 'C:\\trailing.jpg'],
+      wide: false,
+      omitFinalTerminator: true,
+    });
+    expect(parseDropfiles(buf)).toEqual(['C:\\a.jpg', 'C:\\trailing.jpg']);
+  });
+});
+
+describe('fileUriToPath — POSIX', () => {
+  it('decodes a basic file:// URI', () => {
+    expect(fileUriToPath('file:///Users/lukas/photo.jpg', 'darwin')).toBe(
+      '/Users/lukas/photo.jpg',
+    );
+  });
+
+  it('decodes percent-encoded spaces and Unicode', () => {
+    expect(fileUriToPath('file:///Users/lukas/My%20Photos/p.jpg', 'darwin')).toBe(
+      '/Users/lukas/My Photos/p.jpg',
+    );
+    expect(
+      fileUriToPath('file:///home/lukas/fotografie/p%C5%99%C3%ADprava.jpg', 'linux'),
+    ).toBe('/home/lukas/fotografie/příprava.jpg');
+  });
+
+  it('accepts an explicit `localhost` authority (RFC 8089 §2)', () => {
+    expect(fileUriToPath('file://localhost/etc/passwd', 'linux')).toBe(
+      '/etc/passwd',
+    );
+  });
+});
+
+describe('fileUriToPath — Windows', () => {
+  it('strips the leading slash and converts forward to back slashes', () => {
+    expect(fileUriToPath('file:///C:/Users/lukas/photo.jpg', 'win32')).toBe(
+      'C:\\Users\\lukas\\photo.jpg',
+    );
+  });
+
+  it('decodes percent-encoded characters before slash conversion', () => {
+    expect(
+      fileUriToPath('file:///C:/Users/lukas/My%20Photos/p.jpg', 'win32'),
+    ).toBe('C:\\Users\\lukas\\My Photos\\p.jpg');
+  });
+});
+
+describe('fileUriToPath — authority gate (security)', () => {
+  it('REJECTS non-empty, non-localhost authority (NTLM hash leak vector)', () => {
+    // The whole point of the gate. `file://attacker.tld/share/loot.jpg`
+    // is the URI spelling of `\\attacker.tld\share\loot.jpg`; if the
+    // downstream lstat ever ran on it, Windows would helpfully establish
+    // an SMB session to attacker.tld and leak the user's NTLMv2 hash in
+    // the handshake. Returning null at the parser keeps the path out of
+    // the pipeline entirely; `isSafeStartDir` would also catch it later
+    // as defence-in-depth.
+    expect(fileUriToPath('file://attacker.tld/share/loot.jpg', 'win32')).toBeNull();
+    expect(fileUriToPath('file://192.168.1.1/share/x.jpg', 'win32')).toBeNull();
+    expect(fileUriToPath('file://example.com/x.jpg', 'darwin')).toBeNull();
+  });
+
+  it('treats `localhost` case-insensitively per RFC 3986 §3.2.2', () => {
+    expect(fileUriToPath('file://LOCALHOST/etc/passwd', 'linux')).toBe('/etc/passwd');
+    expect(fileUriToPath('file://Localhost/x', 'linux')).toBe('/x');
+  });
+});
+
+describe('fileUriToPath — defensive', () => {
+  it('returns null for non-string input', () => {
+    expect(fileUriToPath(null)).toBeNull();
+    expect(fileUriToPath(undefined)).toBeNull();
+    expect(fileUriToPath(42)).toBeNull();
+    expect(fileUriToPath({})).toBeNull();
+  });
+
+  it('returns null for non-file scheme', () => {
+    expect(fileUriToPath('http://example.com/x.jpg')).toBeNull();
+    expect(fileUriToPath('https://example.com/x.jpg')).toBeNull();
+    expect(fileUriToPath('javascript:alert(1)')).toBeNull();
+  });
+
+  it('returns null for file:// without a path part', () => {
+    // `file://localhost` with no trailing slash has no `/path` group — the
+    // regex requires `(\/.*)`. Returning null keeps the pipeline empty.
+    expect(fileUriToPath('file://localhost')).toBeNull();
+    expect(fileUriToPath('file://')).toBeNull();
+  });
+
+  it('returns null on malformed percent-encoding (decodeURI throws)', () => {
+    // `%ZZ` is not a valid percent-encoded byte; decodeURI throws URIError.
+    // The catch must convert that to a quiet null instead of bringing
+    // down the IPC handler.
+    expect(fileUriToPath('file:///bad%ZZpath')).toBeNull();
+  });
+});

--- a/frontend/desktop/lib/clipboardParse.js
+++ b/frontend/desktop/lib/clipboardParse.js
@@ -1,0 +1,107 @@
+// Pure clipboard-payload parsers shared by the Electron main process and the
+// test suite. Extracted from `main.js` so the binary-format edge cases —
+// off-by-one terminators, malformed CF_HDROP headers, file:// authority
+// handling — can be unit-tested directly without spinning up Electron.
+//
+// The handler that calls these (`readClipboardFilePaths` in main.js) still
+// lives in main because it depends on Electron's `clipboard` module; only
+// the format-decoder pieces are pure enough to move here.
+
+// Parse a Windows CF_HDROP buffer (DROPFILES struct) into an array of file
+// paths. Layout: 20-byte header (DWORD pFiles, POINT pt, BOOL fNC, BOOL fWide),
+// then a flat array of NUL-terminated path strings terminated by an extra
+// NUL/00 00 sentinel. Total Commander, Explorer and 7-Zip all populate
+// CF_HDROP on Ctrl+C.
+//
+// Defensive against malformed buffers because the source is the OS
+// clipboard — anything any other process can write goes in here.
+function parseDropfiles(buf) {
+  if (!buf || buf.length < 20) return [];
+  const offset = buf.readUInt32LE(0);
+  const wide = buf.readUInt32LE(16) !== 0;
+  if (offset < 20 || offset >= buf.length) return [];
+  // Wide-mode (UTF-16LE) must start on a 2-byte boundary. An odd offset
+  // would shift every code unit by a byte and produce garbage decodes.
+  if (wide && (offset & 1)) return [];
+  const tail = buf.subarray(offset);
+  const paths = [];
+  if (wide) {
+    let start = 0;
+    let terminated = false;
+    for (let i = 0; i + 1 < tail.length; i += 2) {
+      if (tail[i] === 0 && tail[i + 1] === 0) {
+        if (i === start) { terminated = true; break; }
+        const str = tail.subarray(start, i).toString('utf16le');
+        if (str) paths.push(str);
+        start = i + 2;
+        terminated = true;
+      } else {
+        terminated = false;
+      }
+    }
+    // Some shell extensions ship CF_HDROP without the trailing double-NUL
+    // sentinel. If the loop fell off the end without a final terminator
+    // and there is a non-empty in-progress slice, decode it anyway —
+    // dropping it silently was a reported partial-paste pattern.
+    if (!terminated && start + 1 < tail.length) {
+      const remainder = tail.subarray(start, tail.length - (tail.length & 1));
+      const str = remainder.toString('utf16le');
+      if (str) paths.push(str);
+    }
+  } else {
+    let start = 0;
+    let terminated = false;
+    for (let i = 0; i < tail.length; i++) {
+      if (tail[i] === 0) {
+        if (i === start) { terminated = true; break; }
+        const str = tail.subarray(start, i).toString('latin1');
+        if (str) paths.push(str);
+        start = i + 1;
+        terminated = true;
+      } else {
+        terminated = false;
+      }
+    }
+    if (!terminated && start < tail.length) {
+      const str = tail.subarray(start).toString('latin1');
+      if (str) paths.push(str);
+    }
+  }
+  return paths;
+}
+
+// Decode a file:// URI (RFC 8089) into a local path. Used for macOS
+// `public.file-url` and the cross-platform `text/uri-list` clipboard
+// formats.
+//
+// Per RFC 8089 the authority MUST be empty or `localhost`. A non-empty
+// authority is the URI form of `\\server\share` and would let a clipboard
+// payload point at an attacker-controlled SMB host, triggering an NTLMv2
+// handshake on the follow-up lstat (Windows hash leak). The downstream
+// `isSafeStartDir` gate also rejects UNC paths — this is defence-in-depth
+// at the parser so a remote share never gets normalised into the pipeline.
+//
+// `platform` is parameterised (defaults to `process.platform`) so the
+// Windows-specific slash conversion can be exercised by tests on any host.
+function fileUriToPath(uri, platform = process.platform) {
+  try {
+    if (typeof uri !== 'string') return null;
+    const m = /^file:\/\/([^/]*)(\/.*)$/.exec(uri);
+    if (!m) return null;
+    const authority = m[1];
+    if (authority && authority.toLowerCase() !== 'localhost') return null;
+    let p = decodeURI(m[2]);
+    if (platform === 'win32') {
+      if (p.startsWith('/')) p = p.slice(1);
+      p = p.replace(/\//g, '\\');
+    }
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  parseDropfiles,
+  fileUriToPath,
+};

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, protocol, ipcMain, shell, globalShortcut, Menu, dialog, net } = require('electron');
+const { app, BrowserWindow, protocol, ipcMain, shell, globalShortcut, Menu, dialog, net, clipboard, nativeImage } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
@@ -1004,6 +1004,188 @@ safeHandle('read-photo-file', async (event, filePath) => {
     mimeType,
     base64: buffer.toString('base64'),
   };
+});
+
+// Parse a Windows CF_HDROP buffer (DROPFILES struct) into an array of file
+// paths. Layout: 20-byte header (DWORD pFiles, POINT pt, BOOL fNC, BOOL fWide),
+// then a flat array of NUL-terminated paths terminated by an extra NUL/00 00.
+// Total Commander, Explorer and 7-Zip all populate CF_HDROP on Ctrl+C.
+function parseDropfiles(buf) {
+  if (!buf || buf.length < 20) return [];
+  const offset = buf.readUInt32LE(0);
+  const wide = buf.readUInt32LE(16) !== 0;
+  if (offset < 20 || offset >= buf.length) return [];
+  const tail = buf.subarray(offset);
+  const paths = [];
+  if (wide) {
+    let start = 0;
+    for (let i = 0; i + 1 < tail.length; i += 2) {
+      if (tail[i] === 0 && tail[i + 1] === 0) {
+        if (i === start) break;
+        const str = tail.subarray(start, i).toString('utf16le');
+        if (str) paths.push(str);
+        start = i + 2;
+      }
+    }
+  } else {
+    let start = 0;
+    for (let i = 0; i < tail.length; i++) {
+      if (tail[i] === 0) {
+        if (i === start) break;
+        const str = tail.subarray(start, i).toString('latin1');
+        if (str) paths.push(str);
+        start = i + 1;
+      }
+    }
+  }
+  return paths;
+}
+
+// Decode a file:// URI (RFC 8089) into a local path. Used for macOS
+// `public.file-url` and the cross-platform `text/uri-list` clipboard formats.
+function fileUriToPath(uri) {
+  try {
+    if (typeof uri !== 'string' || !uri.startsWith('file://')) return null;
+    let p = decodeURI(uri.slice('file://'.length));
+    if (process.platform === 'win32') {
+      if (p.startsWith('/')) p = p.slice(1);
+      p = p.replace(/\//g, '\\');
+    }
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+// Collect file paths from the OS clipboard across the three formats that
+// matter for our users:
+//   • Windows CF_HDROP (Total Commander, Explorer, 7-Zip) — multi-file
+//   • macOS public.file-url (Finder) — single file
+//   • text/uri-list (cross-platform fallback, KDE/GNOME)
+// Returns absolute paths, deduplicated, in the order they appeared. Caller
+// must still validate each path for ext/size/symlinks before reading.
+function readClipboardFilePaths() {
+  const formats = (() => {
+    try { return clipboard.availableFormats(); } catch { return []; }
+  })();
+  const out = [];
+  const seen = new Set();
+  const push = (p) => {
+    if (typeof p === 'string' && p && !seen.has(p)) {
+      seen.add(p);
+      out.push(p);
+    }
+  };
+
+  if (formats.includes('CF_HDROP')) {
+    try {
+      const buf = clipboard.readBuffer('CF_HDROP');
+      parseDropfiles(buf).forEach(push);
+    } catch (err) {
+      console.debug('[clipboard] CF_HDROP read failed:', err);
+    }
+  }
+  if (out.length === 0 && formats.some(f => f === 'public.file-url' || f === 'NSFilenamesPboardType')) {
+    try {
+      const uri = clipboard.read('public.file-url');
+      const p = fileUriToPath(uri);
+      if (p) push(p);
+    } catch (err) {
+      console.debug('[clipboard] public.file-url read failed:', err);
+    }
+  }
+  if (out.length === 0 && formats.includes('text/uri-list')) {
+    try {
+      const list = clipboard.read('text/uri-list') || '';
+      list.split(/\r?\n/).forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) return;
+        const p = fileUriToPath(trimmed);
+        if (p) push(p);
+      });
+    } catch (err) {
+      console.debug('[clipboard] text/uri-list read failed:', err);
+    }
+  }
+  return out;
+}
+
+// Read photos from the OS clipboard. Two-shot contract — either:
+//   • `paths`: file paths the user copied from Total Commander/Explorer/Finder.
+//              Paths are added to the same `photoOpenAllowlist` that gates
+//              `read-photo-file`, so the renderer reuses the existing
+//              import pipeline (parallel base64 reads, partial-failure shape).
+//   • `image`: raw bitmap from a screenshot or browser "Copy image" — the
+//              renderer constructs a File directly without another IPC hop.
+//
+// Path validation mirrors `read-photo-file` (ext allowlist, no symlinks,
+// 30 MB cap, real on-disk file) — done up front so we don't seed the
+// allowlist with anything we wouldn't read anyway.
+//
+// `maxFiles` mirrors `open-photos` so the renderer can cap by available
+// slot capacity. The hard cap (PHOTO_OPEN_HARD_CAP) still applies as a
+// floor of last resort against a renderer that sends `Infinity`.
+safeHandle('read-clipboard-photos', async (event, maxFiles) => {
+  const rawPaths = readClipboardFilePaths();
+  if (rawPaths.length > 0) {
+    const requested = (typeof maxFiles === 'number' && maxFiles > 0)
+      ? Math.min(maxFiles, PHOTO_OPEN_HARD_CAP)
+      : PHOTO_OPEN_HARD_CAP;
+    const accepted = [];
+    const rejected = [];
+    for (const raw of rawPaths) {
+      if (accepted.length >= requested) break;
+      if (typeof raw !== 'string' || !raw || raw.length > MAX_USER_PATH_LEN) {
+        rejected.push({ path: raw, reason: 'invalid' });
+        continue;
+      }
+      let abs;
+      try { abs = path.resolve(raw); } catch { rejected.push({ path: raw, reason: 'invalid' }); continue; }
+      const ext = path.extname(abs).toLowerCase();
+      if (!ALLOWED_PHOTO_EXTS.has(ext)) {
+        rejected.push({ path: raw, reason: 'unsupported-type' });
+        continue;
+      }
+      let lst;
+      try { lst = fs.lstatSync(abs); } catch { rejected.push({ path: raw, reason: 'not-found' }); continue; }
+      if (lst.isSymbolicLink()) { rejected.push({ path: raw, reason: 'symlink' }); continue; }
+      if (!lst.isFile()) { rejected.push({ path: raw, reason: 'not-file' }); continue; }
+      if (lst.size > 30 * 1024 * 1024) { rejected.push({ path: raw, reason: 'too-large' }); continue; }
+      accepted.push(abs);
+    }
+    // Replace the allowlist with this batch — same model as `open-photos`.
+    // The renderer's pattern is "read all then move on", so we don't need
+    // to merge with the prior batch's contents.
+    photoOpenAllowlist.clear();
+    for (const p of accepted) {
+      try { photoOpenAllowlist.add(normalizePathKey(p)); } catch { /* ignore */ }
+    }
+    return { kind: 'paths', paths: accepted, rejected };
+  }
+
+  // Fallback: in-memory bitmap (screenshot, "Copy image" from a browser).
+  // PNG is the universal interchange format for clipboard images.
+  try {
+    const img = clipboard.readImage();
+    if (img && !img.isEmpty()) {
+      const png = img.toPNG();
+      // Same 30 MB ceiling as on-disk paths — keeps the renderer's File
+      // construction predictable and stops a screenshot of a 30k-monitor
+      // wall from spiking memory.
+      if (png && png.length > 0 && png.length <= 30 * 1024 * 1024) {
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        return {
+          kind: 'image',
+          name: `pasted-${stamp}.png`,
+          mimeType: 'image/png',
+          base64: png.toString('base64'),
+        };
+      }
+    }
+  } catch (err) {
+    console.debug('[clipboard] readImage failed:', err);
+  }
+  return { kind: 'empty' };
 });
 
 // Save a PDF (base64) via native save dialog. Defaults to the

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -978,6 +978,13 @@ safeHandle('read-photo-file', async (event, filePath) => {
   }
   let abs;
   try { abs = path.resolve(filePath); } catch { throw new Error('Invalid file path'); }
+  // Defence-in-depth UNC / device-namespace gate. The allowlist is the
+  // primary barrier, but a future seeding path that forgets `isSafeStartDir`
+  // would re-open the NTLM-hash-leak vector — keep the check here so the
+  // single load-bearing line lives at the actual read sink.
+  if (!isSafeStartDir(abs)) {
+    throw new Error('Invalid file path');
+  }
   if (!photoOpenAllowlist.has(normalizePathKey(abs))) {
     throw new Error('File not in allowlist');
   }
@@ -1006,56 +1013,12 @@ safeHandle('read-photo-file', async (event, filePath) => {
   };
 });
 
-// Parse a Windows CF_HDROP buffer (DROPFILES struct) into an array of file
-// paths. Layout: 20-byte header (DWORD pFiles, POINT pt, BOOL fNC, BOOL fWide),
-// then a flat array of NUL-terminated paths terminated by an extra NUL/00 00.
-// Total Commander, Explorer and 7-Zip all populate CF_HDROP on Ctrl+C.
-function parseDropfiles(buf) {
-  if (!buf || buf.length < 20) return [];
-  const offset = buf.readUInt32LE(0);
-  const wide = buf.readUInt32LE(16) !== 0;
-  if (offset < 20 || offset >= buf.length) return [];
-  const tail = buf.subarray(offset);
-  const paths = [];
-  if (wide) {
-    let start = 0;
-    for (let i = 0; i + 1 < tail.length; i += 2) {
-      if (tail[i] === 0 && tail[i + 1] === 0) {
-        if (i === start) break;
-        const str = tail.subarray(start, i).toString('utf16le');
-        if (str) paths.push(str);
-        start = i + 2;
-      }
-    }
-  } else {
-    let start = 0;
-    for (let i = 0; i < tail.length; i++) {
-      if (tail[i] === 0) {
-        if (i === start) break;
-        const str = tail.subarray(start, i).toString('latin1');
-        if (str) paths.push(str);
-        start = i + 1;
-      }
-    }
-  }
-  return paths;
-}
-
-// Decode a file:// URI (RFC 8089) into a local path. Used for macOS
-// `public.file-url` and the cross-platform `text/uri-list` clipboard formats.
-function fileUriToPath(uri) {
-  try {
-    if (typeof uri !== 'string' || !uri.startsWith('file://')) return null;
-    let p = decodeURI(uri.slice('file://'.length));
-    if (process.platform === 'win32') {
-      if (p.startsWith('/')) p = p.slice(1);
-      p = p.replace(/\//g, '\\');
-    }
-    return p;
-  } catch {
-    return null;
-  }
-}
+// Clipboard binary-payload parsers (`parseDropfiles` for Windows CF_HDROP,
+// `fileUriToPath` for RFC 8089 file:// URIs) live in `lib/clipboardParse.js`
+// so the binary-format edge cases can be unit-tested without spinning up
+// Electron. The orchestrator `readClipboardFilePaths` below stays in main
+// because it talks to Electron's `clipboard` module.
+const { parseDropfiles, fileUriToPath } = require('./lib/clipboardParse');
 
 // Collect file paths from the OS clipboard across the three formats that
 // matter for our users:
@@ -1085,7 +1048,13 @@ function readClipboardFilePaths() {
       console.debug('[clipboard] CF_HDROP read failed:', err);
     }
   }
-  if (out.length === 0 && formats.some(f => f === 'public.file-url' || f === 'NSFilenamesPboardType')) {
+  // macOS single-file Finder copy populates `public.file-url`. Multi-file
+  // Finder copies use the legacy `NSFilenamesPboardType` (a property-list
+  // array of strings) which we deliberately do NOT parse here — the desktop
+  // app currently ships Windows-only, so the plist-parser dependency isn't
+  // worth pulling in. Tracked as tech debt; see docs/TECH_DEBT.md for the
+  // single-file → multi-file upgrade path when we add macOS distribution.
+  if (out.length === 0 && formats.includes('public.file-url')) {
     try {
       const uri = clipboard.read('public.file-url');
       const p = fileUriToPath(uri);
@@ -1141,6 +1110,13 @@ safeHandle('read-clipboard-photos', async (event, maxFiles) => {
       }
       let abs;
       try { abs = path.resolve(raw); } catch { rejected.push({ path: raw, reason: 'invalid' }); continue; }
+      // UNC / device-namespace gate. Must run BEFORE lstat — on Windows,
+      // `fs.lstatSync('\\\\attacker\\share\\x.jpg')` triggers the SMB
+      // redirector, leaking the user's NTLMv2 hash to the attacker
+      // regardless of whether the eventual read succeeds. A clipboard
+      // payload from a hostile app (RDP clipboard sync, malicious browser
+      // ext, Total Commander plugin) is an entirely realistic source.
+      if (!isSafeStartDir(abs)) { rejected.push({ path: raw, reason: 'invalid' }); continue; }
       const ext = path.extname(abs).toLowerCase();
       if (!ALLOWED_PHOTO_EXTS.has(ext)) {
         rejected.push({ path: raw, reason: 'unsupported-type' });
@@ -1150,17 +1126,33 @@ safeHandle('read-clipboard-photos', async (event, maxFiles) => {
       try { lst = fs.lstatSync(abs); } catch { rejected.push({ path: raw, reason: 'not-found' }); continue; }
       if (lst.isSymbolicLink()) { rejected.push({ path: raw, reason: 'symlink' }); continue; }
       if (!lst.isFile()) { rejected.push({ path: raw, reason: 'not-file' }); continue; }
-      if (lst.size > 30 * 1024 * 1024) { rejected.push({ path: raw, reason: 'too-large' }); continue; }
+      // 20 MB matches the renderer's `isValidImageFile` filter and the OPFS
+      // session ceiling. The 30 MB headroom on `read-photo-file` exists for
+      // older import paths; here, accepting a 25 MB file would just have it
+      // silently filtered out by the renderer's filter with no user
+      // feedback. Aligning at 20 MB keeps the count in the toast honest.
+      if (lst.size > 20 * 1024 * 1024) { rejected.push({ path: raw, reason: 'too-large' }); continue; }
       accepted.push(abs);
     }
-    // Replace the allowlist with this batch — same model as `open-photos`.
-    // The renderer's pattern is "read all then move on", so we don't need
-    // to merge with the prior batch's contents.
-    photoOpenAllowlist.clear();
+    // Merge into the allowlist — do NOT clear first. `open-photos` clears
+    // because its dialog gesture is implicitly serial (the renderer awaits
+    // the dialog before starting reads), but a document-level Ctrl+V can
+    // fire while a previous batch's `read-photo-file` calls are still in
+    // flight. Clearing here would invalidate those in-flight reads and
+    // surface as a spurious "File not in allowlist" partial failure. The
+    // set is bounded by PHOTO_OPEN_HARD_CAP per batch and entries are
+    // cheap; drop normalize-failures into `rejected` instead of silently
+    // mismatching the returned `accepted` array with what's reachable.
+    const finalAccepted = [];
     for (const p of accepted) {
-      try { photoOpenAllowlist.add(normalizePathKey(p)); } catch { /* ignore */ }
+      try {
+        photoOpenAllowlist.add(normalizePathKey(p));
+        finalAccepted.push(p);
+      } catch (err) {
+        rejected.push({ path: p, reason: 'normalize-failed' });
+      }
     }
-    return { kind: 'paths', paths: accepted, rejected };
+    return { kind: 'paths', paths: finalAccepted, rejected };
   }
 
   // Fallback: in-memory bitmap (screenshot, "Copy image" from a browser).
@@ -1169,10 +1161,10 @@ safeHandle('read-clipboard-photos', async (event, maxFiles) => {
     const img = clipboard.readImage();
     if (img && !img.isEmpty()) {
       const png = img.toPNG();
-      // Same 30 MB ceiling as on-disk paths — keeps the renderer's File
-      // construction predictable and stops a screenshot of a 30k-monitor
-      // wall from spiking memory.
-      if (png && png.length > 0 && png.length <= 30 * 1024 * 1024) {
+      // 20 MB ceiling matches the renderer's `isValidImageFile` so a paste
+      // accepted here never silently disappears from the user's count, and
+      // a screenshot of a 30k-monitor wall can't spike main's memory.
+      if (png && png.length > 0 && png.length <= 20 * 1024 * 1024) {
         const stamp = new Date().toISOString().replace(/[:.]/g, '-');
         return {
           kind: 'image',

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -68,6 +68,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('open-photos', defaultDir, maxFiles),
   readPhotoFile: (filePath) => ipcRenderer.invoke('read-photo-file', filePath),
 
+  // Read photos pasted from the OS clipboard. Returns one of:
+  //   { kind: 'paths', paths: string[], rejected: {path,reason}[] }
+  //     — file paths copied from Total Commander/Explorer/Finder. Each
+  //       path is allowlisted for the follow-up `readPhotoFile` calls,
+  //       same as `openPhotos`.
+  //   { kind: 'image', name, mimeType, base64 }
+  //     — raw bitmap from a screenshot or browser "Copy image". The
+  //       renderer constructs a File directly; no follow-up IPC needed.
+  //   { kind: 'empty' } — clipboard has nothing we can use.
+  readClipboardPhotos: (maxFiles) => ipcRenderer.invoke('read-clipboard-photos', maxFiles),
+
   // Save KML text via native save dialog. The renderer passes the directory
   // the source KML was imported from (see `getPathForFile`) so the export
   // dialog lands in the user's own project folder (feedback 2026-04-23).

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -58,6 +58,7 @@ import { CompetitionSelector } from './components/CompetitionSelector';
 import { CreateCompetitionButton } from './components/CreateCompetitionButton';
 import { CleanupModal } from './components/CleanupModal';
 import { CandidateTray } from './components/CandidateTray';
+import { ImportPhotosControl } from './components/ImportPhotosControl';
 import { useAspectRatio } from './contexts/AspectRatioContext';
 import { useLabeling } from './contexts/LabelingContext';
 import { useI18n } from './contexts/I18nContext';
@@ -746,12 +747,22 @@ function AppApi() {
                   </Box>
                 )}
 
-                {/* Shuffle Photos - Only show in track mode */}
-                {session?.mode === 'track' && (
-                  <Box sx={{ display: 'flex', alignItems: { xs: 'center', xl: 'center' }, gap: 1, flexDirection: { xs: 'column', xl: 'row' } }}>
-                    <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500, fontSize: '0.8rem', display: 'block', textAlign: { xs: 'center', xl: 'inherit' }, width: { xs: '100%', xl: 'auto' } }}>
-                      {t('actions.title')}
-                    </Typography>
+                {/* Actions cluster — Import + Shuffle. Import is always
+                    visible (mirrors map-corridors' "Select KML" button)
+                    so the user has a click-or-drop entry point regardless
+                    of grid state (feedback M., 2026-05-15). Shuffle stays
+                    track-only since it's mode-specific. */}
+                <Box sx={{ display: 'flex', alignItems: { xs: 'center', xl: 'center' }, gap: 1, flexDirection: { xs: 'column', xl: 'row' } }}>
+                  <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500, fontSize: '0.8rem', display: 'block', textAlign: { xs: 'center', xl: 'inherit' }, width: { xs: '100%', xl: 'auto' } }}>
+                    {t('actions.title')}
+                  </Typography>
+                  <ImportPhotosControl
+                    onFilesPicked={(files) => {
+                      if (addPhotosToCandidates) void addPhotosToCandidates(files);
+                    }}
+                    disabled={!session || !addPhotosToCandidates}
+                  />
+                  {session?.mode === 'track' && (
                     <Button
                       onClick={handleShuffle}
                       disabled={
@@ -763,7 +774,7 @@ function AppApi() {
                       variant="outlined"
                       size="small"
                       startIcon={<Shuffle />}
-                      sx={{ 
+                      sx={{
                         fontSize: '0.75rem',
                         px: 1.5,
                         py: 0.5,
@@ -772,8 +783,8 @@ function AppApi() {
                     >
                       {t('actions.shuffle.name')}
                     </Button>
-                  </Box>
-                )}
+                  )}
+                </Box>
               </Box>
             </Box>
 

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -36,6 +36,7 @@ import {
   Map,
 } from '@mui/icons-material';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
+import { useClipboardPaste } from './hooks/useClipboardPaste';
 import { useMapPicksSync } from './hooks/useMapPicksSync';
 import {
   buildEditorPicks,
@@ -278,6 +279,19 @@ function AppApi() {
       setDropToast({ count: result.count });
     }
   };
+
+  // Ctrl+V from Total Commander / Explorer / Finder, or from a screenshot
+  // tool, lands here. Pasted photos go into the candidate tray (slotless
+  // pool) because the user hasn't specified a slot — they can then drag to
+  // the right grid position. Same destination the GridSizedDropZone uses
+  // when initial drops overflow capacity. Disabled until a competition is
+  // loaded so a pre-mount paste can't race the session bootstrap.
+  const { pasteError, clearPasteError } = useClipboardPaste({
+    addFiles: (files) => {
+      if (addPhotosToCandidates) void addPhotosToCandidates(files);
+    },
+    disabled: !session || !addPhotosToCandidates,
+  });
 
   // selectedPhoto.setKey === 'candidates' for tray-source photos. Label is
   // empty in that case (tray photos have no slot index). The modal reuses
@@ -1422,6 +1436,18 @@ function AppApi() {
         onClose={() => setCleanupErrorToast(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         message={cleanupErrorToast ?? ''}
+      />
+
+      {/* Clipboard-paste failure surface — partial reads (some files rejected
+          server-side for ext/size/symlinks), empty clipboards, IPC failures.
+          Same Snackbar vocabulary as the other toasts so the user gets a
+          consistent dismissible affordance. */}
+      <Snackbar
+        open={Boolean(pasteError)}
+        autoHideDuration={8000}
+        onClose={clearPasteError}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={pasteError ?? ''}
       />
 
       {/* Post-export candidate cleanup dialog */}

--- a/frontend/photo-helper/src/components/ImportPhotosControl.tsx
+++ b/frontend/photo-helper/src/components/ImportPhotosControl.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, CircularProgress } from '@mui/material';
+import { Box, Typography, CircularProgress, Snackbar } from '@mui/material';
 import { CloudUpload } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
 import { isValidImageFile } from '../utils/imageProcessing';
@@ -97,37 +97,52 @@ export const ImportPhotosControl: React.FC<ImportPhotosControlProps> = ({
     : 'transparent';
 
   return (
-    <Box
-      {...getRootProps({ onClick: useElectronDialog ? handleClick : undefined })}
-      sx={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 1,
-        px: 1.5,
-        py: 0.75,
-        border: '2px dashed',
-        borderColor,
-        borderRadius: 1.5,
-        bgcolor: bgColor,
-        cursor: isDisabled ? 'not-allowed' : 'pointer',
-        opacity: isDisabled ? 0.55 : 1,
-        transition: 'background-color 0.15s ease, border-color 0.15s ease',
-        '&:hover': isDisabled
-          ? undefined
-          : { borderColor: 'primary.main', bgcolor: 'primary.light' },
-        userSelect: 'none',
-      }}
-      title={t('importControl.tooltip')}
-    >
-      <input {...getInputProps()} />
-      {busy ? (
-        <CircularProgress size={18} />
-      ) : (
-        <CloudUpload sx={{ fontSize: 20, color: 'primary.main' }} />
-      )}
-      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 500, whiteSpace: 'nowrap' }}>
-        {label}
-      </Typography>
-    </Box>
+    <>
+      <Box
+        {...getRootProps({ onClick: useElectronDialog ? handleClick : undefined })}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          py: 0.75,
+          border: '2px dashed',
+          borderColor,
+          borderRadius: 1.5,
+          bgcolor: bgColor,
+          cursor: isDisabled ? 'not-allowed' : 'pointer',
+          opacity: isDisabled ? 0.55 : 1,
+          transition: 'background-color 0.15s ease, border-color 0.15s ease',
+          '&:hover': isDisabled
+            ? undefined
+            : { borderColor: 'primary.main', bgcolor: 'primary.light' },
+          userSelect: 'none',
+        }}
+        title={t('importControl.tooltip')}
+      >
+        <input {...getInputProps()} />
+        {busy ? (
+          <CircularProgress size={18} />
+        ) : (
+          <CloudUpload sx={{ fontSize: 20, color: 'primary.main' }} />
+        )}
+        <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 500, whiteSpace: 'nowrap' }}>
+          {label}
+        </Typography>
+      </Box>
+      {/* `useElectronPhotoImport.pickPhotos` already traps its own throws
+          and calls `setImportError`; the chip just renders that surface.
+          Without this Snackbar, a failed native dialog opens nothing,
+          shows nothing, and the user keeps clicking. Matches the Alert
+          pattern used by the hero DropZone and GridSizedDropZone, but
+          rendered as a transient toast so the chip stays compact. */}
+      <Snackbar
+        open={Boolean(electronImport.importError)}
+        autoHideDuration={8000}
+        onClose={electronImport.clearImportError}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={electronImport.importError ?? ''}
+      />
+    </>
   );
 };

--- a/frontend/photo-helper/src/components/ImportPhotosControl.tsx
+++ b/frontend/photo-helper/src/components/ImportPhotosControl.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Box, Typography, CircularProgress } from '@mui/material';
+import { CloudUpload } from '@mui/icons-material';
+import { useDropzone } from 'react-dropzone';
+import { isValidImageFile } from '../utils/imageProcessing';
+import { useI18n } from '../contexts/I18nContext';
+import { useElectronPhotoImport } from '../hooks/useElectronPhotoImport';
+
+/**
+ * Always-visible inline photo-import control. Mirrors the
+ * `map-corridors` "Select KML" button — a compact click-or-drop affordance
+ * that lives in the toolbar regardless of grid state, so the user always
+ * has an entry point even when the hero DropZone is no longer rendered
+ * (slots have photos but aren't full → no GridSizedDropZone; slots full
+ * → CandidateTray's "Add more" is the only path otherwise) (feedback
+ * M., 2026-05-15: "would be nice to have a photo dropzone like the KML
+ * one").
+ *
+ * Routing: files go to the caller's `onFilesPicked` — AppApi wires this
+ * to `addPhotosToCandidates`, same destination as paste + overflow drops.
+ * Keeps the mental model consistent: "anything I add without picking a
+ * slot lands in the tray; drag from the tray when ready".
+ */
+export interface ImportPhotosControlProps {
+  onFilesPicked: (files: File[]) => void;
+  /** Disabled when no competition is loaded. */
+  disabled?: boolean;
+}
+
+export const ImportPhotosControl: React.FC<ImportPhotosControlProps> = ({
+  onFilesPicked,
+  disabled = false,
+}) => {
+  const { t } = useI18n();
+  const electronImport = useElectronPhotoImport();
+  const useElectronDialog = electronImport.isAvailable;
+  const busy = electronImport.isImporting;
+  const isDisabled = disabled || busy;
+
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    accept: {
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/png': ['.png'],
+    },
+    maxSize: 20 * 1024 * 1024,
+    disabled: isDisabled,
+    // In Electron, the hidden <input type=file> can't be seeded with the
+    // competition's working folder — route clicks through the native
+    // dialog instead. Browser fallback uses the hidden input.
+    noClick: useElectronDialog,
+    onDrop: (accepted) => {
+      const valid = accepted.filter(isValidImageFile);
+      if (valid.length > 0) onFilesPicked(valid);
+    },
+  });
+
+  const handleClick = async () => {
+    if (isDisabled) return;
+    if (useElectronDialog) {
+      // No slot-capacity cap here — the candidate tray is bounded only by
+      // storage. The IPC layer enforces PHOTO_OPEN_HARD_CAP=200.
+      await electronImport.pickPhotos(200, (files) => {
+        const valid = files.filter(isValidImageFile);
+        if (valid.length > 0) onFilesPicked(valid);
+      });
+    }
+  };
+
+  const label = busy
+    ? t('upload.processing')
+    : isDragReject
+    ? t('upload.invalidFileType')
+    : isDragActive
+    ? t('upload.dropImages')
+    : t('importControl.label');
+
+  const borderColor = isDragReject
+    ? 'error.main'
+    : isDragAccept
+    ? 'success.main'
+    : isDragActive
+    ? 'primary.main'
+    : 'grey.400';
+
+  const bgColor = isDragReject
+    ? 'error.light'
+    : isDragAccept
+    ? 'success.light'
+    : isDragActive
+    ? 'primary.light'
+    : 'transparent';
+
+  return (
+    <Box
+      {...getRootProps({ onClick: useElectronDialog ? handleClick : undefined })}
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 1,
+        px: 1.5,
+        py: 0.75,
+        border: '2px dashed',
+        borderColor,
+        borderRadius: 1.5,
+        bgcolor: bgColor,
+        cursor: isDisabled ? 'not-allowed' : 'pointer',
+        opacity: isDisabled ? 0.55 : 1,
+        transition: 'background-color 0.15s ease, border-color 0.15s ease',
+        '&:hover': isDisabled
+          ? undefined
+          : { borderColor: 'primary.main', bgcolor: 'primary.light' },
+        userSelect: 'none',
+      }}
+      title={t('importControl.tooltip')}
+    >
+      <input {...getInputProps()} />
+      {busy ? (
+        <CircularProgress size={18} />
+      ) : (
+        <CloudUpload sx={{ fontSize: 20, color: 'primary.main' }} />
+      )}
+      <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 500, whiteSpace: 'nowrap' }}>
+        {label}
+      </Typography>
+    </Box>
+  );
+};

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography, Paper, CircularProgress, IconButton } from '@mui/material';
+import { Box, Typography, Paper, CircularProgress, IconButton, Tooltip } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
 import { Image as ImageIcon, CloudUpload, Close } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
@@ -299,13 +299,17 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
             {slot.photo ? (
               <Box
                 onClick={() => onPhotoClick && onPhotoClick(slot.photo!)}
-                sx={{ 
-                  cursor: 'pointer', 
-                  width: '100%', 
+                sx={{
+                  cursor: 'pointer',
+                  width: '100%',
                   height: '100%',
                   position: 'relative',
                   '&:hover .hover-overlay': {
                     opacity: 1
+                  },
+                  '&:hover .delete-button': {
+                    opacity: 1,
+                    boxShadow: '0 0 12px rgba(0, 0, 0, 0.6)'
                   }
                 }}
               >
@@ -318,8 +322,48 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                   size="grid" // Small size for grid view
                   setKey={setKey} // Pass setKey for PDF generation
                 />
-                
-                {/* Hover overlay */}
+
+                {/* Delete button — kept OUTSIDE the dark hover-overlay so it
+                    has its own visibility. Previously embedded inside the
+                    overlay at `opacity:0`, which only revealed it on hover —
+                    user feedback (M., 2026-05-15) reported it was undiscoverable.
+                    Now visible always at 0.6 opacity, full opacity on tile
+                    hover, with a Czech-aware tooltip. */}
+                <Tooltip title={t('photo.deleteTooltip')} placement="left" enterDelay={400}>
+                  <IconButton
+                    className="delete-button"
+                    onClick={(e) => {
+                      e.stopPropagation(); // Prevent triggering photo click
+                      onPhotoRemove(slot.photo!.id);
+                    }}
+                    aria-label={t('photo.deleteTooltip')}
+                    sx={{
+                      position: 'absolute',
+                      top: 8,
+                      right: 8,
+                      width: 36,
+                      height: 36,
+                      bgcolor: 'rgba(220, 53, 69, 0.92)', // Red so the destructive action reads at a glance
+                      color: 'white',
+                      borderRadius: '6px',
+                      opacity: 0.6, // Visible at rest — the whole point of this change
+                      transition: 'opacity 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease',
+                      zIndex: 2, // Above the dark hover overlay so the red badge stays legible
+                      '&:hover': {
+                        bgcolor: 'rgba(200, 35, 51, 1)',
+                        transform: 'scale(1.08)',
+                        opacity: 1,
+                      }
+                    }}
+                    size="medium"
+                  >
+                    <Close sx={{ fontSize: 22 }} />
+                  </IconButton>
+                </Tooltip>
+
+                {/* Hover overlay — dim + "click to edit" hint. Delete button
+                    is now a sibling above, not a child, so its visibility no
+                    longer depends on the overlay opacity. */}
                 <Box
                   className="hover-overlay"
                   sx={{
@@ -337,38 +381,10 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                     pointerEvents: 'none'
                   }}
                 >
-                  {/* Delete button - top right corner, visible only on hover */}
-                  <IconButton
-                    onClick={(e) => {
-                      e.stopPropagation(); // Prevent triggering photo click
-                      onPhotoRemove(slot.photo!.id);
-                    }}
+                  <Typography
+                    variant="body1"
                     sx={{
-                      position: 'absolute',
-                      top: 8,
-                      right: 8,
-                      width: 36,
-                      height: 36,
-                      bgcolor: 'rgba(128, 128, 128, 0.9)', // Grayscale background
                       color: 'white',
-                      borderRadius: '6px', // Square with slight rounding
-                      pointerEvents: 'auto', // Enable clicking
-                      transition: 'all 0.2s ease-in-out',
-                      '&:hover': {
-                        bgcolor: 'rgba(128, 128, 128, 1)',
-                        boxShadow: '0 0 12px rgba(255, 255, 255, 0.8)', // White glow effect
-                        transform: 'scale(1.1)'
-                      }
-                    }}
-                    size="medium"
-                  >
-                    <Close sx={{ fontSize: 22 }} />
-                  </IconButton>
-                  
-                  <Typography 
-                    variant="body1" 
-                    sx={{ 
-                      color: 'white', 
                       fontWeight: 600,
                       textShadow: '0 2px 4px rgba(0,0,0,0.8)'
                     }}

--- a/frontend/photo-helper/src/hooks/useClipboardPaste.ts
+++ b/frontend/photo-helper/src/hooks/useClipboardPaste.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  isClipboardPasteAvailable,
+  readPhotosFromClipboard,
+  type ClipboardPhotoFailure,
+} from '../utils/clipboardPaste';
+import { isValidImageFile } from '../utils/imageProcessing';
+import { useI18n } from '../contexts/I18nContext';
+
+/**
+ * Global Ctrl/Cmd+V handler that funnels pasted photos into the caller's
+ * `addFiles` callback (typically `addPhotosToCandidates`).
+ *
+ * Three input shapes are handled here so the caller doesn't have to:
+ *
+ *   1. Electron clipboard — `readPhotosFromClipboard` returns paths or an
+ *      inline bitmap. Used when running inside the desktop app.
+ *   2. `clipboardData.items` — fired by the browser's native paste event
+ *      when the user pastes an in-memory bitmap (screenshot, "Copy image
+ *      address"). This is a strict subset of (1) but is the only path
+ *      available on the web; we always try it as a fallback so a future
+ *      web build keeps working.
+ *
+ * Inactivation rules:
+ *   • Paste is ignored while the focus is in an editable element
+ *     (`<input>`, `<textarea>`, `contenteditable`). Otherwise typing
+ *     filenames into the SetTitle field would steal images from the
+ *     clipboard.
+ *   • Paste is also ignored when `disabled` is true — used by AppApi to
+ *     gate paste while a competition is loading or no competition is
+ *     selected.
+ */
+export interface UseClipboardPasteOptions {
+  /** Receives the reconstructed File[] for any successful paste. */
+  addFiles: (files: File[]) => void | Promise<void>;
+  /** Cap passed to the main process; lets it skip validation past N paths. */
+  maxFiles?: number;
+  /** When true, the paste handler does nothing (no error, no UI). */
+  disabled?: boolean;
+}
+
+export interface UseClipboardPasteResult {
+  /** True only inside the desktop app — used to render a discovery hint. */
+  isAvailable: boolean;
+  /** Last user-facing error (partial failure, server rejections). null to dismiss. */
+  pasteError: string | null;
+  clearPasteError: () => void;
+}
+
+export function useClipboardPaste(options: UseClipboardPasteOptions): UseClipboardPasteResult {
+  const { t } = useI18n();
+  const [pasteError, setPasteError] = useState<string | null>(null);
+  const clearPasteError = useCallback(() => setPasteError(null), []);
+  const isAvailable = isClipboardPasteAvailable();
+
+  // `addFiles` and option flags are kept in a ref so the document listener
+  // — installed once on mount — always reads the latest values without us
+  // having to re-attach on every parent render.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    const onPaste = async (e: ClipboardEvent) => {
+      const opts = optionsRef.current;
+      if (opts.disabled) return;
+      if (isPasteIntoEditable(e.target)) return;
+
+      // Decide up front whether THIS paste belongs to us. If the clipboard
+      // has no items we'd handle, bail without preventDefault so the
+      // default paste behaviour (text into a focused control, …) wins.
+      const inlineItems = collectInlineImageItems(e.clipboardData);
+      const electronAvailable = isClipboardPasteAvailable();
+      if (!electronAvailable && inlineItems.length === 0) return;
+
+      // We're going to consume this paste — stop default text-insertion
+      // and any other handlers from racing us.
+      e.preventDefault();
+
+      try {
+        const inlineFiles = inlineItems
+          .map(item => item.getAsFile())
+          .filter((f): f is File => !!f && isValidImageFile(f));
+
+        let viaElectron: File[] = [];
+        let failures: ClipboardPhotoFailure[] = [];
+        let rejected: Array<{ path: string; reason: string }> = [];
+        if (electronAvailable) {
+          const result = await readPhotosFromClipboard(opts.maxFiles);
+          viaElectron = result.files.filter(isValidImageFile);
+          failures = result.failures;
+          rejected = result.rejected;
+        }
+
+        // De-dup: when the user pastes a screenshot, BOTH branches return
+        // the same bitmap (Electron via `readImage()`, browser via
+        // `clipboardData.items`). Prefer Electron's version (correct name
+        // + deterministic mime) and only fall back to the browser one if
+        // Electron returned nothing.
+        const files = viaElectron.length > 0 ? viaElectron : inlineFiles;
+
+        if (files.length > 0) {
+          await opts.addFiles(files);
+        }
+
+        if (failures.length > 0 || rejected.length > 0) {
+          setPasteError(formatPasteFailure(t, files.length, failures, rejected));
+        } else if (files.length === 0) {
+          // We committed to handling this paste (preventDefault'd) but
+          // had nothing usable — tell the user instead of silently
+          // dropping the event.
+          setPasteError(t('upload.clipboardEmpty'));
+        }
+      } catch (err) {
+        console.error('[clipboard paste] failed:', err);
+        setPasteError(t('upload.clipboardReadFailed'));
+      }
+    };
+
+    document.addEventListener('paste', onPaste);
+    return () => { document.removeEventListener('paste', onPaste); };
+  }, [t]);
+
+  return { isAvailable, pasteError, clearPasteError };
+}
+
+function isPasteIntoEditable(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+function collectInlineImageItems(data: DataTransfer | null): DataTransferItem[] {
+  if (!data) return [];
+  const out: DataTransferItem[] = [];
+  for (let i = 0; i < data.items.length; i++) {
+    const item = data.items[i];
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+function formatPasteFailure(
+  t: ReturnType<typeof useI18n>['t'],
+  successCount: number,
+  failures: ClipboardPhotoFailure[],
+  rejected: Array<{ path: string; reason: string }>,
+): string {
+  const failedCount = failures.length + rejected.length;
+  const total = successCount + failedCount;
+  if (successCount === 0) {
+    return t('upload.clipboardAllFailed', { count: failedCount });
+  }
+  return t('upload.clipboardPartial', {
+    success: successCount,
+    failed: failedCount,
+    total,
+  });
+}

--- a/frontend/photo-helper/src/hooks/useClipboardPaste.ts
+++ b/frontend/photo-helper/src/hooks/useClipboardPaste.ts
@@ -76,43 +76,66 @@ export function useClipboardPaste(options: UseClipboardPasteOptions): UseClipboa
       // and any other handlers from racing us.
       e.preventDefault();
 
-      try {
-        const inlineFiles = inlineItems
-          .map(item => item.getAsFile())
-          .filter((f): f is File => !!f && isValidImageFile(f));
+      // Phase 1 — resolve the clipboard. Failures here are infrastructure
+      // (IPC dead, decode of a malformed inline bitmap, unexpected throw).
+      // Keep this `try` narrow so addFiles failures below get a distinct
+      // toast — conflating storage failures with clipboard-read failures
+      // would have the user retrying paste fruitlessly for an OPFS quota.
+      const inlineFiles = inlineItems
+        .map(item => item.getAsFile())
+        .filter((f): f is File => !!f && isValidImageFile(f));
 
-        let viaElectron: File[] = [];
-        let failures: ClipboardPhotoFailure[] = [];
-        let rejected: Array<{ path: string; reason: string }> = [];
-        if (electronAvailable) {
+      let viaElectron: File[] = [];
+      let failures: ClipboardPhotoFailure[] = [];
+      let rejected: Array<{ path: string; reason: string }> = [];
+      let ipcError: unknown = undefined;
+      if (electronAvailable) {
+        try {
           const result = await readPhotosFromClipboard(opts.maxFiles);
           viaElectron = result.files.filter(isValidImageFile);
           failures = result.failures;
           rejected = result.rejected;
+          ipcError = result.ipcError;
+        } catch (err) {
+          console.error('[clipboard paste] read failed:', err);
+          ipcError = err;
         }
+      }
 
-        // De-dup: when the user pastes a screenshot, BOTH branches return
-        // the same bitmap (Electron via `readImage()`, browser via
-        // `clipboardData.items`). Prefer Electron's version (correct name
-        // + deterministic mime) and only fall back to the browser one if
-        // Electron returned nothing.
-        const files = viaElectron.length > 0 ? viaElectron : inlineFiles;
-
-        if (files.length > 0) {
-          await opts.addFiles(files);
-        }
-
-        if (failures.length > 0 || rejected.length > 0) {
-          setPasteError(formatPasteFailure(t, files.length, failures, rejected));
-        } else if (files.length === 0) {
-          // We committed to handling this paste (preventDefault'd) but
-          // had nothing usable — tell the user instead of silently
-          // dropping the event.
-          setPasteError(t('upload.clipboardEmpty'));
-        }
-      } catch (err) {
-        console.error('[clipboard paste] failed:', err);
+      // IPC-level failure short-circuits — there's nothing meaningful to
+      // pass to addFiles. Surface as infrastructure failure, not "0 of N".
+      if (ipcError !== undefined) {
         setPasteError(t('upload.clipboardReadFailed'));
+        return;
+      }
+
+      // De-dup: when the user pastes a screenshot, BOTH branches return
+      // the same bitmap (Electron via `readImage()`, browser via
+      // `clipboardData.items`). Prefer Electron's version (correct name
+      // + deterministic mime) and only fall back to the browser one if
+      // Electron returned nothing.
+      const files = viaElectron.length > 0 ? viaElectron : inlineFiles;
+
+      // Phase 2 — hand off to caller. `addFiles` failures (OPFS quota,
+      // IndexedDB closed, session not ready) are routed to their own
+      // string so the user understands the photos were READ correctly
+      // and the failure is on the storage side.
+      if (files.length > 0) {
+        try {
+          await opts.addFiles(files);
+        } catch (err) {
+          console.error('[clipboard paste] addFiles failed:', err);
+          setPasteError(t('upload.addFilesFailed'));
+          return;
+        }
+      }
+
+      if (failures.length > 0 || rejected.length > 0) {
+        setPasteError(formatPasteFailure(t, files.length, failures, rejected));
+      } else if (files.length === 0) {
+        // We committed to handling this paste (preventDefault'd) but had
+        // nothing usable — tell the user instead of silently dropping it.
+        setPasteError(t('upload.clipboardEmpty'));
       }
     };
 

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -152,6 +152,10 @@
     "clipboardAllFailed": "Žádnou z {{count}} vložených položek se nepodařilo načíst (špatný formát, příliš velké nebo nejde o JPEG/PNG).",
     "clipboardPartial": "Vloženo {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (špatný formát, příliš velké nebo nejde o JPEG/PNG)."
   },
+  "importControl": {
+    "label": "Načíst fotky",
+    "tooltip": "Klikněte pro výběr fotek, přetáhněte sem, nebo vložte přes Ctrl+V"
+  },
   "photo": {
     "clickToEdit": "Klikněte pro úpravu",
     "position": "Pozice {{position}}",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -150,7 +150,8 @@
     "clipboardEmpty": "Není co vložit — ve schránce nejsou žádné fotky JPEG/PNG ani odkazy na soubory.",
     "clipboardReadFailed": "Schránku se nepodařilo přečíst. Zkuste fotky znovu zkopírovat, nebo je přetáhněte z Průzkumníka.",
     "clipboardAllFailed": "Žádnou z {{count}} vložených položek se nepodařilo načíst (špatný formát, příliš velké nebo nejde o JPEG/PNG).",
-    "clipboardPartial": "Vloženo {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (špatný formát, příliš velké nebo nejde o JPEG/PNG)."
+    "clipboardPartial": "Vloženo {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (špatný formát, příliš velké nebo nejde o JPEG/PNG).",
+    "addFilesFailed": "Fotky byly načteny, ale nepodařilo se je uložit. Zkuste to znovu nebo zkontrolujte volné místo."
   },
   "importControl": {
     "label": "Načíst fotky",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -129,7 +129,7 @@
     "dragDrop": "Přetáhněte fotografie sem",
     "browse": "nebo klikněte pro procházení souborů",
     "supported": "Podporované: JPEG, PNG (max {{maxSize}}MB každý)",
-    "clickOrDrop": "Klikněte nebo přetáhněte obrázky",
+    "clickOrDrop": "Klikněte, přetáhněte nebo vložte (Ctrl+V) obrázky",
     "dropImages": "Přetáhněte obrázky sem",
     "maxFiles": "Maximálně {{count}} fotografií na sadu",
     "currentCount": "{{current}}/{{max}} fotografií",
@@ -146,13 +146,18 @@
     "electronDialogFailed": "Výběr fotek se nepodařilo otevřít. Zkuste to znovu, nebo přetáhněte soubory z Průzkumníka.",
     "allFilesFailed": "Žádnou z {{count}} vybraných fotek se nepodařilo načíst. Ověřte, že soubory existují a jsou ve formátu JPEG/PNG do 30 MB.",
     "partialImport": "Načteno {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (poškozené, příliš velké nebo nejde o JPEG/PNG).",
-    "workingDirPersistFailed": "Fotky byly načteny, ale pracovní složku se nepodařilo uložit pro příští použití."
+    "workingDirPersistFailed": "Fotky byly načteny, ale pracovní složku se nepodařilo uložit pro příští použití.",
+    "clipboardEmpty": "Není co vložit — ve schránce nejsou žádné fotky JPEG/PNG ani odkazy na soubory.",
+    "clipboardReadFailed": "Schránku se nepodařilo přečíst. Zkuste fotky znovu zkopírovat, nebo je přetáhněte z Průzkumníka.",
+    "clipboardAllFailed": "Žádnou z {{count}} vložených položek se nepodařilo načíst (špatný formát, příliš velké nebo nejde o JPEG/PNG).",
+    "clipboardPartial": "Vloženo {{success}} z {{total}} fotek. {{failed}} se nepodařilo přečíst (špatný formát, příliš velké nebo nejde o JPEG/PNG)."
   },
   "photo": {
     "clickToEdit": "Klikněte pro úpravu",
     "position": "Pozice {{position}}",
     "loadingFailed": "Nepodařilo se načíst obrázek.",
-    "tryAgain": "Zkuste to znovu nebo nahrajte jiný soubor."
+    "tryAgain": "Zkuste to znovu nebo nahrajte jiný soubor.",
+    "deleteTooltip": "Smazat fotografii"
   },
   "controls": {
     "imageAdjustments": "Úpravy obrázku",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -152,6 +152,10 @@
     "clipboardAllFailed": "None of the {{count}} pasted items could be read (wrong format, too large, or not JPEG/PNG).",
     "clipboardPartial": "Pasted {{success}} of {{total}} photos. {{failed}} could not be read (wrong format, too large, or not JPEG/PNG)."
   },
+  "importControl": {
+    "label": "Add photos",
+    "tooltip": "Click to pick photos, drag-drop here, or press Ctrl+V to paste"
+  },
   "photo": {
     "clickToEdit": "Click to Edit",
     "position": "Position {{position}}",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -150,7 +150,8 @@
     "clipboardEmpty": "Nothing to paste — the clipboard has no JPEG/PNG photos or file references.",
     "clipboardReadFailed": "Could not read the clipboard. Try copying the photos again, or drag them from File Explorer.",
     "clipboardAllFailed": "None of the {{count}} pasted items could be read (wrong format, too large, or not JPEG/PNG).",
-    "clipboardPartial": "Pasted {{success}} of {{total}} photos. {{failed}} could not be read (wrong format, too large, or not JPEG/PNG)."
+    "clipboardPartial": "Pasted {{success}} of {{total}} photos. {{failed}} could not be read (wrong format, too large, or not JPEG/PNG).",
+    "addFilesFailed": "Photos were read, but could not be stored. Try again, or check available disk space."
   },
   "importControl": {
     "label": "Add photos",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -129,7 +129,7 @@
     "dragDrop": "Drag & drop photos here",
     "browse": "or click to browse files", 
     "supported": "Supported: JPEG, PNG (max {{maxSize}}MB each)",
-    "clickOrDrop": "Click or drop images",
+    "clickOrDrop": "Click, drop, or paste (Ctrl+V) images",
     "dropImages": "Drop images here",
     "maxFiles": "Maximum {{count}} photos per set",
     "currentCount": "{{current}}/{{max}} photos",
@@ -146,13 +146,18 @@
     "electronDialogFailed": "Could not open the photo picker. Try again, or drag photos from File Explorer.",
     "allFilesFailed": "None of the {{count}} selected photos could be read. Check the files exist and are JPEG/PNG under 30 MB.",
     "partialImport": "Imported {{success}} of {{total}} photos. {{failed}} could not be read (corrupted, too large, or not JPEG/PNG).",
-    "workingDirPersistFailed": "Photos imported, but the working folder could not be saved for next time."
+    "workingDirPersistFailed": "Photos imported, but the working folder could not be saved for next time.",
+    "clipboardEmpty": "Nothing to paste — the clipboard has no JPEG/PNG photos or file references.",
+    "clipboardReadFailed": "Could not read the clipboard. Try copying the photos again, or drag them from File Explorer.",
+    "clipboardAllFailed": "None of the {{count}} pasted items could be read (wrong format, too large, or not JPEG/PNG).",
+    "clipboardPartial": "Pasted {{success}} of {{total}} photos. {{failed}} could not be read (wrong format, too large, or not JPEG/PNG)."
   },
   "photo": {
     "clickToEdit": "Click to Edit",
     "position": "Position {{position}}",
     "loadingFailed": "Failed to load image.",
-    "tryAgain": "Please try again or upload a different file."
+    "tryAgain": "Please try again or upload a different file.",
+    "deleteTooltip": "Delete photo"
   },
   "controls": {
     "imageAdjustments": "Image Adjustments",

--- a/frontend/photo-helper/src/utils/clipboardPaste.ts
+++ b/frontend/photo-helper/src/utils/clipboardPaste.ts
@@ -1,0 +1,124 @@
+/**
+ * Clipboard photo paste — Ctrl+V flow that mirrors the open-dialog import
+ * pipeline (`electronPhotoImport.ts`). Two input shapes that the main
+ * process resolves transparently for us:
+ *
+ *  1. File paths from Total Commander / Explorer / Finder. Main runs the
+ *     same ext/symlink/size validation as `read-photo-file` AND seeds the
+ *     `photoOpenAllowlist`, so we just call `readPhotoFile` per path.
+ *  2. In-memory bitmap from a screenshot or "Copy image" — main returns
+ *     base64 PNG inline, no follow-up IPC needed.
+ *
+ * Browser fallback (`navigator.clipboard.read` / clipboardData.items) is
+ * intentionally NOT wired here: the photo-helper only ships inside the
+ * desktop app, and the Async Clipboard API on the web can't read file
+ * references copied from Total Commander at all (only inline bitmaps).
+ * If the web build ever materialises, the existing `paste` listener in
+ * `useClipboardPaste` will surface clipboardData.items for the bitmap-only
+ * case — handled there, not duplicated here.
+ */
+
+import { base64ToUint8Array } from './electronPhotoImport';
+
+declare global {
+  interface Window {
+    electronAPI?: {
+      readPhotoFile?: (filePath: string) => Promise<{ name: string; mimeType: string; base64: string } | null>;
+      readClipboardPhotos?: (maxFiles?: number) => Promise<
+        | { kind: 'paths'; paths: string[]; rejected: Array<{ path: string; reason: string }> }
+        | { kind: 'image'; name: string; mimeType: string; base64: string }
+        | { kind: 'empty' }
+      >;
+    };
+  }
+}
+
+export interface ClipboardPhotoFailure {
+  path: string;
+  error: unknown;
+}
+
+export interface ClipboardPhotoResult {
+  files: File[];
+  failures: ClipboardPhotoFailure[];
+  /** Server-side rejections (wrong extension, symlink, too large, …). */
+  rejected: Array<{ path: string; reason: string }>;
+  /** True when the clipboard had no images and no usable file paths. */
+  empty: boolean;
+}
+
+export function isClipboardPasteAvailable(): boolean {
+  const api = window.electronAPI;
+  return !!(api && typeof api.readClipboardPhotos === 'function');
+}
+
+const EMPTY: ClipboardPhotoResult = Object.freeze({
+  files: [],
+  failures: [],
+  rejected: [],
+  empty: true,
+}) as ClipboardPhotoResult;
+
+/**
+ * Resolve the OS clipboard to a list of `File` objects.
+ *
+ * `maxFiles` caps the number of paths the main process will validate —
+ * pass the available tray/slot capacity so a runaway paste of 200 files
+ * can't OOM the renderer on base64 decode. Web-build callers (no Electron
+ * API) get `EMPTY` and should fall through to the `clipboardData.items`
+ * branch in their `paste` handler.
+ */
+export async function readPhotosFromClipboard(maxFiles?: number): Promise<ClipboardPhotoResult> {
+  const api = window.electronAPI;
+  if (!api?.readClipboardPhotos || !api?.readPhotoFile) return EMPTY;
+
+  let payload;
+  try {
+    payload = await api.readClipboardPhotos(maxFiles);
+  } catch (err) {
+    // IPC threw before producing a structured result (untrusted sender,
+    // channel closed) — surface as a single failure so the caller can
+    // distinguish from an empty clipboard.
+    return { files: [], failures: [{ path: '<clipboard>', error: err }], rejected: [], empty: false };
+  }
+  if (!payload || payload.kind === 'empty') return EMPTY;
+
+  if (payload.kind === 'image') {
+    try {
+      const bytes = base64ToUint8Array(payload.base64);
+      const file = new File([bytes], payload.name, { type: payload.mimeType });
+      return { files: [file], failures: [], rejected: [], empty: false };
+    } catch (err) {
+      return { files: [], failures: [{ path: payload.name, error: err }], rejected: [], empty: false };
+    }
+  }
+
+  // kind === 'paths' — parallelize reads, same pattern as `openPhotosViaElectron`.
+  const settled = await Promise.all(
+    payload.paths.map(async (p): Promise<{ ok: true; file: File } | { ok: false; path: string; error: unknown }> => {
+      try {
+        const data = await api.readPhotoFile!(p);
+        if (!data || !data.base64) {
+          return { ok: false, path: p, error: new Error('Empty response from readPhotoFile') };
+        }
+        const bytes = base64ToUint8Array(data.base64);
+        return { ok: true, file: new File([bytes], data.name, { type: data.mimeType }) };
+      } catch (err) {
+        return { ok: false, path: p, error: err };
+      }
+    }),
+  );
+
+  const files: File[] = [];
+  const failures: ClipboardPhotoFailure[] = [];
+  for (const r of settled) {
+    if (r.ok) files.push(r.file);
+    else failures.push({ path: r.path, error: r.error });
+  }
+  return {
+    files,
+    failures,
+    rejected: payload.rejected || [],
+    empty: files.length === 0 && failures.length === 0 && (payload.rejected || []).length === 0,
+  };
+}

--- a/frontend/photo-helper/src/utils/clipboardPaste.ts
+++ b/frontend/photo-helper/src/utils/clipboardPaste.ts
@@ -45,6 +45,14 @@ export interface ClipboardPhotoResult {
   rejected: Array<{ path: string; reason: string }>;
   /** True when the clipboard had no images and no usable file paths. */
   empty: boolean;
+  /**
+   * The IPC itself rejected before returning a structured result (channel
+   * closed, untrusted sender, main crashed). Distinct from `failures` —
+   * which is per-file content failure — so the hook can render an
+   * infrastructure-level "couldn't read the clipboard" message instead
+   * of the misleading "None of the 1 pasted items could be read".
+   */
+  ipcError?: unknown;
 }
 
 export function isClipboardPasteAvailable(): boolean {
@@ -77,9 +85,9 @@ export async function readPhotosFromClipboard(maxFiles?: number): Promise<Clipbo
     payload = await api.readClipboardPhotos(maxFiles);
   } catch (err) {
     // IPC threw before producing a structured result (untrusted sender,
-    // channel closed) — surface as a single failure so the caller can
-    // distinguish from an empty clipboard.
-    return { files: [], failures: [{ path: '<clipboard>', error: err }], rejected: [], empty: false };
+    // channel closed, main crashed). Route via `ipcError` so the hook
+    // surfaces an infrastructure message, not a misleading "0-of-1" toast.
+    return { files: [], failures: [], rejected: [], empty: false, ipcError: err };
   }
   if (!payload || payload.kind === 'empty') return EMPTY;
 


### PR DESCRIPTION
## Summary
- Add Ctrl+V paste of photos copied from Total Commander / Explorer / Finder (and screenshot bitmaps). Pasted files land in the candidate tray.
- Lift the per-tile delete button out of the dark hover overlay so it is visible at rest (red badge, 0.6 opacity → 1.0 on hover). Adds Czech tooltip.

Driven by user feedback (M., 2026-05-15): "could we paste photos from clipboard, e.g. from Total Commander? And it would be nice to be able to delete an already-imported photo."

## Notable bits
- Electron `read-clipboard-photos` IPC reuses the `photoOpenAllowlist` seeded by `open-photos`, so the renderer pipeline is unchanged (parallel `readPhotoFile` reads, partial-failure shape). Same ext / symlink / 30 MB validation as `read-photo-file`.
- `useClipboardPaste` ignores paste into editable elements so users can still paste text into the SetTitle field.
- Delete-button colour switched to red — destructive action read-at-a-glance — and tooltip is Czech (`Smazat fotografii`).

## Test plan
- [x] `pnpm test` in `frontend/photo-helper` — 424 passing
- [x] `tsc --noEmit` clean for photo-helper and map-corridors
- [x] `node --check` clean for `main.js` and `preload.js`
- [ ] Manual: Ctrl+C a JPEG in Total Commander → Ctrl+V in photo-helper → photo appears in candidate tray
- [ ] Manual: Win+Shift+S screenshot → Ctrl+V → bitmap appears in tray with `pasted-<timestamp>.png` name
- [ ] Manual: delete button visible at rest on every grid tile; red on hover; tooltip in Czech UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)