### PR TITLE
feat(map-corridors): preserve original filename on rename; order list by it #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.15.0] - 2026-05-24
+
+### Changed
+- **Map Corridors:** renaming an imported photo now keeps the original camera
+  filename instead of overwriting it. The custom name (e.g. `TP1`) shows as the
+  primary label in the photo list, marker popup, KML export and the Photo
+  Helper tile, while the original filename (`DSC_0123.JPG`) is preserved
+  underneath. KML `<name>` becomes `TP1 (DSC_0123.JPG)`. Reported by Martin
+  Hrivna 2026-05-17.
+- **Map Corridors:** the right-side photo list and the no-GPS tray are now
+  ordered by the original camera filename (numeric-aware, so `IMG_9` precedes
+  `IMG_10`). Because ordering keys on the immutable filename, renaming a photo
+  no longer moves it — previously the no-GPS tray re-sorted on the new name.
+  Capture time becomes the tie-break for identical filenames.
+
 ## [2.13.6] - 2026-05-17
 
 ### Changed

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.13.6",
+  "version": "2.15.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -34,7 +34,7 @@ import { buildRouteWaypoints } from './corridors/buildRouteWaypoints'
 import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
 import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
-import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline } from './types/markers'
+import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline, noGpsPhotoDisplayName, photoMarkerDisplayName } from './types/markers'
 import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
@@ -798,15 +798,19 @@ function App() {
     const features: any[] = []
     if (markers.length) {
       const markerFeatures = markers.map(m => {
+        // Name part: the custom name (displayName) when set, with the original
+        // camera filename in parentheses so the photo stays identifiable —
+        // e.g. "TP1 (DSC_0123.JPG)". No custom name → just the filename.
+        const namePart = m.displayName ? `${m.displayName} (${m.name})` : m.name
         // Feedback 2026-04-18: drop the " - photo" fallback suffix — readers asked
-        // for clean label-only names. Keep the filename only when the user supplied one.
-        const displayName = m.label && m.name
-          ? `${m.label} - ${m.name}`
-          : (m.label || m.name || '')
+        // for clean label-only names. Prefix the competition label when present.
+        const placeName = m.label && namePart
+          ? `${m.label} - ${namePart}`
+          : (m.label || namePart || '')
         return {
           type: 'Feature',
           properties: {
-            name: displayName,
+            name: placeName,
             role: 'track_photos',
             label: m.label || undefined
           },
@@ -1348,9 +1352,15 @@ function App() {
         <DialogContentText>
           {t('photo.deleteConfirm.body', {
             name: pendingDeletePhoto
-              ? (markers.find(m => m.photoId === pendingDeletePhoto)?.name
-                  ?? (session?.noGpsPhotos ?? []).find(p => p.photoId === pendingDeletePhoto)?.filename
-                  ?? pendingDeletePhoto)
+              ? (() => {
+                  // Resolve the display name at render time so a rename made
+                  // between X-click and confirm surfaces the right label.
+                  const m = markers.find(m => m.photoId === pendingDeletePhoto)
+                  if (m) return photoMarkerDisplayName(m)
+                  const p = (session?.noGpsPhotos ?? []).find(p => p.photoId === pendingDeletePhoto)
+                  if (p) return noGpsPhotoDisplayName(p)
+                  return pendingDeletePhoto
+                })()
               : '',
           })}
         </DialogContentText>

--- a/frontend/map-corridors/src/__tests__/componentLogic.test.ts
+++ b/frontend/map-corridors/src/__tests__/componentLogic.test.ts
@@ -21,33 +21,36 @@ describe('NoGpsTray — drag contract', () => {
   })
 })
 
-describe('compareNoGpsPhotos — sort order', () => {
-  it('orders timestamped entries ASC by timestamp', () => {
+describe('compareNoGpsPhotos — sort order (filename primary, timestamp tie-break)', () => {
+  // User feedback 2026-05-17: order by ORIGINAL filename so a rename (which
+  // only sets displayName) never moves a photo. Timestamp is now only a
+  // tie-break for identical filenames.
+  it('orders by filename ASC even when the timestamp order disagrees', () => {
+    // a.jpg was captured LATER than b.jpg — filename must still win.
     const sorted = [
-      ngp({ photoId: 'b', filename: 'b.jpg', timestamp: '2024-02-01T00:00:00Z' }),
-      ngp({ photoId: 'a', filename: 'a.jpg', timestamp: '2024-01-01T00:00:00Z' }),
+      ngp({ photoId: 'b', filename: 'b.jpg', timestamp: '2024-01-01T00:00:00Z' }),
+      ngp({ photoId: 'a', filename: 'a.jpg', timestamp: '2024-02-01T00:00:00Z' }),
     ].sort(compareNoGpsPhotos).map(p => p.photoId)
     expect(sorted).toEqual(['a', 'b'])
   })
 
-  it('places entries without timestamp at the end', () => {
+  it('is numeric-aware: IMG_9 sorts before IMG_10', () => {
     const sorted = [
-      ngp({ photoId: 'noTs', filename: 'no.jpg' }),
-      ngp({ photoId: 'withTs', filename: 'with.jpg', timestamp: '2024-01-01T00:00:00Z' }),
+      ngp({ photoId: 'ten', filename: 'IMG_10.jpg' }),
+      ngp({ photoId: 'nine', filename: 'IMG_9.jpg' }),
     ].sort(compareNoGpsPhotos).map(p => p.photoId)
-    expect(sorted).toEqual(['withTs', 'noTs'])
+    expect(sorted).toEqual(['nine', 'ten'])
   })
 
-  it('tie-breaks alphabetically by filename when timestamps are equal', () => {
-    const t = '2024-01-01T00:00:00Z'
+  it('tie-breaks by timestamp when filenames are identical', () => {
     const sorted = [
-      ngp({ photoId: 'z', filename: 'z.jpg', timestamp: t }),
-      ngp({ photoId: 'a', filename: 'a.jpg', timestamp: t }),
+      ngp({ photoId: 'late', filename: 'same.jpg', timestamp: '2024-02-01T00:00:00Z' }),
+      ngp({ photoId: 'early', filename: 'same.jpg', timestamp: '2024-01-01T00:00:00Z' }),
     ].sort(compareNoGpsPhotos).map(p => p.photoId)
-    expect(sorted).toEqual(['a', 'z'])
+    expect(sorted).toEqual(['early', 'late'])
   })
 
-  it('tie-breaks alphabetically when BOTH lack a timestamp', () => {
+  it('orders by filename even when entries lack a timestamp', () => {
     const sorted = [
       ngp({ photoId: 'z', filename: 'z.jpg' }),
       ngp({ photoId: 'a', filename: 'a.jpg' }),

--- a/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
@@ -52,11 +52,32 @@ describe('groupPhotosByFlag', () => {
     expect(g.picks).toEqual([])
   })
 
-  it('passes noGpsPhotos through verbatim', () => {
-    const list = [ng('pid-x'), ng('pid-y')]
+  it('sorts noGpsPhotos by filename (numeric-aware) without mutating the input', () => {
+    const list = [ng('pid-y', 'IMG_10.jpg'), ng('pid-x', 'IMG_9.jpg')]
     const g = groupPhotosByFlag([], list)
-    expect(g.noGps).toBe(list) // identity-preserving — safe for memo
+    expect(g.noGps.map(p => p.filename)).toEqual(['IMG_9.jpg', 'IMG_10.jpg']) // 9 < 10 numerically
+    expect(list.map(p => p.filename)).toEqual(['IMG_10.jpg', 'IMG_9.jpg']) // input untouched
     expect(g.total).toBe(2)
+  })
+
+  it('orders each flag group by original filename, numeric-aware', () => {
+    const markers: PhotoMarker[] = [
+      pm({ id: 'p10', photoId: 'a', flag: 'pick', name: 'DSC_0010.JPG' }),
+      pm({ id: 'p9', photoId: 'b', flag: 'pick', name: 'DSC_0009.JPG' }),
+      pm({ id: 'p100', photoId: 'c', flag: 'pick', name: 'DSC_0100.JPG' }),
+    ]
+    const g = groupPhotosByFlag(markers, [])
+    expect(g.picks.map(m => m.name)).toEqual(['DSC_0009.JPG', 'DSC_0010.JPG', 'DSC_0100.JPG'])
+  })
+
+  it('orders by original filename, NOT by a custom displayName', () => {
+    const markers: PhotoMarker[] = [
+      pm({ id: 'z', photoId: 'a', flag: 'pick', name: 'DSC_0002.JPG', displayName: 'AAA' }),
+      pm({ id: 'a', photoId: 'b', flag: 'pick', name: 'DSC_0001.JPG', displayName: 'ZZZ' }),
+    ]
+    const g = groupPhotosByFlag(markers, [])
+    // 0001 before 0002 (filename order) — a rename to ZZZ/AAA must not reorder.
+    expect(g.picks.map(m => m.name)).toEqual(['DSC_0001.JPG', 'DSC_0002.JPG'])
   })
 
   it('total is the sum across all four groups', () => {

--- a/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
@@ -38,6 +38,16 @@ describe('buildMapPickEntry', () => {
     expect(buildMapPickEntry(pm({ photoId: 'pid' }))!.label).toBeUndefined()
   })
 
+  it('projects the custom displayName into entry.filename (Photo Helper tile shows TP1)', () => {
+    const e = buildMapPickEntry(pm({ photoId: 'pid', name: 'DSC_0001.JPG', displayName: 'TP1' }))!
+    expect(e.filename).toBe('TP1')
+  })
+
+  it('falls back to the original filename when no custom name is set', () => {
+    const e = buildMapPickEntry(pm({ photoId: 'pid', name: 'DSC_0001.JPG' }))!
+    expect(e.filename).toBe('DSC_0001.JPG')
+  })
+
   it('writes capturedAt to gps when EXIF GPS was present at import', () => {
     const e = buildMapPickEntry(pm({
       photoId: 'pid',

--- a/frontend/map-corridors/src/__tests__/markersDisplay.test.ts
+++ b/frontend/map-corridors/src/__tests__/markersDisplay.test.ts
@@ -1,0 +1,40 @@
+// Unit tests for the shared display/order primitives added for the
+// rename-preserves-filename feature (user feedback 2026-05-17). These back
+// the list row, marker popup, tray, KML export and map-picks projection — one
+// place to pin "custom name shows, original filename orders".
+
+import { describe, it, expect } from 'vitest'
+import { compareFilenames, noGpsPhotoDisplayName, photoMarkerDisplayName } from '../types/markers'
+
+describe('photoMarkerDisplayName', () => {
+  it('returns the custom displayName when set', () => {
+    expect(photoMarkerDisplayName({ name: 'DSC_0001.JPG', displayName: 'TP1' })).toBe('TP1')
+  })
+  it('falls back to the original filename when no custom name', () => {
+    expect(photoMarkerDisplayName({ name: 'DSC_0001.JPG' })).toBe('DSC_0001.JPG')
+    expect(photoMarkerDisplayName({ name: 'DSC_0001.JPG', displayName: undefined })).toBe('DSC_0001.JPG')
+  })
+})
+
+describe('noGpsPhotoDisplayName', () => {
+  it('returns the custom displayName when set, else the filename', () => {
+    expect(noGpsPhotoDisplayName({ filename: 'DSC_0003.JPG', displayName: 'TP3' })).toBe('TP3')
+    expect(noGpsPhotoDisplayName({ filename: 'DSC_0003.JPG' })).toBe('DSC_0003.JPG')
+  })
+})
+
+describe('compareFilenames', () => {
+  it('is numeric-aware: 9 sorts before 10 (not lexical)', () => {
+    expect(compareFilenames('DSC_0009.JPG', 'DSC_0010.JPG')).toBeLessThan(0)
+    expect(['DSC_0010.JPG', 'DSC_0009.JPG', 'DSC_0100.JPG'].sort(compareFilenames))
+      .toEqual(['DSC_0009.JPG', 'DSC_0010.JPG', 'DSC_0100.JPG'])
+  })
+
+  it('is case-insensitive (sensitivity: base)', () => {
+    expect(compareFilenames('img_1.jpg', 'IMG_1.JPG')).toBe(0)
+  })
+
+  it('returns 0 for identical strings', () => {
+    expect(compareFilenames('same.jpg', 'same.jpg')).toBe(0)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/renamePhoto.test.ts
+++ b/frontend/map-corridors/src/__tests__/renamePhoto.test.ts
@@ -2,70 +2,90 @@
 // Mirrors the `normalizeRename` tests (PhotoListPanel): pin the find / no-op /
 // branch-selection rules without rendering the hook or mocking OPFS.
 // User feedback 2026-05-17 (Martin Hrivna): rename camera filenames to
-// workflow names (TP1, …). Two storage origins must both work — GPS markers
-// (`marker.name`) and the off-map tray (`noGpsPhoto.filename`).
+// workflow names (TP1, …) for identification, BUT preserve the original
+// filename so the list can stay ordered by it. The rename therefore writes
+// `displayName` and never touches `name` / `filename`.
 
 import { describe, it, expect } from 'vitest'
 import { computeRenamedPhoto } from '../hooks/useCorridorSessionOPFS'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 
-const marker = (photoId: string, name: string): PhotoMarker => ({
+const marker = (photoId: string, name: string, displayName?: string): PhotoMarker => ({
   id: `m-${photoId}`,
   lng: 14.4,
   lat: 50.1,
   name,
+  ...(displayName !== undefined ? { displayName } : {}),
   photoId,
 })
 
-const noGps = (photoId: string, filename: string): NoGpsPhoto => ({
+const noGps = (photoId: string, filename: string, displayName?: string): NoGpsPhoto => ({
   photoId,
   filename,
+  ...(displayName !== undefined ? { displayName } : {}),
 })
 
 describe('computeRenamedPhoto', () => {
-  it('renames a GPS marker by photoId, leaving siblings untouched', () => {
+  it('sets displayName on a GPS marker, leaving the original filename intact', () => {
     const session = {
       markers: [marker('p1', 'DSC_0001.JPG'), marker('p2', 'DSC_0002.JPG')],
       noGpsPhotos: [] as readonly NoGpsPhoto[],
     }
     const next = computeRenamedPhoto(session, 'p1', 'TP1')
     expect(next).not.toBeNull()
-    expect(next!.markers[0].name).toBe('TP1')
-    // Sibling untouched, and same object reference is fine (only the renamed
-    // marker is replaced via map).
-    expect(next!.markers[1].name).toBe('DSC_0002.JPG')
+    expect(next!.markers[0].displayName).toBe('TP1')
+    expect(next!.markers[0].name).toBe('DSC_0001.JPG') // original preserved (sort key)
+    // Sibling untouched; noGps array passed through by reference.
+    expect(next!.markers[1].displayName).toBeUndefined()
     expect(next!.noGpsPhotos).toBe(session.noGpsPhotos)
   })
 
-  it('renames a no-GPS tray entry by photoId (filename field)', () => {
+  it('sets displayName on a no-GPS tray entry, preserving its filename', () => {
     const session = {
       markers: [] as readonly PhotoMarker[],
       noGpsPhotos: [noGps('p3', 'DSC_0003.JPG'), noGps('p4', 'DSC_0004.JPG')],
     }
     const next = computeRenamedPhoto(session, 'p4', 'TP2')
     expect(next).not.toBeNull()
-    expect(next!.noGpsPhotos[1].filename).toBe('TP2')
-    expect(next!.noGpsPhotos[0].filename).toBe('DSC_0003.JPG')
+    expect(next!.noGpsPhotos[1].displayName).toBe('TP2')
+    expect(next!.noGpsPhotos[1].filename).toBe('DSC_0004.JPG')
+    expect(next!.noGpsPhotos[0].displayName).toBeUndefined()
     expect(next!.markers).toBe(session.markers)
   })
 
   it('trims surrounding whitespace before writing', () => {
     const session = { markers: [marker('p1', 'old')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
-    expect(computeRenamedPhoto(session, 'p1', '  TP1  ')!.markers[0].name).toBe('TP1')
+    expect(computeRenamedPhoto(session, 'p1', '  TP1  ')!.markers[0].displayName).toBe('TP1')
   })
 
-  it('returns null when the trimmed name equals the current marker name (no-op)', () => {
-    const session = { markers: [marker('p1', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+  it('changes an existing custom name (TP1 → TP2)', () => {
+    const session = { markers: [marker('p1', 'DSC_0001.JPG', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    const next = computeRenamedPhoto(session, 'p1', 'TP2')
+    expect(next!.markers[0].displayName).toBe('TP2')
+    expect(next!.markers[0].name).toBe('DSC_0001.JPG')
+  })
+
+  it('returns null when the trimmed name equals the current custom name (no-op)', () => {
+    const session = { markers: [marker('p1', 'DSC_0001.JPG', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
     expect(computeRenamedPhoto(session, 'p1', ' TP1 ')).toBeNull()
   })
 
-  it('returns null when the trimmed name equals the current tray filename (no-op)', () => {
-    const session = { markers: [] as readonly PhotoMarker[], noGpsPhotos: [noGps('p3', 'TP3')] }
-    expect(computeRenamedPhoto(session, 'p3', 'TP3')).toBeNull()
+  it('clears displayName when renamed back to the original filename', () => {
+    const session = { markers: [marker('p1', 'DSC_0001.JPG', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    const next = computeRenamedPhoto(session, 'p1', 'DSC_0001.JPG')
+    expect(next).not.toBeNull()
+    expect(next!.markers[0].displayName).toBeUndefined()
+    expect(next!.markers[0].name).toBe('DSC_0001.JPG')
   })
 
-  it('returns null for an empty / whitespace-only name', () => {
-    const session = { markers: [marker('p1', 'old')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+  it('returns null when typing the original filename and no custom name exists (no-op)', () => {
+    const session = { markers: [marker('p1', 'DSC_0001.JPG')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
+    // nextDisplayName would be undefined (revert), which already equals current → no write.
+    expect(computeRenamedPhoto(session, 'p1', 'DSC_0001.JPG')).toBeNull()
+  })
+
+  it('returns null for an empty / whitespace-only name (never clears via empty)', () => {
+    const session = { markers: [marker('p1', 'DSC_0001.JPG', 'TP1')], noGpsPhotos: [] as readonly NoGpsPhoto[] }
     expect(computeRenamedPhoto(session, 'p1', '')).toBeNull()
     expect(computeRenamedPhoto(session, 'p1', '   ')).toBeNull()
   })
@@ -79,21 +99,21 @@ describe('computeRenamedPhoto', () => {
   })
 
   it('does not mutate the input arrays (returns fresh copies)', () => {
-    const markers = [marker('p1', 'old')]
+    const markers = [marker('p1', 'DSC_0001.JPG')]
     const session = { markers, noGpsPhotos: [] as readonly NoGpsPhoto[] }
     const next = computeRenamedPhoto(session, 'p1', 'TP1')
-    expect(markers[0].name).toBe('old') // original unchanged
+    expect(markers[0].displayName).toBeUndefined() // original unchanged
     expect(next!.markers).not.toBe(markers) // new array reference
   })
 
   it('tolerates a missing noGpsPhotos field (legacy session)', () => {
     // A pre-ADR-012 session has no `noGpsPhotos` array; the helper's
     // `|| []` guard must keep it from throwing.
-    const session = { markers: [marker('p1', 'old')] } as unknown as Parameters<
+    const session = { markers: [marker('p1', 'DSC_0001.JPG')] } as unknown as Parameters<
       typeof computeRenamedPhoto
     >[0]
     const next = computeRenamedPhoto(session, 'p1', 'TP1')
-    expect(next!.markers[0].name).toBe('TP1')
+    expect(next!.markers[0].displayName).toBe('TP1')
     expect(next!.noGpsPhotos).toEqual([])
   })
 })

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -9,28 +9,17 @@ import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material'
 import { Close, ExpandLess, ExpandMore } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto } from '../types/markers'
-import { compareFilenames, noGpsPhotoDisplayName } from '../types/markers'
+import { compareNoGpsPhotos, noGpsPhotoDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 
 /** Drag type the map drop handler watches for. Public — MapProviderView imports this. */
 export const NO_GPS_PHOTO_DRAG_TYPE = 'application/x-airq-no-gps-photo'
 
-/**
- * Sort comparator for no-GPS tray entries. Ordered by ORIGINAL camera
- * filename (numeric-aware, so `IMG_9` < `IMG_10`), with EXIF timestamp as the
- * tie-break for identical filenames. Sorting by the immutable filename — not
- * the user's `displayName` — keeps a renamed photo from jumping position
- * (user feedback 2026-05-17). Exported for unit testing — a typo flipping the
- * order would otherwise ship silently.
- */
-export function compareNoGpsPhotos(a: NoGpsPhoto, b: NoGpsPhoto): number {
-  const byName = compareFilenames(a.filename, b.filename)
-  if (byName !== 0) return byName
-  const ta = a.timestamp ?? '￿'
-  const tb = b.timestamp ?? '￿'
-  return ta < tb ? -1 : ta > tb ? 1 : 0
-}
+// The tray sort comparator now lives in `types/markers.ts` so the right-side
+// list (`groupPhotosByFlag`) shares the exact same tie-break order. Re-exported
+// here to keep existing importers (and `componentLogic.test.ts`) stable.
+export { compareNoGpsPhotos } from '../types/markers'
 
 const TRAY_HEIGHT_PX = 116        // 80px thumb + chrome, under the 120px ADR-012 cap
 const THUMB_WIDTH_PX = 96         // 4:3 thumbs in horizontal scroll

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -9,6 +9,7 @@ import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material'
 import { Close, ExpandLess, ExpandMore } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto } from '../types/markers'
+import { compareFilenames, noGpsPhotoDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 
@@ -16,16 +17,19 @@ import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 export const NO_GPS_PHOTO_DRAG_TYPE = 'application/x-airq-no-gps-photo'
 
 /**
- * Sort comparator for no-GPS tray entries. EXIF timestamp ASC; entries
- * without a timestamp sort to the end via the `'￿'` sentinel, then
- * tie-break alphabetically by filename. Exported for unit testing — a
- * typo flipping the order would otherwise ship silently.
+ * Sort comparator for no-GPS tray entries. Ordered by ORIGINAL camera
+ * filename (numeric-aware, so `IMG_9` < `IMG_10`), with EXIF timestamp as the
+ * tie-break for identical filenames. Sorting by the immutable filename — not
+ * the user's `displayName` — keeps a renamed photo from jumping position
+ * (user feedback 2026-05-17). Exported for unit testing — a typo flipping the
+ * order would otherwise ship silently.
  */
 export function compareNoGpsPhotos(a: NoGpsPhoto, b: NoGpsPhoto): number {
+  const byName = compareFilenames(a.filename, b.filename)
+  if (byName !== 0) return byName
   const ta = a.timestamp ?? '￿'
   const tb = b.timestamp ?? '￿'
-  if (ta !== tb) return ta < tb ? -1 : 1
-  return a.filename.localeCompare(b.filename)
+  return ta < tb ? -1 : ta > tb ? 1 : 0
 }
 
 const TRAY_HEIGHT_PX = 116        // 80px thumb + chrome, under the 120px ADR-012 cap
@@ -119,6 +123,9 @@ function NoGpsTrayThumb(props: {
 }) {
   const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photo.photoId)
+  // Custom name when set, else the camera filename — shown in the tooltip,
+  // a11y labels, and the no-thumb placeholder.
+  const label = noGpsPhotoDisplayName(photo)
 
   return (
     // Outer wrapper hosts the absolute-positioned delete badge; the inner
@@ -131,11 +138,11 @@ function NoGpsTrayThumb(props: {
         '&:hover .nogps-thumb-delete': { opacity: 1 },
       }}
     >
-      <Tooltip title={`${photo.filename} — ${dragHint}`} placement="top" enterDelay={300}>
+      <Tooltip title={`${label} — ${dragHint}`} placement="top" enterDelay={300}>
         <Box
           draggable
           role="img"
-          aria-label={`${photo.filename}. ${dragHint}.`}
+          aria-label={`${label}. ${dragHint}.`}
           onDragStart={(e: React.DragEvent) => {
             e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
             e.dataTransfer.effectAllowed = 'move'
@@ -157,14 +164,14 @@ function NoGpsTrayThumb(props: {
           {state === 'ready' && url && (
             <img
               src={url}
-              alt={photo.filename}
+              alt={label}
               draggable={false}
               style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain', pointerEvents: 'none' }}
             />
           )}
           {state !== 'ready' && (
             <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10, px: 0.5, textAlign: 'center' }}>
-              {photo.filename}
+              {label}
             </Typography>
           )}
         </Box>

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { Check, ChevronLeft, ChevronRight, Close, EditOutlined, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+import { noGpsPhotoDisplayName, photoMarkerDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 import { groupPhotosByFlag } from './groupPhotosByFlag'
@@ -51,11 +52,12 @@ export interface PhotoListPanelProps {
   /**
    * User feedback 2026-05-17: organisers want to rename camera-assigned
    * filenames (e.g. `DSC_0123.JPG`) to something workflow-meaningful
-   * (e.g. `TP1`). Persists to `marker.name` (GPS path) or
-   * `noGpsPhoto.filename` (no-GPS path). The new name flows downstream to
-   * KML export and to `map-picks.json` (via `entry.filename`), so
-   * Photo Helper sees the same custom name on its candidate tile without
-   * any wire-schema change.
+   * (e.g. `TP1`). Persists to the `displayName` field (on `marker` or
+   * `noGpsPhoto`) WITHOUT overwriting the original filename — that stays as
+   * the list/tray sort key. The custom name flows downstream to KML export
+   * and to `map-picks.json` (via `entry.filename = displayName ?? name`), so
+   * Photo Helper sees the custom name on its candidate tile without any
+   * wire-schema change.
    */
   onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
 }
@@ -222,7 +224,8 @@ function renderGroupItems(
       <PhotoListItem
         key={p.photoId}
         photoId={p.photoId}
-        filename={p.filename}
+        displayName={noGpsPhotoDisplayName(p)}
+        originalFilename={p.filename}
         storage={ctx.storage}
         photosDir={ctx.photosDir}
         // No marker yet — clicking is a no-op for v1. User drags from tray.
@@ -238,7 +241,8 @@ function renderGroupItems(
     <PhotoListItem
       key={m.id}
       photoId={m.photoId!}
-      filename={m.name}
+      displayName={photoMarkerDisplayName(m)}
+      originalFilename={m.name}
       storage={ctx.storage}
       photosDir={ctx.photosDir}
       onClick={() => ctx.onMarkerClick(m.id)}
@@ -256,9 +260,11 @@ function renderGroupItems(
  *
  *  - Trim leading/trailing whitespace.
  *  - Empty (after trim) → reject (return null). Caller treats null as
- *    "cancel without saving" so the previous filename is kept.
- *  - Identical to current filename → return null (no-op, don't write).
- *  - Otherwise return the normalised string.
+ *    "cancel without saving" so the previous name is kept.
+ *  - Identical to the current display value → return null (no-op, don't write).
+ *  - Otherwise return the normalised string. (Reverting to the original
+ *    filename is handled downstream in `computeRenamedPhoto`, which clears the
+ *    custom name; here it's just another non-empty value to pass through.)
  *
  * The cap (`MAX_LEN`) guards against the user pasting a 100 KB blob into
  * the inline field — OPFS handles long strings but the UI doesn't.
@@ -272,7 +278,10 @@ export function normalizeRename(draft: string, current: string, maxLen = 200): s
 
 function PhotoListItem(props: {
   photoId: string
-  filename: string
+  /** Custom name if set, else the original filename — the primary label + edit seed. */
+  displayName: string
+  /** Original camera filename. Shown as a secondary line only when renamed. */
+  originalFilename: string
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
   onClick: (() => void) | undefined
@@ -284,22 +293,25 @@ function PhotoListItem(props: {
   renameSaveAria: string
 }) {
   const {
-    photoId, filename, storage, photosDir, onClick, onDelete, deleteTooltip,
+    photoId, displayName, originalFilename, storage, photosDir, onClick, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
   } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
   const [editing, setEditing] = useState(false)
-  // `draft` is the in-progress text. Seeded with the current filename on
+  // `draft` is the in-progress text. Seeded with the current display value on
   // every entry into edit mode so a previous cancel doesn't leak into the
   // next session.
-  const [draft, setDraft] = useState(filename)
+  const [draft, setDraft] = useState(displayName)
+  // Show the camera filename underneath only when a custom name is in effect —
+  // otherwise the row would print the same string twice.
+  const showOriginal = displayName !== originalFilename
 
   const beginEdit = () => {
-    setDraft(filename)
+    setDraft(displayName)
     setEditing(true)
   }
   const commit = () => {
-    const next = normalizeRename(draft, filename)
+    const next = normalizeRename(draft, displayName)
     setEditing(false)
     if (next !== null) void onRename(photoId, next)
   }
@@ -346,7 +358,7 @@ function PhotoListItem(props: {
           {state === 'ready' && url && (
             <img
               src={url}
-              alt={filename}
+              alt={displayName}
               draggable={false}
               style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
             />
@@ -384,8 +396,12 @@ function PhotoListItem(props: {
           />
         ) : (
           <ListItemText
-            primary={filename}
+            primary={displayName}
+            // Original camera filename underneath, but only when renamed —
+            // gives the user the workflow name (TP1) AND the camera reference.
+            secondary={showOriginal ? originalFilename : undefined}
             primaryTypographyProps={{ variant: 'body2', noWrap: true, sx: { fontSize: 12 } }}
+            secondaryTypographyProps={{ variant: 'caption', noWrap: true, sx: { fontSize: 10 } }}
           />
         )}
       </ListItemButton>

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -12,7 +12,14 @@ import { ALL_PHOTO_LABELS } from '../types/markers'
 
 export interface PhotoMarkerPopupProps {
   photoId: string
+  /** Primary name shown in bold — the custom name if set, else the filename. */
   filename: string
+  /**
+   * Original camera filename, shown as a small secondary line. Pass only when
+   * a custom name is in effect (i.e. differs from `filename`); `undefined`
+   * hides the row so an un-renamed photo isn't printed twice.
+   */
+  originalFilename?: string
   /** ISO 8601 capture timestamp; rendered as-is. Empty/undefined hides the row. */
   timestamp?: string
   storage: StorageInterface
@@ -62,7 +69,7 @@ export function labelButtonState(input: {
 
 export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   const { t } = useI18n()
-  const { photoId, filename, timestamp, storage, photosDir } = props
+  const { photoId, filename, originalFilename, timestamp, storage, photosDir } = props
   const { url: thumbUrl, state: loadState } = usePhotoThumbUrl(storage, photosDir, photoId)
 
   return (
@@ -97,6 +104,11 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
       <Typography variant="body2" sx={{ fontWeight: 600, wordBreak: 'break-all' }}>
         {filename}
       </Typography>
+      {originalFilename && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', wordBreak: 'break-all' }}>
+          {originalFilename}
+        </Typography>
+      )}
       {timestamp && (
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
           {timestamp}

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -3,7 +3,7 @@
 // is testable without mounting React.
 
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
-import { compareFilenames } from '../types/markers'
+import { compareFilenames, compareNoGpsPhotos } from '../types/markers'
 
 export interface GroupedPhotos {
   /** Photo markers with `flag === 'pick'`. Includes label-less picks. */
@@ -42,7 +42,10 @@ export function groupPhotosByFlag(
   picks.sort((a, b) => compareFilenames(a.name, b.name))
   neutral.sort((a, b) => compareFilenames(a.name, b.name))
   rejects.sort((a, b) => compareFilenames(a.name, b.name))
-  const noGps = [...noGpsPhotos].sort((a, b) => compareFilenames(a.filename, b.filename))
+  // Reuse the tray's comparator so the no-GPS group and the NoGpsTray agree on
+  // tie-break order (filename primary, EXIF timestamp tie-break) for identical
+  // filenames — not just on the primary filename sort.
+  const noGps = [...noGpsPhotos].sort(compareNoGpsPhotos)
   return {
     picks,
     neutral,

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -3,6 +3,7 @@
 // is testable without mounting React.
 
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+import { compareFilenames } from '../types/markers'
 
 export interface GroupedPhotos {
   /** Photo markers with `flag === 'pick'`. Includes label-less picks. */
@@ -35,11 +36,18 @@ export function groupPhotosByFlag(
     else if (m.flag === 'reject') rejects.push(m)
     else neutral.push(m)
   }
+  // Order every group by the ORIGINAL camera filename (numeric-aware), so the
+  // list mirrors the shooting sequence regardless of any custom `displayName`.
+  // Sorting by the immutable `name` means renaming a photo never moves it.
+  picks.sort((a, b) => compareFilenames(a.name, b.name))
+  neutral.sort((a, b) => compareFilenames(a.name, b.name))
+  rejects.sort((a, b) => compareFilenames(a.name, b.name))
+  const noGps = [...noGpsPhotos].sort((a, b) => compareFilenames(a.filename, b.filename))
   return {
     picks,
     neutral,
     rejects,
-    noGps: noGpsPhotos,
-    total: picks.length + neutral.length + rejects.length + noGpsPhotos.length,
+    noGps,
+    total: picks.length + neutral.length + rejects.length + noGps.length,
   }
 }

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -37,7 +37,9 @@ export function buildMapPickEntry(marker: PhotoMarker): MapPickEntry | null {
   const flag: MapPickEntry['flag'] = marker.flag ?? 'neutral'
   const entry: MapPickEntry = {
     photoId: marker.photoId,
-    filename: marker.name,
+    // Send the custom name when set so Photo Helper's candidate tile shows
+    // `TP1`, not the camera filename. Falls back to the original filename.
+    filename: marker.displayName ?? marker.name,
     flag,
   }
   if (marker.label) entry.label = marker.label

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -116,13 +116,21 @@ export type CorridorsSession = {
  * `normalizeRename` in PhotoListPanel) so the find/no-op/branch rules can be
  * pinned without rendering the hook or mocking OPFS.
  *
- * Walks BOTH `markers[]` (GPS path — display name on `marker.name`) and
- * `noGpsPhotos[]` (off-map tray — name on `entry.filename`) so a single call
- * handles either origin. Returns the next `{ markers, noGpsPhotos }` arrays,
- * or `null` for a no-op (caller then skips the persist + version bump):
- *  - empty after trim,
- *  - photoId in neither collection,
- *  - the trimmed name already matches the current value.
+ * Writes the user's label to `displayName` and NEVER overwrites the original
+ * `name`/`filename` — that stays as the immutable sort key + identity. Walks
+ * BOTH `markers[]` (GPS path) and `noGpsPhotos[]` (off-map tray) so a single
+ * call handles either origin. Returns the next `{ markers, noGpsPhotos }`
+ * arrays, or `null` for a no-op (caller then skips the persist + version bump).
+ *
+ * Behaviour:
+ *  - empty after trim → null (treated as cancel; never clears via empty).
+ *  - photoId in neither collection → null.
+ *  - trimmed === the original filename → clears `displayName` (back to
+ *    original). This is redundant-state avoidance, not an advertised UI: it
+ *    stops a "TP1 (TP1)"-style duplicate and lets a user revert by re-typing
+ *    the original. No new control is added.
+ *  - otherwise set `displayName = trimmed`.
+ *  - if the resulting `displayName` equals the current one → null (no write).
  *
  * Trusts the caller to have done UI-level validation (`normalizeRename`) but
  * re-applies trim + the no-op guards as a belt-and-suspenders layer.
@@ -139,15 +147,21 @@ export function computeRenamedPhoto(
   const markerIdx = markers.findIndex(m => m.photoId === photoId)
   const noGpsIdx = noGpsPhotos.findIndex(p => p.photoId === photoId)
   if (markerIdx === -1 && noGpsIdx === -1) return null
-  const markerUnchanged = markerIdx !== -1 && markers[markerIdx].name === trimmed
-  const noGpsUnchanged = noGpsIdx !== -1 && noGpsPhotos[noGpsIdx].filename === trimmed
-  if (markerUnchanged || noGpsUnchanged) return null
+
+  // Original filename + current custom name for whichever collection holds it.
+  const original = markerIdx !== -1 ? markers[markerIdx].name : noGpsPhotos[noGpsIdx].filename
+  const currentDisplay = markerIdx !== -1 ? markers[markerIdx].displayName : noGpsPhotos[noGpsIdx].displayName
+  // Re-typing the original filename clears the custom name rather than storing
+  // a redundant `displayName === name`.
+  const nextDisplayName = trimmed === original ? undefined : trimmed
+  if (nextDisplayName === currentDisplay) return null // nothing actually changes
+
   const nextMarkers = markerIdx === -1
     ? markers
-    : markers.map((m, i) => (i === markerIdx ? { ...m, name: trimmed } : m))
+    : markers.map((m, i) => (i === markerIdx ? { ...m, displayName: nextDisplayName } : m))
   const nextNoGps = noGpsIdx === -1
     ? noGpsPhotos
-    : noGpsPhotos.map((p, i) => (i === noGpsIdx ? { ...p, filename: trimmed } : p))
+    : noGpsPhotos.map((p, i) => (i === noGpsIdx ? { ...p, displayName: nextDisplayName } : p))
   return { markers: nextMarkers, noGpsPhotos: nextNoGps }
 }
 
@@ -388,6 +402,9 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
       lng,
       lat,
       name: entry.filename,
+      // Carry the custom name across so dragging a renamed tray photo onto
+      // the map keeps its label (and still preserves the original filename).
+      ...(entry.displayName ? { displayName: entry.displayName } : {}),
       flag: 'pick',
     }
     await persistSession({
@@ -442,20 +459,22 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   }, [persistSession])
 
   /**
-   * Rename a photo's display name in-place. Walks BOTH `markers[]` (GPS path,
-   * where the display name lives on `marker.name`) and `noGpsPhotos[]`
-   * (off-map tray, where it lives on `entry.filename`) so a single call
-   * handles either origin without the caller having to disambiguate.
+   * Set a photo's custom display name (`displayName`) without touching the
+   * original `marker.name` / `noGpsPhoto.filename`. Walks BOTH collections so
+   * a single call handles either origin without the caller disambiguating.
    *
    * The OPFS file under `photos/{photoId}` is untouched — only the
-   * user-facing label changes. The new name flows downstream:
-   *  - KML export uses `marker.name` directly.
-   *  - `buildMapPickEntry` writes `entry.filename = marker.name` so Photo
-   *    Helper's candidate tile picks up the new name on the next sync.
+   * user-facing label changes. The custom name flows downstream:
+   *  - KML export emits `displayName (originalFilename)` so the camera file is
+   *    still identifiable.
+   *  - `buildMapPickEntry` writes `entry.filename = displayName ?? name` so
+   *    Photo Helper's candidate tile shows the custom name on the next sync.
+   * Ordering everywhere stays keyed on the original filename, so a rename
+   * never reorders the list.
    *
    * Caller is expected to pre-trim / validate (see `normalizeRename` in
-   * PhotoListPanel) — this hook trusts its input but still bails on the
-   * empty-string and "no real change" cases as a belt-and-suspenders guard.
+   * PhotoListPanel); the no-op + clear-on-original rules live in
+   * `computeRenamedPhoto`.
    */
   const renamePhoto = useCallback(async (photoId: string, newName: string): Promise<void> => {
     const current = sessionRef.current

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -868,7 +868,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           >
             <PhotoMarkerPopup
               photoId={marker.photoId}
-              filename={marker.name}
+              filename={marker.displayName ?? marker.name}
+              originalFilename={marker.displayName ? marker.name : undefined}
               timestamp={marker.capturedAt.timestamp}
               storage={props.photoStorage}
               photosDir={props.photoDir}

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -207,6 +207,26 @@ export function compareFilenames(a: string, b: string): number {
   return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
 }
 
+/**
+ * Sort comparator for no-GPS tray entries. Ordered by ORIGINAL camera filename
+ * (numeric-aware via {@link compareFilenames}, so `IMG_9` < `IMG_10`), with EXIF
+ * timestamp as the tie-break for identical filenames. Sorting by the immutable
+ * filename — not the user's `displayName` — keeps a renamed photo from jumping
+ * position (user feedback 2026-05-17).
+ *
+ * Single source of truth: both the off-map tray ({@link NoGpsPhoto} thumbnails)
+ * and the right-side list's no-GPS group order through this, so the two surfaces
+ * can never disagree on tie-break order. A typo flipping it would otherwise ship
+ * silently — see `componentLogic.test.ts`.
+ */
+export function compareNoGpsPhotos(a: NoGpsPhoto, b: NoGpsPhoto): number {
+  const byName = compareFilenames(a.filename, b.filename)
+  if (byName !== 0) return byName
+  const ta = a.timestamp ?? '￿'
+  const tb = b.timestamp ?? '￿'
+  return ta < tb ? -1 : ta > tb ? 1 : 0
+}
+
 export function sanitizeNoGpsPhotos(input: unknown): NoGpsPhoto[] {
   if (!Array.isArray(input)) return []
   return input.filter(isNoGpsPhoto)

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -23,7 +23,21 @@ export type PhotoMarker = Readonly<{
   id: string
   lng: number
   lat: number
+  /**
+   * Original camera filename (e.g. `DSC_0123.JPG`), assigned at import and
+   * NEVER overwritten. It is the stable sort key (list/tray order by filename)
+   * and the secondary part of the exported KML name. Renaming writes
+   * `displayName`, not this. See `computeRenamedPhoto`.
+   */
   name: string
+  /**
+   * Optional user-supplied workflow label (e.g. `TP1`). When set it is shown
+   * as the primary name everywhere (list row, marker popup, KML `<name>`,
+   * Photo Helper tile) while `name` is preserved underneath for ordering and
+   * identification. `undefined` = no custom name, fall back to `name`.
+   * User feedback 2026-05-17 (Martin Hrivna).
+   */
+  displayName?: string
   label?: PhotoLabel
   capturedAt?: Readonly<{
     lng: number
@@ -115,6 +129,7 @@ export function isPhotoMarker(value: unknown): value is PhotoMarker {
     typeof v.id === 'string' && v.id.length > 0 &&
     isValidLngLat(v.lng, v.lat) &&
     typeof v.name === 'string' &&
+    (v.displayName === undefined || typeof v.displayName === 'string') &&
     (v.label === undefined || (typeof v.label === 'string' && PHOTO_LABEL_SET.has(v.label))) &&
     isValidCapturedAt(v.capturedAt) &&
     (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0)) &&
@@ -140,7 +155,18 @@ export function sanitizePhotoMarkers(input: unknown): PhotoMarker[] {
 // synthetic coordinates while in the tray.
 export type NoGpsPhoto = Readonly<{
   photoId: string
+  /**
+   * Original camera filename — the immutable sort key for the tray and the
+   * right-side list's no-GPS group. Renaming writes `displayName`, not this.
+   */
   filename: string
+  /**
+   * Optional user-supplied workflow label (e.g. `TP1`). Mirrors
+   * `PhotoMarker.displayName`: shown as the primary name, `filename` preserved
+   * underneath. Carried onto the created `PhotoMarker.displayName` when the
+   * photo is dragged onto the map (`placeNoGpsPhoto`).
+   */
+  displayName?: string
   /** ISO 8601 EXIF DateTimeOriginal; used for tray sort order. Optional — some cameras don't set it. */
   timestamp?: string
 }>
@@ -151,8 +177,34 @@ export function isNoGpsPhoto(value: unknown): value is NoGpsPhoto {
   return (
     typeof v.photoId === 'string' && v.photoId.length > 0 &&
     typeof v.filename === 'string' && v.filename.length > 0 &&
+    (v.displayName === undefined || typeof v.displayName === 'string') &&
     (v.timestamp === undefined || typeof v.timestamp === 'string')
   )
+}
+
+/**
+ * Effective display name for a photo marker: the user's custom `displayName`
+ * if set, otherwise the original camera filename. Single source of truth so
+ * the list row, marker popup, KML export, and map-picks all agree.
+ */
+export function photoMarkerDisplayName(m: Pick<PhotoMarker, 'name' | 'displayName'>): string {
+  return m.displayName ?? m.name
+}
+
+/** Effective display name for a no-GPS tray entry. See {@link photoMarkerDisplayName}. */
+export function noGpsPhotoDisplayName(p: Pick<NoGpsPhoto, 'filename' | 'displayName'>): string {
+  return p.displayName ?? p.filename
+}
+
+/**
+ * Numeric-aware filename comparator for list/tray ordering. `numeric: true`
+ * makes `DSC_0009 < DSC_0010 < DSC_0100` (a plain lexical sort would put
+ * `DSC_0010` before `DSC_0009`). `sensitivity: 'base'` keeps the order stable
+ * regardless of case. Sorts by the ORIGINAL filename, so a rename
+ * (which only touches `displayName`) never reorders the list.
+ */
+export function compareFilenames(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
 }
 
 export function sanitizeNoGpsPhotos(input: unknown): NoGpsPhoto[] {


### PR DESCRIPTION
## Summary
Renaming a photo used to **overwrite** the camera filename (`marker.name` / `noGpsPhoto.filename`). That destroyed the natural sort key and made the no-GPS tray re-sort on the new name. This PR keeps the original filename and treats the custom name as a separate, optional label.

Reported by Martin Hrivna (2026-05-17): keep ordering by original filename ascending, but show a custom name (e.g. `TP1`) for identification.

> bylo by možné v programu přejmenovat natažené fotky… Potom by se s nimi pracovalo už konkrétně, např. TP1 — ale zachovat původní řazení podle názvu souboru.

## Design (decisions confirmed with reporter)
- **Sort key:** original filename ascending, numeric-aware (`DSC_0009` < `DSC_0010` < `DSC_0100`). No-GPS tray drops its timestamp-first rule; capture time is now the tie-break.
- **Clear UX:** no dedicated control. Re-typing the original filename clears the custom name; empty stays a cancel.
- **Photo Helper:** no wire-schema change — `entry.filename = displayName ?? name`.
- **KML/UI naming:** custom name primary, original filename secondary.

## What changed
- **Data model** (`types/markers.ts`): `displayName?` on `PhotoMarker` + `NoGpsPhoto`, validators tolerate it. New shared helpers `photoMarkerDisplayName` / `noGpsPhotoDisplayName` / `compareFilenames` (numeric-aware).
- **Rename** (`computeRenamedPhoto`): writes `displayName`, never the original; clears on revert-to-original; no-op guards intact.
- **Ordering:** `groupPhotosByFlag` sorts each group by original `name`; `compareNoGpsPhotos` sorts by `filename` (timestamp tie-break). A rename never reorders.
- **Display:** list row (primary `TP1`, secondary `DSC_0123.JPG` only when renamed), marker popup (`PhotoMarkerPopup` secondary line), delete-confirm dialog, no-GPS tray labels.
- **Downstream:** KML `<name>` = `TP1 (DSC_0123.JPG)` (XMLSerializer `textContent` keeps it injection-safe); `placeNoGpsPhoto` carries `displayName` onto the created marker; `mapPicksWriter` projects `displayName ?? name`.
- Bumps desktop **2.13.6 → 2.15.0** + CHANGELOG.

## Migration
None. The rename feature shipped only in tag `desktop-v2.14.0`, which has **no `.exe` build** — no user has it yet, so the data-model change carries zero migration risk. Worth landing before the next Windows build.

## Test plan
- [x] `computeRenamedPhoto` rewritten for displayName (set / change / clear-on-original / no-op / immutability / legacy session)
- [x] `groupPhotosByFlag` + `compareNoGpsPhotos` ordering (numeric-aware, displayName-independent)
- [x] New `markersDisplay` helper tests + displayName projection in `mapPicksWriter`
- [x] Full map-corridors suite: 534 passing (+2 todo)
- [x] Typecheck clean
- [ ] Manual: import out-of-order photos → list/tray sorted by filename; rename one → stays in place, shows `TP1` over `DSC_…`; KML `<name>` = `TP1 (DSC_…)`; Photo Helper tile shows `TP1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)