### PR TITLE
feat(map-corridors): hard-delete photos from list and no-GPS tray #minor

### DIFF
--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -197,6 +197,7 @@ function App() {
     setNoGpsPhotos: persistNoGpsPhotos,
     setNoGpsTrayOpen: persistNoGpsTrayOpen,
     placeNoGpsPhoto,
+    removePhoto,
     setUse1NmAfterSp,
     setComputedData,
     saveOriginalKmlText,
@@ -1212,6 +1213,7 @@ function App() {
             onToggleOpen={() => { void persistNoGpsTrayOpen(!(session?.noGpsTrayOpen ?? true)) }}
             storage={storage}
             photosDir={photosDir}
+            onPhotoDelete={(photoId) => { void removePhoto(photoId) }}
           />
           {/* Phase 7 — right-side photo list panel. Auto-hides when there
               are no imported photos (KML-only sessions look unchanged). */}
@@ -1222,6 +1224,7 @@ function App() {
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
+            onPhotoDelete={(photoId) => { void removePhoto(photoId) }}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -6,7 +6,7 @@
 
 import { useMemo } from 'react'
 import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material'
-import { ExpandLess, ExpandMore } from '@mui/icons-material'
+import { Close, ExpandLess, ExpandMore } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
@@ -39,11 +39,16 @@ export interface NoGpsTrayProps {
   onToggleOpen: () => void
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
+  /**
+   * Hard-delete a photo from the corridor session entirely. Mirrors the
+   * X badge on photo-helper grid tiles.
+   */
+  onPhotoDelete: (photoId: string) => void | Promise<void>
 }
 
 export function NoGpsTray(props: NoGpsTrayProps) {
   const { t } = useI18n()
-  const { photos, open, onToggleOpen, storage, photosDir } = props
+  const { photos, open, onToggleOpen, storage, photosDir, onPhotoDelete } = props
 
   const sorted = useMemo(() => [...photos].sort(compareNoGpsPhotos), [photos])
 
@@ -94,6 +99,8 @@ export function NoGpsTray(props: NoGpsTrayProps) {
               storage={storage}
               photosDir={photosDir}
               dragHint={t('photo.tray.dragHint')}
+              onDelete={onPhotoDelete}
+              deleteTooltip={t('photo.deleteTooltip')}
             />
           ))}
         </Box>
@@ -107,49 +114,96 @@ function NoGpsTrayThumb(props: {
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
   dragHint: string
+  onDelete: (photoId: string) => void | Promise<void>
+  deleteTooltip: string
 }) {
-  const { photo, storage, photosDir, dragHint } = props
+  const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photo.photoId)
 
   return (
-    <Tooltip title={`${photo.filename} — ${dragHint}`} placement="top" enterDelay={300}>
-      <Box
-        draggable
-        role="img"
-        aria-label={`${photo.filename}. ${dragHint}.`}
-        onDragStart={(e: React.DragEvent) => {
-          e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
-          e.dataTransfer.effectAllowed = 'move'
-        }}
-        sx={{
-          width: THUMB_WIDTH_PX,
-          height: THUMB_HEIGHT_PX,
-          flexShrink: 0,
-          bgcolor: 'grey.100',
-          borderRadius: 0.5,
-          overflow: 'hidden',
-          cursor: 'grab',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          '&:active': { cursor: 'grabbing' },
-          '&:hover': { boxShadow: 1 },
-        }}
-      >
-        {state === 'ready' && url && (
-          <img
-            src={url}
-            alt={photo.filename}
-            draggable={false}
-            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', pointerEvents: 'none' }}
-          />
-        )}
-        {state !== 'ready' && (
-          <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10, px: 0.5, textAlign: 'center' }}>
-            {photo.filename}
-          </Typography>
-        )}
-      </Box>
-    </Tooltip>
+    // Outer wrapper hosts the absolute-positioned delete badge; the inner
+    // Box owns the drag affordance so dragging onto the map still works.
+    // Reveal full delete-button opacity on hover anywhere on the thumb.
+    <Box
+      sx={{
+        position: 'relative',
+        flexShrink: 0,
+        '&:hover .nogps-thumb-delete': { opacity: 1 },
+      }}
+    >
+      <Tooltip title={`${photo.filename} — ${dragHint}`} placement="top" enterDelay={300}>
+        <Box
+          draggable
+          role="img"
+          aria-label={`${photo.filename}. ${dragHint}.`}
+          onDragStart={(e: React.DragEvent) => {
+            e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
+            e.dataTransfer.effectAllowed = 'move'
+          }}
+          sx={{
+            width: THUMB_WIDTH_PX,
+            height: THUMB_HEIGHT_PX,
+            bgcolor: 'grey.100',
+            borderRadius: 0.5,
+            overflow: 'hidden',
+            cursor: 'grab',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            '&:active': { cursor: 'grabbing' },
+            '&:hover': { boxShadow: 1 },
+          }}
+        >
+          {state === 'ready' && url && (
+            <img
+              src={url}
+              alt={photo.filename}
+              draggable={false}
+              style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', pointerEvents: 'none' }}
+            />
+          )}
+          {state !== 'ready' && (
+            <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10, px: 0.5, textAlign: 'center' }}>
+              {photo.filename}
+            </Typography>
+          )}
+        </Box>
+      </Tooltip>
+      {/* Delete badge — top-right corner. `draggable={false}` so a
+          mouse-down on the X doesn't initiate the drag flow on the
+          underlying thumb; stopPropagation on the click prevents the
+          surrounding Tooltip / drag handlers from racing. */}
+      <Tooltip title={deleteTooltip} placement="top" enterDelay={400}>
+        <IconButton
+          className="nogps-thumb-delete"
+          draggable={false}
+          onDragStart={(e: React.DragEvent) => e.preventDefault()}
+          onMouseDown={e => e.stopPropagation()}
+          onClick={e => {
+            e.stopPropagation()
+            void onDelete(photo.photoId)
+          }}
+          aria-label={deleteTooltip}
+          size="small"
+          sx={{
+            position: 'absolute',
+            top: 2,
+            right: 2,
+            width: 22,
+            height: 22,
+            bgcolor: 'rgba(220, 53, 69, 0.92)',
+            color: 'white',
+            opacity: 0.6,
+            transition: 'opacity 0.15s ease, background-color 0.15s ease',
+            '&:hover': {
+              bgcolor: 'rgba(200, 35, 51, 1)',
+              opacity: 1,
+            },
+          }}
+        >
+          <Close sx={{ fontSize: 14 }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
   )
 }

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -17,7 +17,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { ChevronLeft, ChevronRight, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
+import { ChevronLeft, ChevronRight, Close, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
@@ -41,6 +41,12 @@ export interface PhotoListPanelProps {
    * navigating, per ADR-009.
    */
   onSendToEditor?: () => void | Promise<void>
+  /**
+   * Hard-delete a photo from the corridor session entirely. Mirrors the
+   * X badge on photo-helper grid tiles. Removes from both `markers` and
+   * `noGpsPhotos`, best-effort cleans the file + thumb from storage.
+   */
+  onPhotoDelete: (photoId: string) => void | Promise<void>
 }
 
 type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
@@ -49,7 +55,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -113,7 +119,7 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               count={groupCount(groups, key)}
               collapsed={collapsedGroups[key]}
               onToggle={() => toggleGroup(key)}
-              items={renderGroupItems(groups, key, { storage, photosDir, onMarkerClick })}
+              items={renderGroupItems(groups, key, { storage, photosDir, onMarkerClick, onPhotoDelete, deleteTooltip: t('photo.deleteTooltip') })}
             />
           ))}
         </Box>
@@ -176,6 +182,8 @@ function renderGroupItems(
     storage: StorageInterface | null
     photosDir: DirectoryHandle | null
     onMarkerClick: (markerId: string) => void
+    onPhotoDelete: (photoId: string) => void | Promise<void>
+    deleteTooltip: string
   },
 ): React.ReactNode {
   if (key === 'noGps') {
@@ -188,6 +196,8 @@ function renderGroupItems(
         photosDir={ctx.photosDir}
         // No marker yet — clicking is a no-op for v1. User drags from tray.
         onClick={undefined}
+        onDelete={ctx.onPhotoDelete}
+        deleteTooltip={ctx.deleteTooltip}
       />
     ))
   }
@@ -200,6 +210,8 @@ function renderGroupItems(
       storage={ctx.storage}
       photosDir={ctx.photosDir}
       onClick={() => ctx.onMarkerClick(m.id)}
+      onDelete={ctx.onPhotoDelete}
+      deleteTooltip={ctx.deleteTooltip}
     />
   ))
 }
@@ -210,41 +222,86 @@ function PhotoListItem(props: {
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
   onClick: (() => void) | undefined
+  onDelete: (photoId: string) => void | Promise<void>
+  deleteTooltip: string
 }) {
-  const { photoId, filename, storage, photosDir, onClick } = props
+  const { photoId, filename, storage, photosDir, onClick, onDelete, deleteTooltip } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
   return (
-    <ListItemButton
-      onClick={onClick}
-      disabled={!onClick}
-      sx={{ py: 0.5, gap: 1 }}
+    <Box
+      sx={{
+        position: 'relative',
+        // Reveal full delete-button opacity on hover anywhere on the row,
+        // matching the photo-helper grid-tile pattern.
+        '&:hover .photo-row-delete': { opacity: 1 },
+      }}
     >
-      <Box
-        sx={{
-          width: THUMB_W_PX,
-          height: THUMB_H_PX,
-          flexShrink: 0,
-          bgcolor: 'grey.100',
-          borderRadius: 0.5,
-          overflow: 'hidden',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
+      <ListItemButton
+        onClick={onClick}
+        disabled={!onClick}
+        sx={{ py: 0.5, gap: 1, pr: 4 /* room for the delete badge */ }}
       >
-        {state === 'ready' && url && (
-          <img
-            src={url}
-            alt={filename}
-            draggable={false}
-            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
-          />
-        )}
-      </Box>
-      <ListItemText
-        primary={filename}
-        primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
-      />
-    </ListItemButton>
+        <Box
+          sx={{
+            width: THUMB_W_PX,
+            height: THUMB_H_PX,
+            flexShrink: 0,
+            bgcolor: 'grey.100',
+            borderRadius: 0.5,
+            overflow: 'hidden',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {state === 'ready' && url && (
+            <img
+              src={url}
+              alt={filename}
+              draggable={false}
+              style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            />
+          )}
+        </Box>
+        <ListItemText
+          primary={filename}
+          primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
+        />
+      </ListItemButton>
+      <Tooltip title={deleteTooltip} placement="left" enterDelay={400}>
+        <IconButton
+          className="photo-row-delete"
+          // stopPropagation so the row's `onClick` (fly to marker) doesn't
+          // fire when the user clicks the X. `MouseDown` is also stopped
+          // because ListItemButton has its own ripple-effect handler that
+          // can swallow the click otherwise.
+          onMouseDown={e => e.stopPropagation()}
+          onClick={e => {
+            e.stopPropagation()
+            void onDelete(photoId)
+          }}
+          aria-label={deleteTooltip}
+          size="small"
+          sx={{
+            position: 'absolute',
+            top: '50%',
+            right: 4,
+            transform: 'translateY(-50%)',
+            width: 24,
+            height: 24,
+            bgcolor: 'rgba(220, 53, 69, 0.92)', // Same red as photo-helper grid tiles
+            color: 'white',
+            opacity: 0.6, // Visible at rest — discoverable without hover
+            transition: 'opacity 0.15s ease, background-color 0.15s ease',
+            '&:hover': {
+              bgcolor: 'rgba(200, 35, 51, 1)',
+              opacity: 1,
+            },
+          }}
+        >
+          <Close sx={{ fontSize: 14 }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
   )
 }

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -4,6 +4,7 @@ import type { Discipline } from '../corridors/preciseCorridor'
 import type { NoGpsPhoto, PhotoMarker, GroundMarker } from '../types/markers'
 import { sanitizeGroundMarkers, sanitizeNoGpsPhotos, sanitizePhotoMarkers } from '../types/markers'
 import {
+  deletePhotoThumb,
   initStorage,
   isStorageAvailable,
   loadOrCreateSessionId,
@@ -151,6 +152,11 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   // target for imported photo bytes + thumbnails (see ADR-005 storage
   // layout: `competitions/{compId}/photos/`).
   const [photosDir, setPhotosDir] = useState<DirectoryHandle | null>(null)
+  // Ref mirror so `removePhoto` (and any future cleanup action) can do
+  // best-effort storage IO without re-binding the callback on every
+  // photosDir change — same pattern as storageRef / sessionDirRef.
+  const photosDirRef = useRef<DirectoryHandle | null>(null)
+  useEffect(() => { photosDirRef.current = photosDir }, [photosDir])
   // Parent of corridors/ and photos/. Where map-picks.json lands
   // (Phase 8 cross-app handoff). Null in the legacy flat-session path.
   const [competitionDir, setCompetitionDir] = useState<DirectoryHandle | null>(null)
@@ -354,6 +360,47 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     return true
   }, [persistSession])
 
+  // Remove a photo from this corridor session entirely. Mirrors the X
+  // affordance on photo-helper grid tiles — a single click destroys the
+  // selection, no confirmation (speed matters during flying-competition
+  // review). The photo is filtered out of BOTH `markers` and
+  // `noGpsPhotos` in one persistSession call; in practice only one of
+  // the two contains the id, but filtering both costs nothing and
+  // survives transitional states (`placeNoGpsPhoto` window).
+  //
+  // Storage cleanup is best-effort and runs after the state write. A
+  // failed unlink leaves orphaned bytes under `photos/` (or `thumbs/`)
+  // that the next session reload simply doesn't surface — preferable to
+  // keeping the photo visible because of an unrelated quota / FS hiccup.
+  const removePhoto = useCallback(async (photoId: string): Promise<void> => {
+    const current = sessionRef.current
+    if (!current) return
+    const hadMarker = current.markers.some(m => m.photoId === photoId)
+    const hadNoGps = (current.noGpsPhotos || []).some(p => p.photoId === photoId)
+    if (!hadMarker && !hadNoGps) return
+    await persistSession({
+      ...current,
+      markers: hadMarker
+        ? current.markers.filter(m => m.photoId !== photoId)
+        : current.markers,
+      noGpsPhotos: hadNoGps
+        ? (current.noGpsPhotos || []).filter(p => p.photoId !== photoId)
+        : (current.noGpsPhotos || []),
+      version: current.version + 1,
+      updatedAt: new Date().toISOString(),
+    })
+    const storage = storageRef.current
+    const dir = photosDirRef.current
+    if (storage && dir) {
+      storage.deletePhotoFile(dir, photoId).catch((err: unknown) => {
+        console.warn('[corridor session] photo file cleanup failed', photoId, err)
+      })
+      deletePhotoThumb(storage, dir, photoId).catch((err: unknown) => {
+        console.warn('[corridor session] photo thumb cleanup failed', photoId, err)
+      })
+    }
+  }, [persistSession])
+
   const saveOriginalKmlText = useCallback(async (text: string | null) => {
     if (!sessionRef.current) return
     const storage = storageRef.current
@@ -416,6 +463,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     setNoGpsPhotos,
     setNoGpsTrayOpen,
     placeNoGpsPhoto,
+    removePhoto,
     setComputedData,
     saveOriginalKmlText,
     loadOriginalKmlText,

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -60,6 +60,7 @@
       "collapse": "Skrýt seznam fotek",
       "sendToEditor": "Poslat do editoru ({{count}})"
     },
+    "deleteTooltip": "Smazat fotografii",
     "handoff": {
       "flushFailed": "Výběr se nepodařilo uložit před otevřením editoru. Zkontrolujte úložiště a zkuste to znovu.",
       "editorSyncFailed": "Nepodařilo se použít nejnovější popisky z editoru."

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -60,6 +60,7 @@
       "collapse": "Hide photo list",
       "sendToEditor": "Send to editor ({{count}})"
     },
+    "deleteTooltip": "Delete photo",
     "handoff": {
       "flushFailed": "Couldn't save picks before opening the editor. Check storage and try again.",
       "editorSyncFailed": "Couldn't apply latest labels from the editor."


### PR DESCRIPTION
## Summary
Photo-helper PR #66 added the red X badge for hard-deleting photos from grid tiles. Map-corridors had no equivalent — photos could only be flagged (pick / skip / reject), never removed. This PR adds the X affordance to the right-side **photo list panel** and the bottom-left **no-GPS tray**, mirroring the photo-helper visual contract.

## Visual contract (matches photo-helper)
- Red badge `rgba(220, 53, 69, 0.92)` in the top-right corner
- 0.6 opacity at rest (discoverable without hover)
- 1.0 on hover, darker red `rgba(200, 35, 51, 1)`
- Czech-aware tooltip: \"Smazat fotografii\" / \"Delete photo\"

## What's wired

### Session hook (\`useCorridorSessionOPFS\`)
New \`removePhoto(photoId)\` action:
- Atomically filters the id out of BOTH \`markers\` and \`noGpsPhotos\` in one \`persistSession\` call (filtering both is cheap and survives the transitional state during \`placeNoGpsPhoto\`).
- Best-effort storage cleanup (\`deletePhotoFile\` + \`deletePhotoThumb\`) runs after the state write. A failed unlink leaves orphan bytes that the next session reload doesn't surface — preferable to the photo reappearing because of an unrelated FS hiccup.

### UI components
- \`PhotoListPanel\` — red X positioned absolute top-right of each row, \`stopPropagation\` on click so the parent's \"fly to marker\" doesn't fire.
- \`NoGpsTray\` — red X on each thumb, with \`onDragStart preventDefault\` so a mouse-down on the X doesn't initiate the drag-to-map flow.

## Not touched
- \`PhotoMarkerPopup\` — its Include/Skip/Reject row already covers destructive classification; adding a 4th button would crowd it.
- The \`#minor\` flag triggers the next \`desktop-v*.MINOR.0\` auto-tag on release.

## Test plan
- [x] \`pnpm test\` in \`frontend/map-corridors\` — 505 passing + 2 todo
- [x] \`tsc --noEmit\` clean
- [ ] Manual smoke: import photos, click X on a list item → photo disappears, marker disappears from map
- [ ] Manual smoke: import a no-GPS photo, click X on the tray thumb → tray collapses if empty
- [ ] Manual smoke: drag a no-GPS thumb to map — drag still works (X doesn't intercept)