### PR TITLE
fix(clipboard-paste): use clipboard.has('CF_HDROP') so Windows Explorer Ctrl-V works

### DIFF
--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1040,7 +1040,16 @@ function readClipboardFilePaths() {
     }
   };
 
-  if (formats.includes('CF_HDROP')) {
+  // Direct OS-level format probe via `clipboard.has`, NOT `availableFormats`.
+  // `availableFormats()` returns Chromium's MIME-translated names (text/plain,
+  // text/html, text/uri-list, Files, image/png, …) and does NOT surface the
+  // raw Win32 format names — so `formats.includes('CF_HDROP')` is always
+  // false even when Windows Explorer / Total Commander / 7-Zip have populated
+  // CF_HDROP via Ctrl+C. `clipboard.has(format)` bypasses the translation
+  // and asks the underlying OS clipboard directly, which is what we need
+  // for native Win32 formats. Reported by user 2026-05-16: Ctrl-V from
+  // Explorer paste pasted nothing because this gate never opened.
+  if (clipboard.has('CF_HDROP')) {
     try {
       const buf = clipboard.readBuffer('CF_HDROP');
       parseDropfiles(buf).forEach(push);


### PR DESCRIPTION
## Summary
User reported (2026-05-16) that copying photos in Windows Explorer with Ctrl-C and pasting into the app with Ctrl-V produced the \"Nothing to paste\" toast, even though Explorer had populated CF_HDROP on the clipboard. The upload button worked because it doesn't touch the clipboard.

## Root cause
\`clipboard.availableFormats()\` returns Chromium's MIME-translated names (\`text/plain\`, \`text/html\`, \`text/uri-list\`, \`Files\`, \`image/png\`, …). It does NOT surface raw Win32 format names like \`CF_HDROP\`. So the guard \`formats.includes('CF_HDROP')\` evaluated to false even when CF_HDROP was on the clipboard, and the code fell through to \`public.file-url\` (macOS only) and \`text/uri-list\` (which Windows Explorer doesn't set on Ctrl-C — only on web-style drag), ending with an empty-clipboard report.

Total Commander appeared to work in earlier smoke tests because TC populates extra MIME-mapped formats too; Explorer only sets the Win32 natives, which exposed the bug.

## Fix
One-line behavioural change in \`main.js\`:

\`\`\`diff
-  if (formats.includes('CF_HDROP')) {
+  if (clipboard.has('CF_HDROP')) {
\`\`\`

\`clipboard.has(format)\` talks directly to the OS clipboard by name, bypassing Chromium's MIME translation — the right API for native Win32 formats. The \`public.file-url\` (macOS UTI) and \`text/uri-list\` (KDE/GNOME drag) branches stay on \`formats.includes\` because those ARE MIME types that availableFormats handles correctly.

## Test plan
- [x] \`pnpm test\` in \`frontend/desktop\` — 63 passing (parseDropfiles + pathValidation suites cover the parsing layer)
- [x] \`node --check main.js\` — syntax clean
- [ ] Manual: Ctrl-C a JPEG in Windows Explorer → Ctrl-V in the app → photo appears in candidate tray
- [ ] Manual: Ctrl-C in Total Commander → Ctrl-V → photos appear (regression check — was already working)
- [ ] Manual: Win+Shift+S screenshot → Ctrl-V → bitmap appears (regression check)

The format probe is a one-line OS boundary — doesn't lend itself to vitest mocking without restructuring the orchestrator. Manual smoke is the verification path.