### PR TITLE
feat(map-corridors): rename "Select KML" button to advertise photos

### DIFF
--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "Umístění fotek",
-    "selectKml": "Načíst KML",
+    "selectKml": "Načíst KML nebo fotky",
     "exportKml": "Exportovat KML",
     "printMap": "Tisk mapy",
     "toggleBase": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app": {
     "title": "Photo Placement",
-    "selectKml": "Select KML",
+    "selectKml": "Select KML or photos",
     "exportKml": "Export KML",
     "printMap": "Print Map",
     "toggleBase": {


### PR DESCRIPTION
## Summary
- The hidden `<input type=\"file\">` behind the \"Select KML\" button already accepts `.jpg/.jpeg/.png` alongside KML/GPX (`App.tsx:1092`), and `onFileInputChange` routes images via `classifyDroppedFiles` → `handlePhotoFiles` exactly like the drop-on-map flow.
- The button label was the only thing that didn't say so — users learning paste/drop in photo-helper had no signal that the same button also picks photos in map-corridors.

## Changes
- `cs.json`: `selectKml` = `"Načíst KML"` → `"Načíst KML nebo fotky"`
- `en.json`: `selectKml` = `"Select KML"` → `"Select KML or photos"`

Matches the existing `dropHint` overlay (`"Drop KML or photos"` / `"Přetáhni KML nebo fotky"`) so the button and the drop-target agree.

## Test plan
- [x] `pnpm test` in `frontend/map-corridors` — 505 passing + 2 todo
- [x] `tsc --noEmit` clean
- [ ] Manual: launch desktop app → corridors → button reads new label in both locales; click still opens the multi-accept picker