### PR TITLE
fix(handoff): drop-the-last bug + pick-only transfer + preserve pm- OPFS on editor delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.13.3] - 2026-05-17
+
+### Fixed
+- **Map Corridors → Photo Helper handoff (round 2):** "Poslat do editoru
+  (N)" now actually transfers only the N picks shown in the button
+  count, not the entire marker set. Reported by Martin Hrivna after
+  2.13.2 testing: with 4 photos and 2 flagged, all 4 were arriving in
+  the editor. Fix filters `buildMapPicks` to `flag === 'pick'`; the
+  cleanup pass in `useMapPicksSync` then drops a photo from the editor
+  whenever it's un-picked on the corridor side.
+- **Photo Helper:** deleting a `pm-`-prefixed candidate (i.e., one
+  pushed in from Map Corridors) no longer destroys the underlying OPFS
+  file. The bytes live under the shared `competitions/{compId}/photos/`
+  directory and Map Corridors needs them to re-serve the photo on the
+  next handoff. Symptom pre-fix: delete in editor + re-Send → silent
+  skip → "nepropíše se žádná". Map Corridors' photo-list X button
+  remains the canonical place for permanent pm- deletion.
+
 ## [2.13.2] - 2026-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.13.2] - 2026-05-16
+
+### Fixed
+- **Photo Helper:** map → editor handoff now lands all selected photos
+  instead of just the last one. Reported by Martin Hrivna: selecting 3
+  photos in Map Corridors and clicking "Poslat do editoru (3)" delivered
+  only the last one, with the remainder appearing one-per-minimize cycle
+  thereafter. Root cause was a stale-closure read of `currentCompetition`
+  inside `updateCurrentCompetition`; sequential `addExistingCandidate`
+  calls during `syncMapPicksOnce` each rebuilt their update on the same
+  pre-update snapshot, so `setCurrentCompetition`'s last-write-wins
+  dropped the earlier inserts. Fixed by routing the read through a
+  synchronously-updated ref so chained async calls see prior updates.
+
 ## [2.8.3] - 2026-05-06
 
 ### Fixed

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.9.0",
+  "version": "2.13.2",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
@@ -91,13 +91,28 @@ describe('buildMapPickEntry', () => {
 })
 
 describe('buildMapPicks', () => {
-  it('skips KML markers and projects photo markers in order', () => {
+  it('skips KML markers and projects ONLY photo markers flagged as pick', () => {
+    // User feedback 2026-05-17: "Poslat do editoru (N)" must match the
+    // number of photos that actually transfer. The button counts picks,
+    // so the writer emits picks only — non-pick (neutral / reject /
+    // un-flagged) markers stay on the corridor side, where their flag
+    // is still tracked on PhotoMarker.flag.
     const result = buildMapPicks([
       pm({ id: 'kml', photoId: undefined }),
       pm({ id: 'p1', photoId: 'pid-1', flag: 'pick' }),
-      pm({ id: 'p2', photoId: 'pid-2' }),
+      pm({ id: 'p2', photoId: 'pid-2' }), // no flag → neutral → excluded
+      pm({ id: 'p3', photoId: 'pid-3', flag: 'reject' }), // excluded
+      pm({ id: 'p4', photoId: 'pid-4', flag: 'pick' }),
     ])
-    expect(result.map(e => e.photoId)).toEqual(['pid-1', 'pid-2'])
+    expect(result.map(e => e.photoId)).toEqual(['pid-1', 'pid-4'])
+  })
+
+  it('excludes a marker whose flag is explicitly absent (neutral default)', () => {
+    expect(buildMapPicks([pm({ id: 'p1', photoId: 'pid-1' })])).toEqual([])
+  })
+
+  it('excludes reject-flagged markers (reject state lives only in corridor session)', () => {
+    expect(buildMapPicks([pm({ id: 'p1', photoId: 'pid-1', flag: 'reject' })])).toEqual([])
   })
 
   it('returns [] for empty input', () => {

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -67,12 +67,29 @@ export function buildMapPickEntry(marker: PhotoMarker): MapPickEntry | null {
 }
 
 /**
- * Project an array of PhotoMarkers, skipping non-photo entries. Used by
- * both App.tsx (scheduling writes) and tests.
+ * Project an array of PhotoMarkers, skipping non-photo entries AND
+ * non-pick flags. User feedback 2026-05-17 (Martin Hrivna) flagged the
+ * UX mismatch: the footer button reads "Poslat do editoru (N)" with
+ * N = picks.length, but the writer used to emit every marker regardless
+ * of flag, so the editor received all photos. The fix aligns wire
+ * behavior with the visible count — only photos the user has flagged
+ * as `pick` are crossed over to photo-helper.
+ *
+ * Consequences:
+ *  - Unpicking in map-corridors removes the entry from the file; the
+ *    photo-helper `syncMapPicksOnce` cleanup pass then removes the
+ *    candidate from the editor pool. "Unpick" becomes the natural
+ *    "remove from editor" verb without needing an extra UI.
+ *  - Reject / neutral flag state is preserved purely on the corridor
+ *    side (PhotoMarker.flag) — the wire file is now a transport for
+ *    PICKS only, not a general flag-state mirror.
+ *
+ * Used by both App.tsx (scheduling writes) and tests.
  */
 export function buildMapPicks(markers: readonly PhotoMarker[]): MapPickEntry[] {
   const out: MapPickEntry[] = []
   for (const m of markers) {
+    if (m.flag !== 'pick') continue
     const entry = buildMapPickEntry(m)
     if (entry) out.push(entry)
   }

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import type { DirectoryHandle, StorageInterface } from '@airq/shared-storage';
+import type { ApiPhoto } from '../types/api';
 
 // PR #62 review G1 / G2 / G5: the hook layer wraps the pure helpers with
 // capacity clamps, smart-drop routing, mode-bucket mirroring, and the
@@ -567,5 +568,63 @@ describe('useCompetitionSystem — deleteCandidates snapshot-drift result (PR #6
       returnValue = await (result.current as any).deleteCandidates([]);
     });
     expect(returnValue).toEqual({ deleted: 0, skipped: 0 });
+  });
+});
+
+// Regression: handoff bug reported by Martin Hrivna 2026-05-16.
+// `syncMapPicksOnce` (photo-helper side) iterates N entries from
+// map-picks.json and awaits `session.addCandidate(...)` for each,
+// having captured `session` from `sessionRef.current` ONCE at the
+// start of the run. Inside, `addExistingCandidate` calls
+// `updateCurrentCompetition`, which used to read `currentCompetition`
+// from the closure — stale until React re-renders. Across N sequential
+// awaits in the same microtask burst no render happens, so each
+// invocation built its updated session on the same pre-update
+// snapshot and `setCurrentCompetition`'s last-write-wins dropped the
+// earlier inserts. User symptom: "vybral jsem 3 fotky, přenesla se jen
+// jedna poslední", and "po minimalizaci se najednou objeví dvě, po
+// další tři" (each visibility re-sync added exactly one more).
+//
+// The fix moved updateCurrentCompetition to read from a synchronously-
+// updated ref. This test pins that contract by capturing
+// addExistingCandidate ONCE and awaiting 3 calls back-to-back.
+describe('useCompetitionSystem — addExistingCandidate sequential race (handoff regression)', () => {
+  it('adds all 3 photos when called sequentially without intervening renders', async () => {
+    const result = await setup();
+    // Capture ONCE — mirrors useMapPicksSync's sessionRef.current.addCandidate
+    // pattern. Re-reading result.current.addExistingCandidate after each await
+    // would mask the bug because renderHook surfaces the latest closure.
+    const addExistingCandidate = result.current.addExistingCandidate;
+    const sessionId = result.current.session!.id;
+
+    const photos: ApiPhoto[] = [1, 2, 3].map(i => ({
+      id: `pm-photo-${i}`,
+      sessionId,
+      url: `blob:test/pm-${i}`,
+      filename: `pm-${i}.jpg`,
+      canvasState: {
+        position: { x: 0, y: 0 },
+        scale: 1,
+        brightness: 0,
+        contrast: 1,
+        sharpness: 0,
+        whiteBalance: { temperature: 0, tint: 0, auto: false },
+        labelPosition: 'bottom-left' as const,
+      },
+      label: '',
+      flag: 'pick',
+    }));
+
+    await act(async () => {
+      // Sequential awaits against the SAME captured callback. Pre-fix this
+      // would land only photos[2] in candidates.
+      await addExistingCandidate(photos[0]);
+      await addExistingCandidate(photos[1]);
+      await addExistingCandidate(photos[2]);
+    });
+
+    const finalIds = result.current.session!.candidates!.photos.map(p => p.id);
+    expect(finalIds).toEqual(expect.arrayContaining(['pm-photo-1', 'pm-photo-2', 'pm-photo-3']));
+    expect(result.current.session!.candidates!.photos.length).toBe(3);
   });
 });

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -627,4 +627,102 @@ describe('useCompetitionSystem — addExistingCandidate sequential race (handoff
     expect(finalIds).toEqual(expect.arrayContaining(['pm-photo-1', 'pm-photo-2', 'pm-photo-3']));
     expect(result.current.session!.candidates!.photos.length).toBe(3);
   });
+
+  // Regression: handoff bug part 2, reported by Martin Hrivna 2026-05-17.
+  // After my first fix landed all picks in the editor, the user deleted
+  // them and clicked "Poslat do editoru" again — nothing transferred.
+  // Root cause: photo-helper's `removeCandidate` deletes the OPFS file
+  // via `competitionService.deletePhotosByIds`. For `pm-` prefixed photos
+  // the OPFS file lives in the SHARED `competitions/{compId}/photos/`
+  // directory that map-corridors also reads from. Stranding the file
+  // makes `useMapPicksSync.getPhotoBlob` throw NotFoundError on the next
+  // pass and the entry is silently skipped, so the editor stays empty.
+  // The map-corridors hard-delete path is the canonical pm- delete site;
+  // photo-helper's tray-delete now treats pm- photos as "remove from
+  // my session, keep the bytes" so the next handoff can re-insert.
+  it('removeCandidate KEEPS the OPFS file for pm-prefixed photos (map-corridors owns them)', async () => {
+    const result = await setup();
+    // Seed an on-disk `pm-` photo so addExistingCandidate has bytes to
+    // back the candidate. Maps to the shared OPFS layout that map-corridors
+    // writes into.
+    const compId = result.current.currentCompetition!.id;
+    const photosDirPath = `/competitions/${compId}/photos`;
+    const photosDir = { path: photosDirPath } as DirectoryHandle;
+    const pmId = 'pm-test-photo-1';
+    await storageMock.savePhotoFile(photosDir, pmId, makeFile('pm.jpg'));
+
+    const pmPhoto: ApiPhoto = {
+      id: pmId,
+      sessionId: result.current.session!.id,
+      url: 'blob:test/pm',
+      filename: 'pm.jpg',
+      canvasState: {
+        position: { x: 0, y: 0 },
+        scale: 1,
+        brightness: 0,
+        contrast: 1,
+        sharpness: 0,
+        whiteBalance: { temperature: 0, tint: 0, auto: false },
+        labelPosition: 'bottom-left' as const,
+      },
+      label: '',
+      flag: 'pick',
+    };
+    await act(async () => {
+      await result.current.addExistingCandidate(pmPhoto);
+    });
+    expect(result.current.session!.candidates!.photos.map(p => p.id)).toContain(pmId);
+    expect((await storageMock.listDirectory(photosDir)).map(e => e.name)).toContain(pmId);
+
+    await act(async () => {
+      await result.current.removeCandidate(pmId);
+    });
+
+    // Candidate is gone from the session — that's what the user wanted.
+    expect(result.current.session!.candidates!.photos.map(p => p.id)).not.toContain(pmId);
+    // ...but the OPFS bytes are preserved so map-corridors can still
+    // serve them on the next handoff round.
+    expect((await storageMock.listDirectory(photosDir)).map(e => e.name)).toContain(pmId);
+  });
+
+  it('deleteCandidates KEEPS OPFS files for pm-prefixed photos but deletes non-pm', async () => {
+    const result = await setup();
+    const compId = result.current.currentCompetition!.id;
+    const photosDirPath = `/competitions/${compId}/photos`;
+    const photosDir = { path: photosDirPath } as DirectoryHandle;
+
+    // Mixed batch: one pm- (map-owned) and one regular photo-helper candidate.
+    const pmId = 'pm-bulk-test-1';
+    await storageMock.savePhotoFile(photosDir, pmId, makeFile('pm.jpg'));
+    await act(async () => {
+      await result.current.addExistingCandidate({
+        id: pmId,
+        sessionId: result.current.session!.id,
+        url: 'blob:test/pm-bulk',
+        filename: 'pm.jpg',
+        canvasState: {
+          position: { x: 0, y: 0 },
+          scale: 1,
+          brightness: 0,
+          contrast: 1,
+          sharpness: 0,
+          whiteBalance: { temperature: 0, tint: 0, auto: false },
+          labelPosition: 'bottom-left' as const,
+        },
+        label: '',
+        flag: 'pick',
+      });
+      await result.current.addPhotosToCandidates([makeFile('local.jpg')]);
+    });
+    const localId = result.current.session!.candidates!.photos.find(p => p.id !== pmId)!.id;
+
+    await act(async () => {
+      await (result.current as any).deleteCandidates([pmId, localId]);
+    });
+
+    const remainingFiles = (await storageMock.listDirectory(photosDir)).map(e => e.name);
+    expect(remainingFiles).toContain(pmId);       // pm- preserved for map-corridors
+    expect(remainingFiles).not.toContain(localId); // local fully removed
+    expect(result.current.session!.candidates!.photos.length).toBe(0);
+  });
 });

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -813,7 +813,17 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     }, { updatePhotos: true });
     // Free the OPFS file (PR #62 review C3). `saveSessionPhotos` never prunes,
     // so without an explicit delete the file orphans and storage stats lie.
-    if (compId && !referencedElsewhere) {
+    //
+    // EXCEPTION: pm-prefixed photos are owned by map-corridors (shared
+    // `competitions/{compId}/photos/` directory). Deleting the file here
+    // strands map-corridors' marker — `getPhotoBlob` then throws
+    // NotFoundError on the next `useMapPicksSync` pass and the entry is
+    // silently skipped, so a re-Send brings back nothing. The map-corridors
+    // hard-delete path (`removePhoto` in `useCorridorSessionOPFS`) is the
+    // canonical place to delete pm- bytes, and it cleans up both the
+    // marker and the file in one shot. User feedback 2026-05-17.
+    const isMapOwned = photoId.startsWith('pm-');
+    if (compId && !referencedElsewhere && !isMapOwned) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {
@@ -921,7 +931,14 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       }
       // Only delete the OPFS files that no other container references —
       // protects against a promotion racing the delete (PR #62 review IMP-2).
-      safeIds = presentIds.filter(id => !isPhotoReferencedInSession(next, id));
+      // Also exclude `pm-` prefixed photos: those are owned by map-corridors
+      // (shared `competitions/{compId}/photos/`); deleting them here strands
+      // the map marker and silently breaks the next `useMapPicksSync` pass
+      // (`getPhotoBlob` → NotFoundError → entry skipped). See removeCandidate
+      // for the symmetric guard and user feedback 2026-05-17 rationale.
+      safeIds = presentIds.filter(id =>
+        !isPhotoReferencedInSession(next, id) && !id.startsWith('pm-')
+      );
       return next;
     }, { updatePhotos: true });
     if (compId && safeIds.length > 0) {

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -127,7 +127,27 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   const [error, setError] = useState<string | null>(null);
   const [cleanupCandidates, setCleanupCandidates] = useState<CleanupCandidate[]>([]);
   const [storageStats, setStorageStats] = useState<StorageStats | null>(null);
-  
+
+  // Synchronous mirror of `currentCompetition`. Updated by `applyCurrentCompetition`
+  // (and the effect below for any direct setCurrentCompetition call sites) so that
+  // sequential async setters running within the same render frame each read the
+  // already-applied update from the previous call. Without this, the closure-
+  // captured `currentCompetition` is stale across awaits and last-write-wins on
+  // `setCurrentCompetition` silently drops earlier updates. Repro: map-corridors
+  // → editor handoff with N picks lands only the last one because
+  // `syncMapPicksOnce` awaits N `addExistingCandidate` calls back-to-back without
+  // React rendering between them. See useMapPicksSync.test.ts (sequential).
+  const currentCompetitionRef = useRef<Competition | null>(null);
+  useEffect(() => { currentCompetitionRef.current = currentCompetition; }, [currentCompetition]);
+
+  // Write-through helper: updates the ref synchronously AND queues the React
+  // setState. Every call site that wants the next sequential read to see this
+  // value MUST go through here instead of bare `setCurrentCompetition`.
+  const applyCurrentCompetition = useCallback((next: Competition | null) => {
+    currentCompetitionRef.current = next;
+    setCurrentCompetition(next);
+  }, []);
+
   const migrationPerformed = useRef(false);
 
   // Read external competition ID from URL (set by desktop launcher)
@@ -460,22 +480,35 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
   }, [currentCompetition, refreshCompetitions]);
 
   // Session Operations (proxied to current competition)
+  //
+  // Reads the live competition from `currentCompetitionRef` rather than the
+  // closure so sequential calls within the same render frame see each
+  // other's updates. Critical for the handoff path: `syncMapPicksOnce`
+  // awaits N `addExistingCandidate` calls back-to-back; without the ref read
+  // every call would re-derive `updatedCompetition` from the same initial
+  // snapshot and `setCurrentCompetition`'s last-write-wins would land only
+  // the final call's photo on screen.
+  //
+  // We also commit the new value to the ref BEFORE awaiting the disk write
+  // so the next caller in the chain sees this update immediately, not after
+  // the persist has settled.
   const updateCurrentCompetition = useCallback(async (
     updater: (session: ApiPhotoSession) => ApiPhotoSession,
     options?: { updatePhotos?: boolean }
   ) => {
-    if (!currentCompetition) return;
-    
+    const current = currentCompetitionRef.current;
+    if (!current) return;
+
     try {
-      const originalSession = currentCompetition.session;
+      const originalSession = current.session;
       const updatedSession = updater(originalSession);
-      
+
       // Check if competition name changed in session and sync it
       const nameChanged = updatedSession.competition_name !== originalSession.competition_name;
-      const newCompetitionName = nameChanged && updatedSession.competition_name.trim() 
+      const newCompetitionName = nameChanged && updatedSession.competition_name.trim()
         ? updatedSession.competition_name.trim()
-        : currentCompetition.name;
-      
+        : current.name;
+
       // Detect if photos have actually changed (not just metadata). Includes
       // the candidate pool so promoting/demoting/adding to the tray triggers
       // a write — `competitionService.saveSessionPhotos` walks candidates
@@ -489,23 +522,37 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
         JSON.stringify(originalSession.sets.set2.photos.map(p => p.id)) !== JSON.stringify(updatedSession.sets.set2.photos.map(p => p.id)) ||
         origCandIds.length !== nextCandIds.length ||
         JSON.stringify(origCandIds) !== JSON.stringify(nextCandIds);
-      
+
       const updatedCompetition: Competition = {
-        ...currentCompetition,
+        ...current,
         name: newCompetitionName,
         session: updatedSession,
         lastModified: new Date().toISOString(),
         photoCount: updatedSession.sets.set1.photos.length + updatedSession.sets.set2.photos.length
       };
-      
-      await competitionService.updateCompetition(updatedCompetition, { updatePhotos: photosChanged });
+
+      // Publish the new value to the ref BEFORE the await so the very next
+      // caller (e.g. syncMapPicksOnce iterating over picks) reads our
+      // update, not the pre-update snapshot. The React state update is
+      // still deferred until after the disk write succeeds, which preserves
+      // the prior "no phantom UI on failed persist" contract.
+      currentCompetitionRef.current = updatedCompetition;
+
+      try {
+        await competitionService.updateCompetition(updatedCompetition, { updatePhotos: photosChanged });
+      } catch (err) {
+        // Persist failed — roll back the ref so the next caller doesn't
+        // build on top of unsaved phantom state.
+        currentCompetitionRef.current = current;
+        throw err;
+      }
       setCurrentCompetition(updatedCompetition);
-      
+
       // Refresh competitions list if name changed
       if (nameChanged) {
         await refreshCompetitions();
       }
-      
+
       // Update storage stats after any photo changes
       if (photosChanged) {
         try {
@@ -515,12 +562,12 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
           console.warn('Failed to update storage stats:', err);
         }
       }
-      
+
     } catch (err) {
       console.error('Failed to update competition:', err);
       setError(err instanceof Error ? err.message : 'Failed to update competition');
     }
-  }, [currentCompetition, refreshCompetitions]);
+  }, [refreshCompetitions]);
 
   /**
    * Build a fresh ApiPhoto from a File. Shared by slot-add and candidate-add


### PR DESCRIPTION
## Summary
Three layered fixes to the Map Corridors → Photo Helper handoff after Martin Hrivna's testing:

1. **Sequential pick race** (initial commit on this branch). `updateCurrentCompetition` read `currentCompetition` from a closure that didn't refresh between sequential async calls — `syncMapPicksOnce`'s N back-to-back `addExistingCandidate` awaits had `setCurrentCompetition`'s last-write-wins drop earlier inserts. Fixed by routing through a synchronously-updated `currentCompetitionRef`.

2. **All markers transferred regardless of pick state** (round 2). \`buildMapPicks\` emitted every marker (defaulting absent flag to neutral), so "Poslat do editoru (2)" with 4 imported photos sent all 4. Now filters to \`flag === 'pick'\`; the cleanup pass in \`useMapPicksSync\` removes a photo from the editor when it's un-picked on the corridor side.

3. **Delete-in-editor + re-Send → nothing transfers** (round 2). \`removeCandidate\` / \`deleteCandidates\` deleted the OPFS file via \`competitionService.deletePhotosByIds\`. For \`pm-\`-prefixed photos the bytes live in the SHARED \`competitions/{compId}/photos/\` directory that Map Corridors also reads from; stranding the file made \`getPhotoBlob\` throw NotFoundError on the next sync and the entry was silently skipped. Skip the OPFS delete for \`pm-\` ids — Map Corridors' photo-list X button remains the canonical permanent-delete site.

## Repro
**Bug 1 (pre-3-commits):** mark 3 photos as picks → Send → only the last lands.
**Bug 2 (pre-this commit):** mark 2 of 4 as picks → Send → all 4 transfer.
**Bug 3 (pre-this commit):** delete a transferred photo in Photo Helper → re-Send → silent skip, no photos.

## Test plan
- [x] mapPicksWriter regression: pick-only filter + reject + absent-flag exclusion
- [x] useCompetitionSystem.candidates regression: \`removeCandidate\` / \`deleteCandidates\` preserve \`pm-\` OPFS files
- [x] Existing sequential-race regression (commit 0b5e93c) still passes
- [x] Full photo-helper suite: 429/429
- [x] Full map-corridors suite: 507/507 (+2 todo)
- [x] Desktop suite: 63/63
- [x] Typecheck (photo-helper + map-corridors): clean
- [ ] Manual: 4 photos, mark 2 as picks → Send → confirm only 2 land. Delete in editor → re-Send → confirm 2 land again.

## Follow-ups (not in this PR)
- User also asked for ability to rename imported photos to e.g. TP1. The label system already exists for map markers; we could surface it in the right-side photo list. Tracking separately.
- "Delete in editor" for \`pm-\` photos now leaves the photo deletable only from Map Corridors. The next visibilitychange may re-add them to the candidate tray if the marker is still flagged as a pick — by design, but worth a UX pass if user wants "delete = stay deleted" without un-picking in the map.

Reported by Martin Hrivna on 2026-05-16 and 2026-05-17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)