### PR TITLE
feat(map-corridors): rename imported photos inline (e.g. DSC_0123.JPG → TP1) #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.13.4] - 2026-05-17
+
+### Added
+- **Map Corridors:** rename imported photos directly in the right-side
+  photo list. Click the new pencil icon on any row, type a workflow-
+  friendly name (e.g. `TP1`), press Enter to save or Esc to cancel.
+  The new name replaces the camera-assigned filename throughout: KML
+  export, the marker tooltip, and Photo Helper's candidate tile (via
+  the existing `entry.filename` field in `map-picks.json` — no schema
+  change). Reported by Martin Hrivna 2026-05-16.
+
 ## [2.13.3] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.13.6] - 2026-05-17
+
+### Changed
+- **Map Corridors:** clicking the X badge on a photo (either in the
+  right-side list or in the no-GPS tray) now opens a confirmation
+  dialog before removing. The pencil rename icon sits right next to
+  the X and a misclick used to be irreversible; user feedback
+  2026-05-17 asked for the safety net. Cancel restores the prior
+  state; the dialog header is "Smazat fotografii?" and shows the
+  current display name (incl. any rename made before clicking X).
+
 ## [2.13.5] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.13.5] - 2026-05-17
+
+### Fixed
+- **Photo Helper:** filename renames performed in Map Corridors AFTER
+  the first "Poslat do editoru" now propagate to the candidate tile
+  in the editor instead of being silently dropped. `syncMapPicksOnce`'s
+  update branch previously diffed only `flag` and `label`; a renamed
+  photo already in the editor pool kept its old filename forever.
+  Adds `setCandidateFilename` to the session contract and a filename
+  diff in the update branch (one-way: map authoritative for `pm-`
+  filenames). User feedback 2026-05-17.
+
 ## [2.13.4] - 2026-05-17
 
 ### Added

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.13.5",
+  "version": "2.13.6",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -198,6 +198,7 @@ function App() {
     setNoGpsTrayOpen: persistNoGpsTrayOpen,
     placeNoGpsPhoto,
     removePhoto,
+    renamePhoto,
     setUse1NmAfterSp,
     setComputedData,
     saveOriginalKmlText,
@@ -1225,6 +1226,7 @@ function App() {
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
             onPhotoDelete={(photoId) => { void removePhoto(photoId) }}
+            onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}
           />
         </Box>
       </Container>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -9,7 +9,7 @@ import type { GeoJSON } from 'geojson'
 import { buildPreciseCorridorsAndGates, DISCIPLINE_CONFIGS } from './corridors/preciseCorridor'
 import type { Discipline } from './corridors/preciseCorridor'
 
-import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogContent, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Tooltip, Alert, Snackbar, LinearProgress } from '@mui/material'
+import { Box, Button, Checkbox, Chip, Container, FormControlLabel, Typography, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Table, TableHead, TableRow, TableCell, TableBody, IconButton, Tooltip, Alert, Snackbar, LinearProgress } from '@mui/material'
 import { Download, Place, Print, Home, PhotoCamera, Flag } from '@mui/icons-material'
 import { downloadKML } from './utils/exportKML'
 import { appendFeaturesToKML } from './utils/kmlMerge'
@@ -232,6 +232,13 @@ function App() {
   const markers = session?.markers ?? []
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null)
   const [isAnswerSheetOpen, setAnswerSheetOpen] = useState(false)
+  // User feedback 2026-05-17: the X badge on every photo row deletes
+  // without confirmation. The new rename pencil sits adjacent and a
+  // misclick used to be irreversible. Track the photoId pending deletion
+  // here; clicking X stashes the id, the dialog completes the removal.
+  // Lifted to App.tsx so both PhotoListPanel and NoGpsTray share one
+  // dialog without each panel growing its own confirmation state.
+  const [pendingDeletePhoto, setPendingDeletePhoto] = useState<string | null>(null)
   const answerSheetRef = useRef<HTMLDivElement | null>(null)
   const usedLabels = useMemo(() => {
     const set = new Set<PhotoLabel>()
@@ -1214,7 +1221,7 @@ function App() {
             onToggleOpen={() => { void persistNoGpsTrayOpen(!(session?.noGpsTrayOpen ?? true)) }}
             storage={storage}
             photosDir={photosDir}
-            onPhotoDelete={(photoId) => { void removePhoto(photoId) }}
+            onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
           />
           {/* Phase 7 — right-side photo list panel. Auto-hides when there
               are no imported photos (KML-only sessions look unchanged). */}
@@ -1225,7 +1232,7 @@ function App() {
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
-            onPhotoDelete={(photoId) => { void removePhoto(photoId) }}
+            onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}
           />
         </Box>
@@ -1324,6 +1331,47 @@ function App() {
         </Alert>
       ) : undefined}
     </Snackbar>
+    {/* Delete-photo confirmation. Built lazily off `pendingDeletePhoto`:
+        clicking X on a row (either the photo list panel or the no-GPS tray)
+        stores the photoId; `Smazat` calls removePhoto, `Zrušit` clears the
+        state. The display name is resolved at render time from the current
+        marker / tray entry so a rename made between X-click and confirm
+        still surfaces the right label. */}
+    <Dialog
+      open={pendingDeletePhoto !== null}
+      onClose={() => setPendingDeletePhoto(null)}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle>{t('photo.deleteConfirm.title')}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          {t('photo.deleteConfirm.body', {
+            name: pendingDeletePhoto
+              ? (markers.find(m => m.photoId === pendingDeletePhoto)?.name
+                  ?? (session?.noGpsPhotos ?? []).find(p => p.photoId === pendingDeletePhoto)?.filename
+                  ?? pendingDeletePhoto)
+              : '',
+          })}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setPendingDeletePhoto(null)}>
+          {t('photo.deleteConfirm.cancel')}
+        </Button>
+        <Button
+          onClick={() => {
+            if (pendingDeletePhoto) void removePhoto(pendingDeletePhoto)
+            setPendingDeletePhoto(null)
+          }}
+          color="error"
+          variant="contained"
+          autoFocus
+        >
+          {t('photo.deleteConfirm.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
     </>
   )
 }

--- a/frontend/map-corridors/src/__tests__/photoListPanel.test.ts
+++ b/frontend/map-corridors/src/__tests__/photoListPanel.test.ts
@@ -1,0 +1,40 @@
+// Pure-logic tests for the rename normaliser used by PhotoListPanel.
+// User feedback 2026-05-17 (Martin Hrivna): camera-assigned filenames
+// like `DSC_0123.JPG` are noise during competition workflow — pin the
+// validation rules so a future UI rework of the inline-edit affordance
+// doesn't quietly drift the behaviour.
+
+import { describe, it, expect } from 'vitest'
+import { normalizeRename } from '../components/PhotoListPanel'
+
+describe('normalizeRename', () => {
+  it('returns the trimmed draft when it differs from current', () => {
+    expect(normalizeRename('TP1', 'DSC_0123.JPG')).toBe('TP1')
+  })
+
+  it('trims surrounding whitespace before comparing', () => {
+    expect(normalizeRename('  TP1  ', 'DSC_0123.JPG')).toBe('TP1')
+  })
+
+  it('returns null when the trimmed draft equals current (no-op write)', () => {
+    expect(normalizeRename(' DSC_0123.JPG ', 'DSC_0123.JPG')).toBeNull()
+  })
+
+  it('returns null for empty after trim (cancel-like behaviour)', () => {
+    expect(normalizeRename('   ', 'DSC_0123.JPG')).toBeNull()
+    expect(normalizeRename('', 'DSC_0123.JPG')).toBeNull()
+  })
+
+  it('respects the max-length cap by truncation, not rejection', () => {
+    // Guard against the user pasting a 100 KB blob — we cap rather than
+    // throw so the rename still succeeds with a sane prefix.
+    const oneHundred = 'X'.repeat(100)
+    expect(normalizeRename(oneHundred + oneHundred + oneHundred, 'old', 50))
+      .toBe('X'.repeat(50))
+  })
+
+  it('compares post-truncation against current (so a cap-induced no-op returns null)', () => {
+    // If the draft after truncation matches `current`, that's also a no-op.
+    expect(normalizeRename('X'.repeat(300), 'X'.repeat(10), 10)).toBeNull()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/renamePhoto.test.ts
+++ b/frontend/map-corridors/src/__tests__/renamePhoto.test.ts
@@ -1,0 +1,99 @@
+// Pure-logic tests for the rename transform behind the `renamePhoto` action.
+// Mirrors the `normalizeRename` tests (PhotoListPanel): pin the find / no-op /
+// branch-selection rules without rendering the hook or mocking OPFS.
+// User feedback 2026-05-17 (Martin Hrivna): rename camera filenames to
+// workflow names (TP1, …). Two storage origins must both work — GPS markers
+// (`marker.name`) and the off-map tray (`noGpsPhoto.filename`).
+
+import { describe, it, expect } from 'vitest'
+import { computeRenamedPhoto } from '../hooks/useCorridorSessionOPFS'
+import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+
+const marker = (photoId: string, name: string): PhotoMarker => ({
+  id: `m-${photoId}`,
+  lng: 14.4,
+  lat: 50.1,
+  name,
+  photoId,
+})
+
+const noGps = (photoId: string, filename: string): NoGpsPhoto => ({
+  photoId,
+  filename,
+})
+
+describe('computeRenamedPhoto', () => {
+  it('renames a GPS marker by photoId, leaving siblings untouched', () => {
+    const session = {
+      markers: [marker('p1', 'DSC_0001.JPG'), marker('p2', 'DSC_0002.JPG')],
+      noGpsPhotos: [] as readonly NoGpsPhoto[],
+    }
+    const next = computeRenamedPhoto(session, 'p1', 'TP1')
+    expect(next).not.toBeNull()
+    expect(next!.markers[0].name).toBe('TP1')
+    // Sibling untouched, and same object reference is fine (only the renamed
+    // marker is replaced via map).
+    expect(next!.markers[1].name).toBe('DSC_0002.JPG')
+    expect(next!.noGpsPhotos).toBe(session.noGpsPhotos)
+  })
+
+  it('renames a no-GPS tray entry by photoId (filename field)', () => {
+    const session = {
+      markers: [] as readonly PhotoMarker[],
+      noGpsPhotos: [noGps('p3', 'DSC_0003.JPG'), noGps('p4', 'DSC_0004.JPG')],
+    }
+    const next = computeRenamedPhoto(session, 'p4', 'TP2')
+    expect(next).not.toBeNull()
+    expect(next!.noGpsPhotos[1].filename).toBe('TP2')
+    expect(next!.noGpsPhotos[0].filename).toBe('DSC_0003.JPG')
+    expect(next!.markers).toBe(session.markers)
+  })
+
+  it('trims surrounding whitespace before writing', () => {
+    const session = { markers: [marker('p1', 'old')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    expect(computeRenamedPhoto(session, 'p1', '  TP1  ')!.markers[0].name).toBe('TP1')
+  })
+
+  it('returns null when the trimmed name equals the current marker name (no-op)', () => {
+    const session = { markers: [marker('p1', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    expect(computeRenamedPhoto(session, 'p1', ' TP1 ')).toBeNull()
+  })
+
+  it('returns null when the trimmed name equals the current tray filename (no-op)', () => {
+    const session = { markers: [] as readonly PhotoMarker[], noGpsPhotos: [noGps('p3', 'TP3')] }
+    expect(computeRenamedPhoto(session, 'p3', 'TP3')).toBeNull()
+  })
+
+  it('returns null for an empty / whitespace-only name', () => {
+    const session = { markers: [marker('p1', 'old')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    expect(computeRenamedPhoto(session, 'p1', '')).toBeNull()
+    expect(computeRenamedPhoto(session, 'p1', '   ')).toBeNull()
+  })
+
+  it('returns null when the photoId is in neither collection', () => {
+    const session = {
+      markers: [marker('p1', 'old')],
+      noGpsPhotos: [noGps('p3', 'old')],
+    }
+    expect(computeRenamedPhoto(session, 'missing', 'TP1')).toBeNull()
+  })
+
+  it('does not mutate the input arrays (returns fresh copies)', () => {
+    const markers = [marker('p1', 'old')]
+    const session = { markers, noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    const next = computeRenamedPhoto(session, 'p1', 'TP1')
+    expect(markers[0].name).toBe('old') // original unchanged
+    expect(next!.markers).not.toBe(markers) // new array reference
+  })
+
+  it('tolerates a missing noGpsPhotos field (legacy session)', () => {
+    // A pre-ADR-012 session has no `noGpsPhotos` array; the helper's
+    // `|| []` guard must keep it from throwing.
+    const session = { markers: [marker('p1', 'old')] } as unknown as Parameters<
+      typeof computeRenamedPhoto
+    >[0]
+    const next = computeRenamedPhoto(session, 'p1', 'TP1')
+    expect(next!.markers[0].name).toBe('TP1')
+    expect(next!.noGpsPhotos).toEqual([])
+  })
+})

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -14,10 +14,11 @@ import {
   ListItemText,
   Paper,
   Stack,
+  TextField,
   Tooltip,
   Typography,
 } from '@mui/material'
-import { ChevronLeft, ChevronRight, Close, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
+import { Check, ChevronLeft, ChevronRight, Close, EditOutlined, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
@@ -47,6 +48,16 @@ export interface PhotoListPanelProps {
    * `noGpsPhotos`, best-effort cleans the file + thumb from storage.
    */
   onPhotoDelete: (photoId: string) => void | Promise<void>
+  /**
+   * User feedback 2026-05-17: organisers want to rename camera-assigned
+   * filenames (e.g. `DSC_0123.JPG`) to something workflow-meaningful
+   * (e.g. `TP1`). Persists to `marker.name` (GPS path) or
+   * `noGpsPhoto.filename` (no-GPS path). The new name flows downstream to
+   * KML export and to `map-picks.json` (via `entry.filename`), so
+   * Photo Helper sees the same custom name on its candidate tile without
+   * any wire-schema change.
+   */
+  onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
 }
 
 type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
@@ -55,7 +66,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -119,7 +130,18 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               count={groupCount(groups, key)}
               collapsed={collapsedGroups[key]}
               onToggle={() => toggleGroup(key)}
-              items={renderGroupItems(groups, key, { storage, photosDir, onMarkerClick, onPhotoDelete, deleteTooltip: t('photo.deleteTooltip') })}
+              items={renderGroupItems(groups, key, {
+                storage,
+                photosDir,
+                onMarkerClick,
+                onPhotoDelete,
+                onPhotoRename,
+                deleteTooltip: t('photo.deleteTooltip'),
+                renameTooltip: t('photo.renameTooltip'),
+                renamePlaceholder: t('photo.renamePlaceholder'),
+                renameSaveAria: t('photo.renameSaveAria'),
+                renameCancelAria: t('photo.renameCancelAria'),
+              })}
             />
           ))}
         </Box>
@@ -183,9 +205,21 @@ function renderGroupItems(
     photosDir: DirectoryHandle | null
     onMarkerClick: (markerId: string) => void
     onPhotoDelete: (photoId: string) => void | Promise<void>
+    onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
     deleteTooltip: string
+    renameTooltip: string
+    renamePlaceholder: string
+    renameSaveAria: string
+    renameCancelAria: string
   },
 ): React.ReactNode {
+  const commonRenameCtx = {
+    onRename: ctx.onPhotoRename,
+    renameTooltip: ctx.renameTooltip,
+    renamePlaceholder: ctx.renamePlaceholder,
+    renameSaveAria: ctx.renameSaveAria,
+    renameCancelAria: ctx.renameCancelAria,
+  }
   if (key === 'noGps') {
     return g.noGps.map(p => (
       <PhotoListItem
@@ -198,6 +232,7 @@ function renderGroupItems(
         onClick={undefined}
         onDelete={ctx.onPhotoDelete}
         deleteTooltip={ctx.deleteTooltip}
+        {...commonRenameCtx}
       />
     ))
   }
@@ -212,8 +247,30 @@ function renderGroupItems(
       onClick={() => ctx.onMarkerClick(m.id)}
       onDelete={ctx.onPhotoDelete}
       deleteTooltip={ctx.deleteTooltip}
+      {...commonRenameCtx}
     />
   ))
+}
+
+/**
+ * Validate and normalise a rename draft. Exported for unit testing — the
+ * keyboard / blur paths in `PhotoListItem` all funnel through this, so a
+ * single test pins the rules:
+ *
+ *  - Trim leading/trailing whitespace.
+ *  - Empty (after trim) → reject (return null). Caller treats null as
+ *    "cancel without saving" so the previous filename is kept.
+ *  - Identical to current filename → return null (no-op, don't write).
+ *  - Otherwise return the normalised string.
+ *
+ * The cap (`MAX_LEN`) guards against the user pasting a 100 KB blob into
+ * the inline field — OPFS handles long strings but the UI doesn't.
+ */
+export function normalizeRename(draft: string, current: string, maxLen = 200): string | null {
+  const trimmed = draft.trim().slice(0, maxLen)
+  if (trimmed.length === 0) return null
+  if (trimmed === current) return null
+  return trimmed
 }
 
 function PhotoListItem(props: {
@@ -224,22 +281,56 @@ function PhotoListItem(props: {
   onClick: (() => void) | undefined
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
+  onRename: (photoId: string, newName: string) => void | Promise<void>
+  renameTooltip: string
+  renamePlaceholder: string
+  renameSaveAria: string
+  renameCancelAria: string
 }) {
-  const { photoId, filename, storage, photosDir, onClick, onDelete, deleteTooltip } = props
+  const {
+    photoId, filename, storage, photosDir, onClick, onDelete, deleteTooltip,
+    onRename, renameTooltip, renamePlaceholder, renameSaveAria, renameCancelAria,
+  } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
+  const [editing, setEditing] = useState(false)
+  // `draft` is the in-progress text. Seeded with the current filename on
+  // every entry into edit mode so a previous cancel doesn't leak into the
+  // next session.
+  const [draft, setDraft] = useState(filename)
+
+  const beginEdit = () => {
+    setDraft(filename)
+    setEditing(true)
+  }
+  const commit = () => {
+    const next = normalizeRename(draft, filename)
+    setEditing(false)
+    if (next !== null) void onRename(photoId, next)
+  }
+  const cancel = () => {
+    setEditing(false)
+  }
+
   return (
     <Box
       sx={{
         position: 'relative',
         // Reveal full delete-button opacity on hover anywhere on the row,
-        // matching the photo-helper grid-tile pattern.
+        // matching the photo-helper grid-tile pattern. The rename pencil
+        // mirrors the same hover reveal so resting state stays uncluttered.
         '&:hover .photo-row-delete': { opacity: 1 },
+        '&:hover .photo-row-rename': { opacity: 1 },
       }}
     >
       <ListItemButton
-        onClick={onClick}
-        disabled={!onClick}
-        sx={{ py: 0.5, gap: 1, pr: 4 /* room for the delete badge */ }}
+        onClick={editing ? undefined : onClick}
+        disabled={!editing && !onClick}
+        // Edit mode disables ListItemButton's click ripple so the TextField
+        // doesn't swallow keystrokes via focus contention.
+        component={editing ? 'div' : undefined}
+        // Two icon-buttons live in the right pad (rename + delete) when
+        // not editing; one (save) when editing. pr: 7 covers the wider case.
+        sx={{ py: 0.5, gap: 1, pr: 7 }}
       >
         <Box
           sx={{
@@ -263,45 +354,142 @@ function PhotoListItem(props: {
             />
           )}
         </Box>
-        <ListItemText
-          primary={filename}
-          primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
-        />
+        {editing ? (
+          <TextField
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            // `autoFocus` + `selectOnFocus` (via inputProps onFocus) makes
+            // the user-typed first character REPLACE the camera filename
+            // rather than appending — the whole point of rename is to
+            // replace, not extend.
+            autoFocus
+            onFocus={e => e.target.select()}
+            onKeyDown={e => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commit()
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                cancel()
+              }
+              // stopPropagation prevents ListItemButton from re-interpreting
+              // Space/Enter as activation while the user is typing.
+              e.stopPropagation()
+            }}
+            onBlur={commit}
+            onClick={e => e.stopPropagation()}
+            placeholder={renamePlaceholder}
+            size="small"
+            variant="standard"
+            fullWidth
+            inputProps={{ 'aria-label': renameTooltip, maxLength: 200, style: { fontSize: 12 } }}
+          />
+        ) : (
+          <ListItemText
+            primary={filename}
+            primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
+          />
+        )}
       </ListItemButton>
-      <Tooltip title={deleteTooltip} placement="left" enterDelay={400}>
-        <IconButton
-          className="photo-row-delete"
-          // stopPropagation so the row's `onClick` (fly to marker) doesn't
-          // fire when the user clicks the X. `MouseDown` is also stopped
-          // because ListItemButton has its own ripple-effect handler that
-          // can swallow the click otherwise.
-          onMouseDown={e => e.stopPropagation()}
-          onClick={e => {
-            e.stopPropagation()
-            void onDelete(photoId)
-          }}
-          aria-label={deleteTooltip}
-          size="small"
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            right: 4,
-            transform: 'translateY(-50%)',
-            width: 24,
-            height: 24,
-            bgcolor: 'rgba(220, 53, 69, 0.92)', // Same red as photo-helper grid tiles
-            color: 'white',
-            opacity: 0.6, // Visible at rest — discoverable without hover
-            transition: 'opacity 0.15s ease, background-color 0.15s ease',
-            '&:hover': {
-              bgcolor: 'rgba(200, 35, 51, 1)',
+      {editing ? (
+        <Tooltip title={renameSaveAria} placement="left" enterDelay={400}>
+          <IconButton
+            // MouseDown on the save button would otherwise blur the input
+            // and fire commit() via onBlur BEFORE this onClick — meaning we
+            // commit on the OLD draft and then this handler runs on stale
+            // state. Stopping mousedown keeps focus, so onClick is the
+            // single commit path.
+            onMouseDown={e => e.preventDefault()}
+            onClick={e => {
+              e.stopPropagation()
+              commit()
+            }}
+            aria-label={renameSaveAria}
+            size="small"
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              right: 4,
+              transform: 'translateY(-50%)',
+              width: 24,
+              height: 24,
+              bgcolor: 'success.main',
+              color: 'white',
               opacity: 1,
-            },
-          }}
-        >
-          <Close sx={{ fontSize: 14 }} />
-        </IconButton>
-      </Tooltip>
+              '&:hover': { bgcolor: 'success.dark' },
+            }}
+          >
+            <Check sx={{ fontSize: 14 }} />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <>
+          <Tooltip title={renameTooltip} placement="left" enterDelay={400}>
+            <IconButton
+              className="photo-row-rename"
+              onMouseDown={e => e.stopPropagation()}
+              onClick={e => {
+                e.stopPropagation()
+                beginEdit()
+              }}
+              aria-label={renameTooltip}
+              size="small"
+              sx={{
+                position: 'absolute',
+                top: '50%',
+                right: 32, // sits left of the X
+                transform: 'translateY(-50%)',
+                width: 24,
+                height: 24,
+                bgcolor: 'rgba(25, 118, 210, 0.85)',
+                color: 'white',
+                opacity: 0.6,
+                transition: 'opacity 0.15s ease, background-color 0.15s ease',
+                '&:hover': {
+                  bgcolor: 'rgba(21, 101, 192, 1)',
+                  opacity: 1,
+                },
+              }}
+            >
+              <EditOutlined sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={deleteTooltip} placement="left" enterDelay={400}>
+            <IconButton
+              className="photo-row-delete"
+              // stopPropagation so the row's `onClick` (fly to marker) doesn't
+              // fire when the user clicks the X. `MouseDown` is also stopped
+              // because ListItemButton has its own ripple-effect handler that
+              // can swallow the click otherwise.
+              onMouseDown={e => e.stopPropagation()}
+              onClick={e => {
+                e.stopPropagation()
+                void onDelete(photoId)
+              }}
+              aria-label={deleteTooltip}
+              size="small"
+              sx={{
+                position: 'absolute',
+                top: '50%',
+                right: 4,
+                transform: 'translateY(-50%)',
+                width: 24,
+                height: 24,
+                bgcolor: 'rgba(220, 53, 69, 0.92)', // Same red as photo-helper grid tiles
+                color: 'white',
+                opacity: 0.6, // Visible at rest — discoverable without hover
+                transition: 'opacity 0.15s ease, background-color 0.15s ease',
+                '&:hover': {
+                  bgcolor: 'rgba(200, 35, 51, 1)',
+                  opacity: 1,
+                },
+              }}
+            >
+              <Close sx={{ fontSize: 14 }} />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
     </Box>
   )
 }

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -140,7 +140,6 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
                 renameTooltip: t('photo.renameTooltip'),
                 renamePlaceholder: t('photo.renamePlaceholder'),
                 renameSaveAria: t('photo.renameSaveAria'),
-                renameCancelAria: t('photo.renameCancelAria'),
               })}
             />
           ))}
@@ -210,7 +209,6 @@ function renderGroupItems(
     renameTooltip: string
     renamePlaceholder: string
     renameSaveAria: string
-    renameCancelAria: string
   },
 ): React.ReactNode {
   const commonRenameCtx = {
@@ -218,7 +216,6 @@ function renderGroupItems(
     renameTooltip: ctx.renameTooltip,
     renamePlaceholder: ctx.renamePlaceholder,
     renameSaveAria: ctx.renameSaveAria,
-    renameCancelAria: ctx.renameCancelAria,
   }
   if (key === 'noGps') {
     return g.noGps.map(p => (
@@ -285,11 +282,10 @@ function PhotoListItem(props: {
   renameTooltip: string
   renamePlaceholder: string
   renameSaveAria: string
-  renameCancelAria: string
 }) {
   const {
     photoId, filename, storage, photosDir, onClick, onDelete, deleteTooltip,
-    onRename, renameTooltip, renamePlaceholder, renameSaveAria, renameCancelAria,
+    onRename, renameTooltip, renamePlaceholder, renameSaveAria,
   } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
   const [editing, setEditing] = useState(false)
@@ -325,9 +321,11 @@ function PhotoListItem(props: {
       <ListItemButton
         onClick={editing ? undefined : onClick}
         disabled={!editing && !onClick}
-        // Edit mode disables ListItemButton's click ripple so the TextField
-        // doesn't swallow keystrokes via focus contention.
-        component={editing ? 'div' : undefined}
+        // Edit mode renders as a div so the inner TextField isn't nested
+        // inside a <button> (a11y violation + focus contention). Spread
+        // `component` conditionally — MUI's overload typing rejects
+        // `component={undefined}`.
+        {...(editing ? { component: 'div' as const } : {})}
         // Two icon-buttons live in the right pad (rename + delete) when
         // not editing; one (save) when editing. pr: 7 covers the wider case.
         sx={{ py: 0.5, gap: 1, pr: 7 }}

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -401,6 +401,48 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     }
   }, [persistSession])
 
+  /**
+   * Rename a photo's display name in-place. Walks BOTH `markers[]` (GPS path,
+   * where the display name lives on `marker.name`) and `noGpsPhotos[]`
+   * (off-map tray, where it lives on `entry.filename`) so a single call
+   * handles either origin without the caller having to disambiguate.
+   *
+   * The OPFS file under `photos/{photoId}` is untouched — only the
+   * user-facing label changes. The new name flows downstream:
+   *  - KML export uses `marker.name` directly.
+   *  - `buildMapPickEntry` writes `entry.filename = marker.name` so Photo
+   *    Helper's candidate tile picks up the new name on the next sync.
+   *
+   * Caller is expected to pre-trim / validate (see `normalizeRename` in
+   * PhotoListPanel) — this hook trusts its input but still bails on the
+   * empty-string and "no real change" cases as a belt-and-suspenders guard.
+   */
+  const renamePhoto = useCallback(async (photoId: string, newName: string): Promise<void> => {
+    const current = sessionRef.current
+    if (!current) return
+    const trimmed = newName.trim()
+    if (trimmed.length === 0) return
+    const markerIdx = current.markers.findIndex(m => m.photoId === photoId)
+    const noGpsIdx = (current.noGpsPhotos || []).findIndex(p => p.photoId === photoId)
+    if (markerIdx === -1 && noGpsIdx === -1) return
+    const markerUnchanged = markerIdx !== -1 && current.markers[markerIdx].name === trimmed
+    const noGpsUnchanged = noGpsIdx !== -1 && (current.noGpsPhotos || [])[noGpsIdx].filename === trimmed
+    if (markerUnchanged || noGpsUnchanged) return
+    const nextMarkers = markerIdx === -1
+      ? current.markers
+      : current.markers.map((m, i) => (i === markerIdx ? { ...m, name: trimmed } : m))
+    const nextNoGps = noGpsIdx === -1
+      ? (current.noGpsPhotos || [])
+      : (current.noGpsPhotos || []).map((p, i) => (i === noGpsIdx ? { ...p, filename: trimmed } : p))
+    await persistSession({
+      ...current,
+      markers: nextMarkers,
+      noGpsPhotos: nextNoGps,
+      version: current.version + 1,
+      updatedAt: new Date().toISOString(),
+    })
+  }, [persistSession])
+
   const saveOriginalKmlText = useCallback(async (text: string | null) => {
     if (!sessionRef.current) return
     const storage = storageRef.current
@@ -464,6 +506,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
     setNoGpsTrayOpen,
     placeNoGpsPhoto,
     removePhoto,
+    renamePhoto,
     setComputedData,
     saveOriginalKmlText,
     loadOriginalKmlText,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -111,6 +111,46 @@ export type CorridorsSession = {
   noGpsTrayOpen: boolean
 }
 
+/**
+ * Pure transform behind the `renamePhoto` action. Extracted (like
+ * `normalizeRename` in PhotoListPanel) so the find/no-op/branch rules can be
+ * pinned without rendering the hook or mocking OPFS.
+ *
+ * Walks BOTH `markers[]` (GPS path — display name on `marker.name`) and
+ * `noGpsPhotos[]` (off-map tray — name on `entry.filename`) so a single call
+ * handles either origin. Returns the next `{ markers, noGpsPhotos }` arrays,
+ * or `null` for a no-op (caller then skips the persist + version bump):
+ *  - empty after trim,
+ *  - photoId in neither collection,
+ *  - the trimmed name already matches the current value.
+ *
+ * Trusts the caller to have done UI-level validation (`normalizeRename`) but
+ * re-applies trim + the no-op guards as a belt-and-suspenders layer.
+ */
+export function computeRenamedPhoto(
+  session: Pick<CorridorsSession, 'markers' | 'noGpsPhotos'>,
+  photoId: string,
+  newName: string,
+): { markers: readonly PhotoMarker[]; noGpsPhotos: readonly NoGpsPhoto[] } | null {
+  const trimmed = newName.trim()
+  if (trimmed.length === 0) return null
+  const markers = session.markers
+  const noGpsPhotos = session.noGpsPhotos || []
+  const markerIdx = markers.findIndex(m => m.photoId === photoId)
+  const noGpsIdx = noGpsPhotos.findIndex(p => p.photoId === photoId)
+  if (markerIdx === -1 && noGpsIdx === -1) return null
+  const markerUnchanged = markerIdx !== -1 && markers[markerIdx].name === trimmed
+  const noGpsUnchanged = noGpsIdx !== -1 && noGpsPhotos[noGpsIdx].filename === trimmed
+  if (markerUnchanged || noGpsUnchanged) return null
+  const nextMarkers = markerIdx === -1
+    ? markers
+    : markers.map((m, i) => (i === markerIdx ? { ...m, name: trimmed } : m))
+  const nextNoGps = noGpsIdx === -1
+    ? noGpsPhotos
+    : noGpsPhotos.map((p, i) => (i === noGpsIdx ? { ...p, filename: trimmed } : p))
+  return { markers: nextMarkers, noGpsPhotos: nextNoGps }
+}
+
 const defaultSession = (id: string): CorridorsSession => ({
   id,
   version: 1,
@@ -420,24 +460,12 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   const renamePhoto = useCallback(async (photoId: string, newName: string): Promise<void> => {
     const current = sessionRef.current
     if (!current) return
-    const trimmed = newName.trim()
-    if (trimmed.length === 0) return
-    const markerIdx = current.markers.findIndex(m => m.photoId === photoId)
-    const noGpsIdx = (current.noGpsPhotos || []).findIndex(p => p.photoId === photoId)
-    if (markerIdx === -1 && noGpsIdx === -1) return
-    const markerUnchanged = markerIdx !== -1 && current.markers[markerIdx].name === trimmed
-    const noGpsUnchanged = noGpsIdx !== -1 && (current.noGpsPhotos || [])[noGpsIdx].filename === trimmed
-    if (markerUnchanged || noGpsUnchanged) return
-    const nextMarkers = markerIdx === -1
-      ? current.markers
-      : current.markers.map((m, i) => (i === markerIdx ? { ...m, name: trimmed } : m))
-    const nextNoGps = noGpsIdx === -1
-      ? (current.noGpsPhotos || [])
-      : (current.noGpsPhotos || []).map((p, i) => (i === noGpsIdx ? { ...p, filename: trimmed } : p))
+    const patch = computeRenamedPhoto(current, photoId, newName)
+    if (!patch) return
     await persistSession({
       ...current,
-      markers: nextMarkers,
-      noGpsPhotos: nextNoGps,
+      markers: patch.markers,
+      noGpsPhotos: patch.noGpsPhotos,
       version: current.version + 1,
       updatedAt: new Date().toISOString(),
     })

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -61,6 +61,12 @@
       "sendToEditor": "Poslat do editoru ({{count}})"
     },
     "deleteTooltip": "Smazat fotografii",
+    "deleteConfirm": {
+      "title": "Smazat fotografii?",
+      "body": "„{{name}}“ bude odebrána z této soutěže. Akci nelze vrátit.",
+      "cancel": "Zrušit",
+      "confirm": "Smazat"
+    },
     "renameTooltip": "Přejmenovat fotografii",
     "renamePlaceholder": "např. TP1",
     "renameSaveAria": "Uložit název",

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -70,7 +70,6 @@
     "renameTooltip": "Přejmenovat fotografii",
     "renamePlaceholder": "např. TP1",
     "renameSaveAria": "Uložit název",
-    "renameCancelAria": "Zrušit přejmenování",
     "handoff": {
       "flushFailed": "Výběr se nepodařilo uložit před otevřením editoru. Zkontrolujte úložiště a zkuste to znovu.",
       "editorSyncFailed": "Nepodařilo se použít nejnovější popisky z editoru."

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -61,6 +61,10 @@
       "sendToEditor": "Poslat do editoru ({{count}})"
     },
     "deleteTooltip": "Smazat fotografii",
+    "renameTooltip": "Přejmenovat fotografii",
+    "renamePlaceholder": "např. TP1",
+    "renameSaveAria": "Uložit název",
+    "renameCancelAria": "Zrušit přejmenování",
     "handoff": {
       "flushFailed": "Výběr se nepodařilo uložit před otevřením editoru. Zkontrolujte úložiště a zkuste to znovu.",
       "editorSyncFailed": "Nepodařilo se použít nejnovější popisky z editoru."

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -61,6 +61,12 @@
       "sendToEditor": "Send to editor ({{count}})"
     },
     "deleteTooltip": "Delete photo",
+    "deleteConfirm": {
+      "title": "Delete photo?",
+      "body": "\"{{name}}\" will be removed from this competition. This cannot be undone.",
+      "cancel": "Cancel",
+      "confirm": "Delete"
+    },
     "renameTooltip": "Rename photo",
     "renamePlaceholder": "e.g. TP1",
     "renameSaveAria": "Save name",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -70,7 +70,6 @@
     "renameTooltip": "Rename photo",
     "renamePlaceholder": "e.g. TP1",
     "renameSaveAria": "Save name",
-    "renameCancelAria": "Cancel rename",
     "handoff": {
       "flushFailed": "Couldn't save picks before opening the editor. Check storage and try again.",
       "editorSyncFailed": "Couldn't apply latest labels from the editor."

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -61,6 +61,10 @@
       "sendToEditor": "Send to editor ({{count}})"
     },
     "deleteTooltip": "Delete photo",
+    "renameTooltip": "Rename photo",
+    "renamePlaceholder": "e.g. TP1",
+    "renameSaveAria": "Save name",
+    "renameCancelAria": "Cancel rename",
     "handoff": {
       "flushFailed": "Couldn't save picks before opening the editor. Check storage and try again.",
       "editorSyncFailed": "Couldn't apply latest labels from the editor."

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -113,6 +113,7 @@ function AppApi() {
     demoteSlotToCandidate,
     setCandidateFlag,
     setCandidateLabel,
+    setCandidateFilename,
     updateCandidatePhotoState,
     deleteCandidates,
   } = sessionHookResult;
@@ -167,7 +168,8 @@ function AppApi() {
     removeCandidate,
     setCandidateFlag,
     setCandidateLabel,
-  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag, setCandidateLabel]);
+    setCandidateFilename,
+  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag, setCandidateLabel, setCandidateFilename]);
 
   useMapPicksSync(pmcCompetitionDir, pmcPhotosDir, pmcSessionApi);
 

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -38,6 +38,7 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   removeCandidate: Mock
   setCandidateFlag: Mock
   setCandidateLabel: Mock
+  setCandidateFilename: Mock
 } {
   const candidates = [...initialCandidates]
   const api = {
@@ -58,12 +59,17 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
         found.labelUpdatedAt = new Date().toISOString()
       }
     }),
+    setCandidateFilename: vi.fn(async (id: string, filename: string) => {
+      const found = candidates.find(p => p.id === id)
+      if (found) found.filename = filename
+    }),
   }
   return api as MapPicksSyncSessionApi & {
     addCandidate: Mock
     removeCandidate: Mock
     setCandidateFlag: Mock
     setCandidateLabel: Mock
+    setCandidateFilename: Mock
   }
 }
 
@@ -339,6 +345,62 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
   })
 })
 
+// Regression: rename in map-corridors after the first Send must
+// propagate to an ALREADY-existing candidate in the editor pool.
+// User feedback 2026-05-17 (Martin Hrivna): renaming `DSC_0123.JPG`
+// → `TP1` in map-corridors after Send had no effect — the insert
+// branch picked up `entry.filename` correctly on first sync, but
+// subsequent renames hit the update branch which used to diff only
+// `flag` and `label`. The fix adds a filename diff + setCandidateFilename.
+describe('syncMapPicksOnce — filename one-way sync (rename of existing pm- candidate)', () => {
+  it('calls setCandidateFilename when remote filename differs from local', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{ photoId: 'pm-abc', filename: 'TP1', flag: 'pick' }],
+    })
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick') } // filename = 'pm-abc.jpg' from existing()
+    const session = fakeSession([local])
+    const result = await syncMapPicksOnce(
+      storage as unknown as StorageInterface, competitionDir, photosDir, session,
+    )
+    expect(session.setCandidateFilename).toHaveBeenCalledWith('pm-abc', 'TP1')
+    expect(result.updates).toBe(1)
+  })
+
+  it('does NOT call setCandidateFilename when filename matches', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{ photoId: 'pm-abc', filename: 'pm-abc.jpg', flag: 'pick' }],
+    })
+    const session = fakeSession([existing('pm-abc', 'pick')])
+    await syncMapPicksOnce(
+      storage as unknown as StorageInterface, competitionDir, photosDir, session,
+    )
+    expect(session.setCandidateFilename).not.toHaveBeenCalled()
+  })
+
+  it('updates filename AND flag together if both diverge (touched once)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{ photoId: 'pm-abc', filename: 'TP2', flag: 'pick' }],
+    })
+    const session = fakeSession([existing('pm-abc', 'neutral')])
+    const result = await syncMapPicksOnce(
+      storage as unknown as StorageInterface, competitionDir, photosDir, session,
+    )
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick')
+    expect(session.setCandidateFilename).toHaveBeenCalledWith('pm-abc', 'TP2')
+    // Both writes count toward a single "touched" tally (one update event).
+    expect(result.updates).toBe(1)
+  })
+})
+
 describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs fixed)', () => {
   it('does NOT double-insert when the same pm-id appears twice in the file (one createObjectURL call only)', async () => {
     // Defensive: a torn writer could repeat an entry. The local index must
@@ -385,6 +447,7 @@ describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs
       removeCandidate: vi.fn(async () => undefined),
       setCandidateFlag: vi.fn(async () => undefined),
       setCandidateLabel: vi.fn(async () => undefined),
+      setCandidateFilename: vi.fn(async () => undefined),
     }
     const result = await syncMapPicksOnce(
       storage as unknown as StorageInterface,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -88,6 +88,12 @@ export interface UseCompetitionSystemResult {
    * to keep `ApiPhoto.label: string` non-nullable).
    */
   setCandidateLabel: (photoId: string, label: string) => Promise<void>;
+  /**
+   * Set the display filename in place. Called by `useMapPicksSync` when
+   * map-corridors renames a `pm-` photo after it's already been handed
+   * off. One-way; map is authoritative for pm- filenames.
+   */
+  setCandidateFilename: (photoId: string, filename: string) => Promise<void>;
   updateCandidatePhotoState: (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => Promise<void>;
   /**
    * Delete a specific subset of candidate ids — session entries removed AND
@@ -888,6 +894,20 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     });
   }, [updateCurrentCompetition]);
 
+  // One-way filename sync — map-corridors is authoritative for the
+  // display name on `pm-` candidates. `useMapPicksSync` calls this when
+  // it observes `existing.filename !== entry.filename` on an
+  // already-inserted entry. No timestamp pairing because there's no
+  // editor-side rename UI; if one is added later, mirror the
+  // labelUpdatedAt newer-wins pattern.
+  const setCandidateFilename = useCallback(async (photoId: string, filename: string) => {
+    await updateCurrentCompetition(session => {
+      const existing = session.candidates?.photos ?? [];
+      const next = existing.map(p => p.id === photoId ? { ...p, filename } : p);
+      return { ...session, candidates: { photos: next } };
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition]);
+
   const updateCandidatePhotoState = useCallback(async (photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     await updateCurrentCompetition(session => updateCandidateCanvasStatePure(session, photoId, canvasState));
   }, [updateCurrentCompetition]);
@@ -1422,6 +1442,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     demoteSlotToCandidate,
     setCandidateFlag,
     setCandidateLabel,
+    setCandidateFilename,
     updateCandidatePhotoState,
     deleteCandidates,
     clearAllCandidates,

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -48,6 +48,18 @@ export interface MapPicksSyncSessionApi {
    * `labelUpdatedAt`. Empty string = explicit clear.
    */
   setCandidateLabel: (photoId: string, label: string) => Promise<void> | void;
+  /**
+   * Update the display filename in place. User feedback 2026-05-17
+   * (Martin Hrivna): map-corridors now lets the user rename imported
+   * photos to workflow-friendly names (`TP1` etc.). For freshly-handed-
+   * off photos that lands automatically via the insert path
+   * (`entry.filename` → `ApiPhoto.filename`), but a rename of a photo
+   * ALREADY in the editor's pool would otherwise be ignored — the prior
+   * update branch only diffed `flag` and `label`. Map-corridors is the
+   * authority for `filename` on `pm-` entries; one-way sync, no
+   * timestamp / newer-wins (no editor-side filename edit exists).
+   */
+  setCandidateFilename: (photoId: string, filename: string) => Promise<void> | void;
 }
 
 const PM_PREFIX = PM_PHOTO_ID_PREFIX;
@@ -143,6 +155,16 @@ export async function syncMapPicksOnce(
       const remoteIsNewer = remoteAt && (!localAt || remoteAt > localAt);
       if (remoteIsNewer && existing.label !== remoteLabel) {
         await session.setCandidateLabel(entry.photoId, remoteLabel);
+        touched = true;
+      }
+      // One-way filename sync (map-corridors → editor). No timestamp
+      // because the editor doesn't have a rename UI — every divergence
+      // is the map's authoritative value. Without this branch, a rename
+      // in map-corridors AFTER first Send is silently lost: the insert
+      // branch picks it up on the first sync, but subsequent renames hit
+      // the update branch which used to ignore `filename`.
+      if (existing.filename !== entry.filename) {
+        await session.setCandidateFilename(entry.photoId, entry.filename);
         touched = true;
       }
       if (touched) updates++;


### PR DESCRIPTION
## Summary
Ships three Map Corridors changes (desktop 2.13.3 → 2.13.6):

- **2.13.4 — Inline rename.** Click the pencil on any photo row, type a workflow-friendly name (e.g. `TP1`), Enter to save or Esc to cancel. The new name replaces the camera filename throughout: KML export (`<name>`, XML-escaped), marker tooltip, and Photo Helper's candidate tile (via the existing `entry.filename` field — no shared-handoff schema change).
- **2.13.5 — Filename one-way sync fix.** A rename done in Map Corridors *after* the first "Poslat do editoru" now propagates to an already-existing candidate tile in the editor. `syncMapPicksOnce`'s update branch previously diffed only `flag`/`label`; it now diffs `filename` too (one-way, map authoritative for `pm-` filenames).
- **2.13.6 — Delete confirmation.** Clicking the X on a photo row (list or no-GPS tray) now opens a confirm dialog ("Smazat fotografii?") — the rename pencil sits adjacent and a misclick used to be irreversible.

## Pure helpers + tests
- `normalizeRename` (PhotoListPanel) — trim / no-op / length-cap rules.
- `computeRenamedPhoto` (useCorridorSessionOPFS) — find / no-op / GPS-vs-tray branch selection, extracted from the `renamePhoto` action and unit-tested without rendering the hook.
- Filename-sync regression tests in `useMapPicksSync.test.ts`.

## What flows where
- `marker.name` (GPS photos) and `noGpsPhoto.filename` (off-map tray) — both updated in one persist via `renamePhoto`.
- KML export uses `marker.name` directly → renamed in `<name>` automatically (escaped via `xmlEscape`).
- `buildMapPickEntry` writes `entry.filename = marker.name` → Photo Helper picks up the new name on the next sync.
- OPFS file under `photos/{photoId}` is untouched — only the user-facing label changes.

## Test plan
- [x] `normalizeRename` + `computeRenamedPhoto` unit tests
- [x] Filename one-way sync regression tests
- [x] Full map-corridors suite: 522 passing (+2 todo)
- [x] Typecheck clean
- [ ] Manual: import 4 photos, rename one → confirm name in panel, KML export, and (after Send) Photo Helper candidate tile; X → confirm dialog

## Follow-up (not in this PR)
- Bidirectional rename: editing the filename in Photo Helper does NOT propagate back to Map Corridors (the editor-picks wire schema carries only labels). If users start renaming in both places, add a `filename` / `filenameUpdatedAt` pair to `EditorPickEntry` with the same newer-wins resolution the label uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)