### PR TITLE
feat(map-corridors): photo variants compare + hide rejected markers #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [Unreleased]
+
+### Added
+- **Map Corridors:** side-by-side variant compare. When organisers shoot the
+  same turn point 2–3× for insurance, Ctrl/Cmd+click (Shift+click for a range)
+  the rows in the photo list to select the variants, then "Srovnat varianty (N)"
+  opens a modal showing them full-res next to each other. Picking a winner
+  (click or keys `1`/`2`/`3`) promotes it to a pick and rejects the others in a
+  single atomic write. Rejected losers stay in the "Odmítnuté" list group as the
+  undo path — files are never deleted.
+
+### Changed
+- **Map Corridors:** rejected photos are now hidden from the map entirely
+  (pin, ghost capture dot and dashed line all disappear) instead of rendering as
+  a faded red `×`. The row remains under "Odmítnuté" so the reject is reversible.
+
 ## [2.15.1] - 2026-05-24
 
 ### Fixed

--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -821,8 +821,8 @@ UI specification and the Phase 4/5 test plans aligned.
 
 | GPS | Flag = `pick`   | Flag = `neutral`     | Flag = `reject`        |
 |---|---|---|---|
-| **With GPS** | Subject pin at `lng/lat`; ghost capture marker + dashed line iff drag has occurred | Small grey capture dot | Red `×` at capture, 40% opacity, hidden when "Hide rejects" is on |
-| **No GPS** | Subject pin at user-dropped `lng/lat`; no capture ghost or dashed line | Thumbnail in the off-map tray ([ADR-012](#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)) | Thumbnail in the off-map tray with a red overlay; same "Hide rejects" filter applies |
+| **With GPS** | Subject pin at `lng/lat`; ghost capture marker + dashed line iff drag has occurred | Small grey capture dot | **Hidden from the map entirely** (per [ADR-022](#adr-022--variant-compare-side-by-side-modal--reject-hides-marker)). Row remains in the "Odmítnuté" list group as the undo path |
+| **No GPS** | Subject pin at user-dropped `lng/lat`; no capture ghost or dashed line | Thumbnail in the off-map tray ([ADR-012](#adr-012-no-gps-photo-placement-off-map-tray-pinned-to-map-corner)) | Same hide rule once the photo has a marker; the off-map tray entry itself is unaffected |
 
 The `neutral`-with-GPS state is the on-import default for every photo
 that has GPS. The `neutral`-no-GPS state is "still in the tray, awaiting
@@ -842,11 +842,65 @@ Click semantics per state:
 
 ---
 
+## ADR-022 — Variant compare: side-by-side modal + reject-hides-marker
+
+**Context.** Field feedback (2026-05-24): organisers shoot the same turn
+point 2–3 times for insurance. The per-photo Include/Skip/Reject popup
+forces a serial judgement; users want an "eyes side-by-side, then pick the
+best" affordance. Originally listed below as deferred-to-v2 — promoted
+because the workflow is now common.
+
+**Decision.**
+
+1. **Selection is manual + ephemeral.** No persistent "variant group"
+   record. Multi-select lives in `PhotoListPanel` local state
+   (`selectedIds: readonly string[]`); Ctrl/Cmd+click toggles, Shift+click
+   extends a range over the visible row order. Hard-capped at
+   `MAX_COMPARE_VARIANTS = 3`.
+
+2. **Reject hides the marker.** Render filter in `MapProviderView` (and
+   in `buildGhostFeatures` / `buildDashedLineFeatures` so the ghost +
+   dashed line disappear with the pin). Rejected photos remain in the
+   "Odmítnuté" list group — that is the undo path. Files are *not*
+   deleted from OPFS. This supersedes the previous "Red × at capture,
+   40% opacity, hidden when 'Hide rejects' is on" entry in the visual
+   state matrix below — there is no "Hide rejects" toggle anymore; reject
+   simply hides.
+
+3. **Winner promotion is auto.** The picked tile in the compare modal
+   becomes `flag='pick'`, losers become `flag='reject'`. The mutation
+   happens in a single `persistMarkers` write so a hard-reload mid-resolve
+   cannot observe a half-applied state.
+
+4. **Cross-app contract unchanged.** [ADR-005](#adr-005--cross-app-handoff-via-a-one-way-map-picksjson-file) and
+   [ADR-017](#adr-017--flag-lives-in-map-picksjson-only-denormalized-to-geojson-properties-at-render-time)
+   already say "only `pick` reaches Photo Helper." Variants change which
+   photos earn the pick, not the wire format.
+
+**Why not auto-clustering.** GPS + timestamp clustering is on the v2
+list; we could land it as a *suggestion* layer over the manual selection
+later without rewriting Phase 12.
+
+**Why not a persistent variant-group record.** Selection state is what the
+user is doing *right now*. Persisting the group adds a join table to OPFS
+and a UI surface for "ungroup this variant set" — both are scope creep for
+zero workflow gain, because rejecting is reversible from the list panel
+already.
+
+**Why 3 max.** Two columns reads at any laptop width; three is workable.
+Four side-by-side photos are too cramped to make a "best of" call at
+typical screen widths, and field reports cap at 2–3 shots per point.
+
+**Files implementing this ADR.** See Phase 12 in `implementation-plan.md`.
+
+---
+
 ## Decisions explicitly deferred to v2
 
 These are recorded so they're not re-debated during v1 review.
 
-- **Side-by-side compare modal.** Out of scope.
+- ~~**Side-by-side compare modal.** Out of scope.~~ Shipped in Phase 12,
+  see [ADR-022](#adr-022--variant-compare-side-by-side-modal--reject-hides-marker).
 - **Time-cluster suggestion** ("photos taken within 30 s — pick best").
 - **Keyboard shortcuts** (I/S/R, ←/→).
 - **Manual EXIF correction** (overriding GPS for individual photos).

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -831,3 +831,61 @@ implementation by the implementer:
    need confirming.
 7. **`extractExif` HEIC-by-content detection** — verify `exifr` accepts a
    magic-byte sniff or whether we need a separate prefix check.
+
+---
+
+## Phase 12 — Photo variants (side-by-side compare)
+
+**Why now.** Organisers commonly shoot the same turn point 2–3× (insurance
+against motion blur, framing, or a passing aircraft in front of the
+subject). The per-photo Include/Skip/Reject flow forces a row-by-row
+judgement; users wanted an "eyes side-by-side, then pick" affordance.
+Originally deferred to v2 ([decisions.md → Deferred](decisions.md#decisions-explicitly-deferred-to-v2));
+promoted because the workflow is now hot.
+
+**Scope.** Manual selection (Ctrl/Cmd+click + Shift+click range) of 2–3
+variants in `PhotoListPanel`, then a side-by-side `Dialog` to pick the
+winner. Winner is auto-promoted to `flag='pick'`; losers move to
+`flag='reject'`, which (Step 2 of this phase) hides them from the map
+entirely. The rejected losers remain in the "Odmítnuté" list group as the
+undo path — files stay in OPFS.
+
+**Out of scope.**
+- Auto-clustering by GPS proximity + timestamp. Manual only for v1.
+- Persistent variant-group records. Selection is ephemeral.
+- Bidirectional sync with Photo Helper. Cross-app contract unchanged
+  ([ADR-005](decisions.md#adr-005--cross-app-handoff-via-a-one-way-map-picksjson-file)) —
+  only picks reach the editor.
+
+**Files touched.**
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — render filter
+  rejects markers (`flag !== 'reject'`).
+- `frontend/map-corridors/src/map/photoLayers/captureFeatures.ts` —
+  matching filter on the ghost-dot + dashed-line projections so the
+  capture marker disappears with its pin.
+- `frontend/map-corridors/src/components/PhotoListPanel.tsx` — selection
+  state, Ctrl/Cmd/Shift handling, "Srovnat varianty (N)" footer button.
+  New pure helpers `toggleSelection` / `computeRangeSelection`.
+- `frontend/map-corridors/src/components/PhotoCompareModal.tsx` — new MUI
+  Dialog rendering N tiles side-by-side. Loads full-res via
+  `usePhotoFullUrl`.
+- `frontend/map-corridors/src/components/usePhotoFullUrl.ts` — new sibling
+  hook of `usePhotoThumbUrl`.
+- `frontend/map-corridors/src/App.tsx` — owns modal state +
+  `handleCompareResolve` (single `persistMarkers` write so a reload
+  mid-resolve can never observe a half-applied state).
+- `frontend/map-corridors/src/locales/{cs,en}.json` — `photo.list.compareSelected`,
+  `photo.list.compareLimitTip`, `photo.list.clearSelection`,
+  `photo.compare.*`.
+
+**Smoke addendum (extends Phase 11 script).**
+
+a. Drop 3 JPGs whose GPS sits within ~50 m of the same turn point.
+b. Ctrl-click 3 rows in the panel → "Srovnat varianty (3)" appears.
+c. Click → modal opens, full-res images side-by-side.
+d. Press `2` (or click "Vybrat tuto" on tile 2) → modal closes.
+   Map shows 1 pin (blue, pick); the other 2 variants' pins are gone;
+   "Odmítnuté" group shows the 2 losers.
+e. Hard reload → state survives.
+f. Un-reject one loser from the panel → its marker reappears.
+g. Click "Send to editor (1)" → Photo Helper receives only the winner.

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -39,6 +39,8 @@ import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
+import { PhotoCompareModal } from './components/PhotoCompareModal'
+import type { PhotoMarker } from './types/markers'
 import {
   buildMapPicks,
   flushPendingMapPicks,
@@ -239,6 +241,11 @@ function App() {
   // Lifted to App.tsx so both PhotoListPanel and NoGpsTray share one
   // dialog without each panel growing its own confirmation state.
   const [pendingDeletePhoto, setPendingDeletePhoto] = useState<string | null>(null)
+  // Phase 12 — variant compare modal state. Holds the user's selected
+  // markers (in click order) while the dialog is open. `null` = dialog
+  // closed. Owned at App level so the resolve handler can hit the same
+  // `persistMarkers` setter used by every other flag mutation.
+  const [compareVariants, setCompareVariants] = useState<readonly PhotoMarker[] | null>(null)
   const answerSheetRef = useRef<HTMLDivElement | null>(null)
   const usedLabels = useMemo(() => {
     const set = new Set<PhotoLabel>()
@@ -700,6 +707,29 @@ function App() {
   const handlePhotoReject = useCallback((markerId: string) => {
     void setPhotoFlag(markerId, 'reject')
   }, [setPhotoFlag])
+
+  // Phase 12 — atomic variant resolution. Promotes the winner to 'pick' and
+  // demotes every loser to 'reject' in a single OPFS write so the user
+  // can't observe a half-resolved session if they hard-reload mid-write.
+  // The losers stay in OPFS (files + thumbs) — the rejected state alone
+  // hides their markers from the map, and the user can undo by un-rejecting
+  // from the list panel.
+  const handleCompareResolve = useCallback(async (winnerId: string, loserIds: readonly string[]) => {
+    const loserSet = new Set(loserIds)
+    const now = new Date().toISOString()
+    await persistMarkers((prev) =>
+      prev.map(m => {
+        if (m.id === winnerId) return { ...m, flag: 'pick', labelUpdatedAt: now }
+        if (loserSet.has(m.id)) return { ...m, flag: 'reject', labelUpdatedAt: now }
+        return m
+      }),
+    )
+  }, [persistMarkers])
+
+  const handleCompareVariants = useCallback((selected: readonly PhotoMarker[]) => {
+    if (selected.length < 2) return
+    setCompareVariants(selected)
+  }, [])
 
   // Phase 6 — drop-from-tray handler. Atomic: a single persistSession
   // mutates BOTH markers and noGpsPhotos in one write, so a partial
@@ -1232,10 +1262,19 @@ function App() {
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}
+            onCompareVariants={handleCompareVariants}
           />
         </Box>
       </Container>
     </Box>
+    <PhotoCompareModal
+      open={compareVariants !== null}
+      markers={compareVariants ?? []}
+      storage={storage}
+      photosDir={photosDir}
+      onClose={() => setCompareVariants(null)}
+      onResolve={handleCompareResolve}
+    />
     <Dialog open={isAnswerSheetOpen} onClose={() => setAnswerSheetOpen(false)} maxWidth="sm" fullWidth>
       <DialogContent dividers sx={{ p: 1 }}>
         <Box sx={{ position: 'relative' }}>

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -40,6 +40,7 @@ import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
 import { PhotoCompareModal } from './components/PhotoCompareModal'
+import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
 import type { PhotoMarker } from './types/markers'
 import {
   buildMapPicks,
@@ -713,17 +714,11 @@ function App() {
   // can't observe a half-resolved session if they hard-reload mid-write.
   // The losers stay in OPFS (files + thumbs) — the rejected state alone
   // hides their markers from the map, and the user can undo by un-rejecting
-  // from the list panel.
+  // from the list panel. This is a flag-only mutation — `resolveVariantFlags`
+  // deliberately leaves `labelUpdatedAt` untouched (see its docstring) so it
+  // can't masquerade as a newer label edit in the cross-app sync.
   const handleCompareResolve = useCallback(async (winnerId: string, loserIds: readonly string[]) => {
-    const loserSet = new Set(loserIds)
-    const now = new Date().toISOString()
-    await persistMarkers((prev) =>
-      prev.map(m => {
-        if (m.id === winnerId) return { ...m, flag: 'pick', labelUpdatedAt: now }
-        if (loserSet.has(m.id)) return { ...m, flag: 'reject', labelUpdatedAt: now }
-        return m
-      }),
-    )
+    await persistMarkers((prev) => resolveVariantFlags(prev, winnerId, loserIds))
   }, [persistMarkers])
 
   const handleCompareVariants = useCallback((selected: readonly PhotoMarker[]) => {

--- a/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
+++ b/frontend/map-corridors/src/__tests__/captureFeatures.test.ts
@@ -74,6 +74,16 @@ describe('buildGhostFeatures', () => {
     expect(fc.features).toEqual([])
   })
 
+  it("skips rejected photos so the ghost dot disappears with the marker", () => {
+    // Rejecting hides the live <Marker> in MapProviderView; the ghost dot is the
+    // visual echo of "where the camera was" and must vanish with it, otherwise
+    // a stray grey dot would remain on the map with no pin to explain it.
+    const fc = buildGhostFeatures([
+      pm({ photoId: 'pid-1', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 }, flag: 'reject' }),
+    ])
+    expect(fc.features).toEqual([])
+  })
+
   it('mixed batch — only moved photo markers leave a ghost', () => {
     const fc = buildGhostFeatures([
       pm({ id: 'kml', photoId: undefined, lng: 14, lat: 50 }),
@@ -113,5 +123,12 @@ describe('buildDashedLineFeatures', () => {
       pm({ photoId: 'pid-abc', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 } }),
     ])
     expect(fc.features[0].properties.photoId).toBe('pid-abc')
+  })
+
+  it('skips rejected photos so the dashed line disappears with the marker', () => {
+    const fc = buildDashedLineFeatures([
+      pm({ photoId: 'pid-1', lng: 14.5, lat: 50.5, capturedAt: { lng: 14, lat: 50 }, flag: 'reject' }),
+    ])
+    expect(fc.features).toEqual([])
   })
 })

--- a/frontend/map-corridors/src/__tests__/photoListPanel.test.ts
+++ b/frontend/map-corridors/src/__tests__/photoListPanel.test.ts
@@ -5,7 +5,7 @@
 // doesn't quietly drift the behaviour.
 
 import { describe, it, expect } from 'vitest'
-import { normalizeRename } from '../components/PhotoListPanel'
+import { computeRangeSelection, normalizeRename, toggleSelection } from '../components/PhotoListPanel'
 
 describe('normalizeRename', () => {
   it('returns the trimmed draft when it differs from current', () => {
@@ -36,5 +36,57 @@ describe('normalizeRename', () => {
   it('compares post-truncation against current (so a cap-induced no-op returns null)', () => {
     // If the draft after truncation matches `current`, that's also a no-op.
     expect(normalizeRename('X'.repeat(300), 'X'.repeat(10), 10)).toBeNull()
+  })
+})
+
+// Phase 12 (photo variants). The selection helpers feed PhotoCompareModal:
+// click order must be preserved (the modal renders left-to-right in that
+// order) and Shift-range must extend rather than replace so the user can
+// fold a stray fourth click into an earlier selection without restarting.
+
+describe('toggleSelection', () => {
+  it('appends a new id at the end (preserves click order)', () => {
+    expect(toggleSelection(['a', 'b'], 'c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('removes an already-selected id without reordering siblings', () => {
+    expect(toggleSelection(['a', 'b', 'c'], 'b')).toEqual(['a', 'c'])
+  })
+
+  it('empty selection + first toggle yields a single-element selection', () => {
+    expect(toggleSelection([], 'a')).toEqual(['a'])
+  })
+
+  it('toggling the lone selected id clears the selection', () => {
+    expect(toggleSelection(['a'], 'a')).toEqual([])
+  })
+})
+
+describe('computeRangeSelection', () => {
+  const order = ['a', 'b', 'c', 'd', 'e']
+
+  it('extends from anchor to target inclusive, preserving prior selection', () => {
+    expect(computeRangeSelection(order, 'b', 'd', ['a'])).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('works backwards (target before anchor) — order normalised to visible order', () => {
+    expect(computeRangeSelection(order, 'd', 'b', [])).toEqual(['b', 'c', 'd'])
+  })
+
+  it('range of length 1 (anchor == target) selects just that id', () => {
+    expect(computeRangeSelection(order, 'c', 'c', [])).toEqual(['c'])
+  })
+
+  it("does not duplicate ids already present in prev", () => {
+    // 'b' is in prev; the range b..d must not produce ['b', 'b', 'c', 'd'].
+    expect(computeRangeSelection(order, 'b', 'd', ['b'])).toEqual(['b', 'c', 'd'])
+  })
+
+  it('returns prev unchanged when the anchor is unknown (e.g. just-deleted photo)', () => {
+    expect(computeRangeSelection(order, 'ghost', 'c', ['a'])).toEqual(['a'])
+  })
+
+  it('returns prev unchanged when the target is unknown', () => {
+    expect(computeRangeSelection(order, 'a', 'ghost', ['b'])).toEqual(['b'])
   })
 })

--- a/frontend/map-corridors/src/__tests__/resolveVariantFlags.test.ts
+++ b/frontend/map-corridors/src/__tests__/resolveVariantFlags.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { resolveVariantFlags } from '../photoVariants/resolveVariantFlags'
+import type { PhotoMarker } from '../types/markers'
+
+// Phase 12 (photo variants) — the compare modal's "pick a winner" reducer.
+// This is the feature's headline correctness property: exactly the winner
+// becomes 'pick', exactly the losers become 'reject', everyone else is left
+// alone — and, critically, it is a FLAG-ONLY mutation that must never touch
+// `labelUpdatedAt` (which would let it masquerade as a newer label edit and
+// clobber labels in the map↔editor sync).
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', ...over } as PhotoMarker
+}
+
+describe('resolveVariantFlags', () => {
+  it('promotes the winner to pick and demotes losers to reject', () => {
+    const markers = [
+      pm({ id: 'a', photoId: 'a' }),
+      pm({ id: 'b', photoId: 'b' }),
+      pm({ id: 'c', photoId: 'c' }),
+    ]
+    const out = resolveVariantFlags(markers, 'b', ['a', 'c'])
+    expect(out.find(m => m.id === 'b')!.flag).toBe('pick')
+    expect(out.find(m => m.id === 'a')!.flag).toBe('reject')
+    expect(out.find(m => m.id === 'c')!.flag).toBe('reject')
+  })
+
+  it('leaves markers outside the variant set untouched (same reference)', () => {
+    const bystander = pm({ id: 'z', photoId: 'z', flag: 'pick', label: 'A' as never })
+    const markers = [pm({ id: 'a', photoId: 'a' }), pm({ id: 'b', photoId: 'b' }), bystander]
+    const out = resolveVariantFlags(markers, 'a', ['b'])
+    // Identity-preserved: a bystander marker is returned by reference, not cloned.
+    expect(out.find(m => m.id === 'z')).toBe(bystander)
+  })
+
+  it('does NOT touch labelUpdatedAt — flag-only mutation (regression guard for #74)', () => {
+    // Bumping labelUpdatedAt on a flag change makes the winner/loser look like
+    // a newer LABEL edit to useEditorPicksSync/useMapPicksSync, which can wipe
+    // or freeze labels across the app boundary. Pin that it stays put.
+    const winner = pm({ id: 'a', photoId: 'a', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' })
+    const loser = pm({ id: 'b', photoId: 'b', label: 'B' as never, labelUpdatedAt: '2025-01-02T00:00:00Z' })
+    const out = resolveVariantFlags([winner, loser], 'a', ['b'])
+    expect(out.find(m => m.id === 'a')!.labelUpdatedAt).toBe('2025-01-01T00:00:00Z')
+    expect(out.find(m => m.id === 'b')!.labelUpdatedAt).toBe('2025-01-02T00:00:00Z')
+    // The label itself is also preserved — only the flag changes.
+    expect(out.find(m => m.id === 'a')!.label).toBe('A')
+    expect(out.find(m => m.id === 'b')!.label).toBe('B')
+  })
+
+  it('handles the 2-variant case (one winner, one loser)', () => {
+    const out = resolveVariantFlags([pm({ id: 'a', photoId: 'a' }), pm({ id: 'b', photoId: 'b' })], 'a', ['b'])
+    expect(out.map(m => m.flag)).toEqual(['pick', 'reject'])
+  })
+})

--- a/frontend/map-corridors/src/components/PhotoCompareModal.tsx
+++ b/frontend/map-corridors/src/components/PhotoCompareModal.tsx
@@ -1,0 +1,220 @@
+// Phase 12 of photo-map-culling — side-by-side compare of 2–3 variants of
+// the same turn point. The user opens this from PhotoListPanel after Ctrl-
+// or Shift-clicking the rows they want to weigh against each other; picking
+// a winner promotes it to `flag='pick'` and demotes the rest to
+// `flag='reject'` (which hides their markers from the map per Step 2). The
+// rejected variants are NOT deleted from OPFS — they live in the
+// "Odmítnuté" list group as the undo path if the user changes their mind.
+
+import { useCallback, useEffect } from 'react'
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { Close } from '@mui/icons-material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import type { PhotoMarker } from '../types/markers'
+import { photoMarkerDisplayName } from '../types/markers'
+import { useI18n } from '../contexts/I18nContext'
+import { usePhotoFullUrl } from './usePhotoFullUrl'
+
+export interface PhotoCompareModalProps {
+  open: boolean
+  /** Selected variants, in the order the user picked them. */
+  markers: readonly PhotoMarker[]
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  onClose: () => void
+  /**
+   * Winner promoted to pick, losers demoted to reject. The parent owns
+   * the actual marker mutation so the OPFS write is atomic — a single
+   * `persistMarkers` call rather than N round-trips that could leave the
+   * session in a half-resolved state mid-write.
+   */
+  onResolve: (winnerId: string, loserIds: readonly string[]) => void | Promise<void>
+}
+
+export function PhotoCompareModal(props: PhotoCompareModalProps) {
+  const { open, markers, storage, photosDir, onClose, onResolve } = props
+  const { t } = useI18n()
+
+  const handlePick = useCallback((winnerId: string) => {
+    const loserIds = markers
+      .filter(m => m.id !== winnerId)
+      .map(m => m.id)
+    void onResolve(winnerId, loserIds)
+    onClose()
+  }, [markers, onResolve, onClose])
+
+  // Keyboard shortcuts 1/2/3 → pick that index. Wired at the dialog level
+  // so the user doesn't have to mouse to a button after eyeballing the
+  // photos. Only active while the dialog is open.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === '1' || e.key === '2' || e.key === '3') {
+        const idx = Number(e.key) - 1
+        if (idx >= 0 && idx < markers.length) {
+          e.preventDefault()
+          handlePick(markers[idx].id)
+        }
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [open, markers, handlePick])
+
+  if (!open) return null
+  // Defensive: 0 or 1 variants makes the "compare" framing nonsensical.
+  // PhotoListPanel already disables the trigger button, but a stale-state
+  // open with too few markers should be a graceful no-op, not a crash.
+  if (markers.length < 2) return null
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="xl"
+      keepMounted={false}
+      aria-labelledby="photo-compare-title"
+    >
+      <DialogTitle id="photo-compare-title" sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+        <Box sx={{ flex: 1 }}>{t('photo.compare.title')}</Box>
+        <Typography variant="caption" color="text.secondary">
+          {t('photo.compare.shortcut')}
+        </Typography>
+        <IconButton size="small" onClick={onClose} aria-label={t('photo.compare.cancel')}>
+          <Close fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 1.5 }}>
+        <Box
+          sx={{
+            display: 'grid',
+            // 1 col on narrow screens (mobile), N cols otherwise. Capped at
+            // 3 by PhotoListPanel's selection limit, so this never grows
+            // past 3 columns regardless of viewport.
+            gridTemplateColumns: { xs: '1fr', sm: `repeat(${markers.length}, 1fr)` },
+            gap: 1.5,
+          }}
+        >
+          {markers.map((m, idx) => (
+            <CompareTile
+              key={m.id}
+              marker={m}
+              index={idx}
+              storage={storage}
+              photosDir={photosDir}
+              onPick={() => handlePick(m.id)}
+            />
+          ))}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('photo.compare.cancel')}</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+function CompareTile(props: {
+  marker: PhotoMarker
+  index: number
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  onPick: () => void
+}) {
+  const { marker, index, storage, photosDir, onPick } = props
+  const { t } = useI18n()
+  // Defensive guard: PhotoListPanel's selection filter excludes markers
+  // without a photoId (KML markers), so this should always be defined when
+  // the modal opens via the supported path. Falling through to a missing-
+  // photo render keeps the UI honest if a future caller forgets the guard.
+  const { url, state } = usePhotoFullUrl(storage, photosDir, marker.photoId ?? '')
+  const ts = marker.capturedAt?.timestamp
+
+  return (
+    <Stack spacing={1} sx={{ minWidth: 0 }}>
+      <Box
+        sx={{
+          position: 'relative',
+          width: '100%',
+          // 70vh max so the image area stays inside the viewport even with
+          // the title + actions stacked above/below. `aspect-ratio: auto`
+          // (default) preserves the photo's native ratio via objectFit.
+          maxHeight: '70vh',
+          minHeight: 240,
+          bgcolor: 'grey.900',
+          borderRadius: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {state === 'ready' && url && (
+          <img
+            src={url}
+            alt={photoMarkerDisplayName(marker)}
+            style={{ maxWidth: '100%', maxHeight: '70vh', objectFit: 'contain' }}
+          />
+        )}
+        {state === 'loading' && (
+          <Typography variant="caption" color="grey.300">
+            {t('photo.compare.loading')}
+          </Typography>
+        )}
+        {state === 'missing' && (
+          <Typography variant="caption" color="error.light">
+            {t('photo.compare.missing')}
+          </Typography>
+        )}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 6,
+            left: 6,
+            bgcolor: 'rgba(0,0,0,0.55)',
+            color: 'white',
+            px: 0.75,
+            py: 0.25,
+            borderRadius: 0.5,
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+          aria-hidden
+        >
+          {/* Number badge mirrors the 1/2/3 keyboard shortcut so the user
+              can map key → tile at a glance. */}
+          {index + 1}
+        </Box>
+      </Box>
+      <Stack direction="row" spacing={1} alignItems="baseline" sx={{ minWidth: 0 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {photoMarkerDisplayName(marker)}
+        </Typography>
+        {ts && (
+          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>
+            {ts}
+          </Typography>
+        )}
+      </Stack>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={onPick}
+        aria-label={t('photo.compare.pickAria', { name: photoMarkerDisplayName(marker), index: index + 1 })}
+      >
+        {t('photo.compare.pick')}
+      </Button>
+    </Stack>
+  )
+}

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -2,7 +2,7 @@
 // Lists all imported photos grouped by flag. Click an item to fly the
 // map to its marker. Auto-hides when there are no photos.
 
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Badge,
   Box,
@@ -18,7 +18,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
-import { Check, ChevronLeft, ChevronRight, Close, EditOutlined, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
+import { Check, ChevronLeft, ChevronRight, Close, CompareArrows, EditOutlined, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { noGpsPhotoDisplayName, photoMarkerDisplayName } from '../types/markers'
@@ -60,7 +60,27 @@ export interface PhotoListPanelProps {
    * wire-schema change.
    */
   onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
+  /**
+   * Phase 12 (variants) — open the compare modal with the user-selected
+   * markers. Called when the user clicks the "Srovnat varianty (N)" footer
+   * button. Undefined disables the variant workflow entirely (e.g., no
+   * active competition / parent didn't opt in).
+   *
+   * Selection happens in this panel (Ctrl/Cmd+click toggles, Shift+click
+   * ranges), then this prop is invoked with the chosen `PhotoMarker[]` in
+   * selection order so the modal can show them in a stable layout.
+   */
+  onCompareVariants?: (markers: readonly PhotoMarker[]) => void
 }
+
+/**
+ * Hard cap on how many photos can be compared at once. The user's workflow
+ * is "2–3 variants of the same turn point"; the modal layout (side-by-side)
+ * stops being legible past 3 columns at typical screen widths. Enforced both
+ * by disabling the trigger button when |selection| > MAX and by an early
+ * return in `triggerCompare`.
+ */
+export const MAX_COMPARE_VARIANTS = 3
 
 type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
 
@@ -68,7 +88,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -77,12 +97,91 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
     noGps: false,
   })
 
+  // Phase 12 — multi-select for variant compare. Selection holds photoIds
+  // in click order so the compare modal can render them in the order the
+  // user picked. Anchor ref drives Shift+click range selection. We hold
+  // an array (not a Set) so iteration is stable and order survives toggle.
+  const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
+  const lastAnchorRef = useRef<string | null>(null)
+
   const groups = useMemo(() => groupPhotosByFlag(markers, noGpsPhotos), [markers, noGpsPhotos])
+
+  // Visible-order index of every selectable row (GPS markers only — noGps
+  // rows have no marker to compare). Drives Shift+click range expansion.
+  const orderedSelectableIds = useMemo(() => {
+    const ids: string[] = []
+    for (const m of groups.picks) if (m.photoId) ids.push(m.photoId)
+    for (const m of groups.neutral) if (m.photoId) ids.push(m.photoId)
+    for (const m of groups.rejects) if (m.photoId) ids.push(m.photoId)
+    return ids
+  }, [groups])
+
+  // Prune selection if a selected photo disappears (deleted, or its marker
+  // demoted). Without this, a stale photoId could leak into the compare
+  // modal and crash on lookup.
+  useEffect(() => {
+    setSelectedIds(prev => {
+      if (prev.length === 0) return prev
+      const valid = new Set(orderedSelectableIds)
+      const next = prev.filter(id => valid.has(id))
+      if (next.length === prev.length) return prev
+      if (lastAnchorRef.current && !valid.has(lastAnchorRef.current)) {
+        lastAnchorRef.current = next.length > 0 ? next[next.length - 1] : null
+      }
+      return next
+    })
+  }, [orderedSelectableIds])
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds([])
+    lastAnchorRef.current = null
+  }, [])
+
+  const handleRowClick = useCallback((photoId: string, markerId: string, e: React.MouseEvent) => {
+    if (e.shiftKey && lastAnchorRef.current) {
+      const anchor = lastAnchorRef.current
+      setSelectedIds(prev => computeRangeSelection(orderedSelectableIds, anchor, photoId, prev))
+      return
+    }
+    if (e.ctrlKey || e.metaKey) {
+      setSelectedIds(prev => toggleSelection(prev, photoId))
+      lastAnchorRef.current = photoId
+      return
+    }
+    // Plain click: fly to marker and clear any selection so the user
+    // doesn't stay in selection mode without an obvious cue.
+    clearSelection()
+    onMarkerClick(markerId)
+  }, [orderedSelectableIds, clearSelection, onMarkerClick])
+
+  const selectedMarkers = useMemo(() => {
+    const byPhotoId = new Map<string, PhotoMarker>()
+    for (const m of markers) if (m.photoId) byPhotoId.set(m.photoId, m)
+    const out: PhotoMarker[] = []
+    for (const pid of selectedIds) {
+      const m = byPhotoId.get(pid)
+      if (m) out.push(m)
+    }
+    return out
+  }, [selectedIds, markers])
+
+  const triggerCompare = useCallback(() => {
+    if (!onCompareVariants) return
+    if (selectedMarkers.length < 2 || selectedMarkers.length > MAX_COMPARE_VARIANTS) return
+    onCompareVariants(selectedMarkers)
+    clearSelection()
+  }, [onCompareVariants, selectedMarkers, clearSelection])
+
   if (groups.total === 0) return null
 
   const toggleGroup = (key: GroupKey) => {
     setCollapsedGroups(prev => ({ ...prev, [key]: !prev[key] }))
   }
+
+  const compareDisabled = selectedMarkers.length < 2 || selectedMarkers.length > MAX_COMPARE_VARIANTS
+  const compareTooltip = selectedMarkers.length > MAX_COMPARE_VARIANTS
+    ? t('photo.list.compareLimitTip', { max: MAX_COMPARE_VARIANTS })
+    : ''
 
   return (
     <Paper
@@ -135,7 +234,8 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               items={renderGroupItems(groups, key, {
                 storage,
                 photosDir,
-                onMarkerClick,
+                onRowClick: handleRowClick,
+                selectedIds,
                 onPhotoDelete,
                 onPhotoRename,
                 deleteTooltip: t('photo.deleteTooltip'),
@@ -145,6 +245,32 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               })}
             />
           ))}
+        </Box>
+      )}
+      {!collapsedPanel && onCompareVariants && selectedMarkers.length >= 1 && (
+        <Box sx={{ p: 1, borderTop: '1px solid', borderColor: 'divider', display: 'flex', gap: 1 }}>
+          <Tooltip title={compareTooltip} placement="top" disableHoverListener={!compareTooltip}>
+            {/* Tooltip needs a non-disabled wrapper to fire on a disabled
+                Button — span gets the hover, Button gets the disable. */}
+            <span style={{ flex: 1 }}>
+              <Button
+                fullWidth
+                variant="contained"
+                size="small"
+                color="secondary"
+                startIcon={<CompareArrows fontSize="small" />}
+                disabled={compareDisabled}
+                onClick={triggerCompare}
+              >
+                {t('photo.list.compareSelected', { count: selectedMarkers.length })}
+              </Button>
+            </span>
+          </Tooltip>
+          <Tooltip title={t('photo.list.clearSelection')} placement="top">
+            <IconButton size="small" onClick={clearSelection} aria-label={t('photo.list.clearSelection')}>
+              <Close fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Box>
       )}
       {!collapsedPanel && onSendToEditor && (
@@ -163,6 +289,52 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
       )}
     </Paper>
   )
+}
+
+/**
+ * Toggle a photoId in the selection list. Append on first click, remove on
+ * second. Exported for unit testing — keeps the multi-select event handler
+ * pure and lets a single test pin the ordering rules:
+ *
+ *  - First click on a new id → append to the end (preserves click order).
+ *  - Click on an already-selected id → remove (no shuffle of other ids).
+ */
+export function toggleSelection(
+  prev: readonly string[],
+  id: string,
+): readonly string[] {
+  return prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+}
+
+/**
+ * Shift+click range selection. Builds the union of the previous selection
+ * with every id between `anchor` and `target` in the visible row order, so
+ * a user can extend an existing selection without losing prior picks.
+ * Returns `prev` unchanged when either id isn't in the ordered list (a
+ * defensive no-op against stale anchors from photos that were just deleted).
+ *
+ * Exported for unit testing — drives the variant-compare workflow.
+ */
+export function computeRangeSelection(
+  orderedIds: readonly string[],
+  anchor: string,
+  target: string,
+  prev: readonly string[],
+): readonly string[] {
+  const a = orderedIds.indexOf(anchor)
+  const b = orderedIds.indexOf(target)
+  if (a < 0 || b < 0) return prev
+  const [lo, hi] = a <= b ? [a, b] : [b, a]
+  const range = orderedIds.slice(lo, hi + 1)
+  const seen = new Set(prev)
+  const next = [...prev]
+  for (const id of range) {
+    if (!seen.has(id)) {
+      next.push(id)
+      seen.add(id)
+    }
+  }
+  return next
 }
 
 function groupCount(g: ReturnType<typeof groupPhotosByFlag>, key: GroupKey): number {
@@ -204,7 +376,8 @@ function renderGroupItems(
   ctx: {
     storage: StorageInterface | null
     photosDir: DirectoryHandle | null
-    onMarkerClick: (markerId: string) => void
+    onRowClick: (photoId: string, markerId: string, e: React.MouseEvent) => void
+    selectedIds: readonly string[]
     onPhotoDelete: (photoId: string) => void | Promise<void>
     onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
     deleteTooltip: string
@@ -219,6 +392,7 @@ function renderGroupItems(
     renamePlaceholder: ctx.renamePlaceholder,
     renameSaveAria: ctx.renameSaveAria,
   }
+  const selectedSet = new Set(ctx.selectedIds)
   if (key === 'noGps') {
     return g.noGps.map(p => (
       <PhotoListItem
@@ -229,7 +403,10 @@ function renderGroupItems(
         storage={ctx.storage}
         photosDir={ctx.photosDir}
         // No marker yet — clicking is a no-op for v1. User drags from tray.
+        // Also intentionally not selectable for variant-compare: variants
+        // need GPS markers to associate the loser's hidden position with.
         onClick={undefined}
+        selected={false}
         onDelete={ctx.onPhotoDelete}
         deleteTooltip={ctx.deleteTooltip}
         {...commonRenameCtx}
@@ -245,7 +422,8 @@ function renderGroupItems(
       originalFilename={m.name}
       storage={ctx.storage}
       photosDir={ctx.photosDir}
-      onClick={() => ctx.onMarkerClick(m.id)}
+      onClick={(e) => ctx.onRowClick(m.photoId!, m.id, e)}
+      selected={selectedSet.has(m.photoId!)}
       onDelete={ctx.onPhotoDelete}
       deleteTooltip={ctx.deleteTooltip}
       {...commonRenameCtx}
@@ -284,7 +462,14 @@ function PhotoListItem(props: {
   originalFilename: string
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
-  onClick: (() => void) | undefined
+  /**
+   * Row click receives the raw event so the caller can branch on modifier
+   * keys (Ctrl/Cmd → toggle in variant selection, Shift → range select,
+   * plain click → fly to marker). `undefined` disables the row entirely.
+   */
+  onClick: ((e: React.MouseEvent) => void) | undefined
+  /** Whether this row is part of the variant-compare selection. */
+  selected: boolean
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
   onRename: (photoId: string, newName: string) => void | Promise<void>
@@ -293,7 +478,7 @@ function PhotoListItem(props: {
   renameSaveAria: string
 }) {
   const {
-    photoId, displayName, originalFilename, storage, photosDir, onClick, onDelete, deleteTooltip,
+    photoId, displayName, originalFilename, storage, photosDir, onClick, selected, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
   } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
@@ -333,6 +518,7 @@ function PhotoListItem(props: {
       <ListItemButton
         onClick={editing ? undefined : onClick}
         disabled={!editing && !onClick}
+        selected={selected}
         // Edit mode renders as a div so the inner TextField isn't nested
         // inside a <button> (a11y violation + focus contention). Spread
         // `component` conditionally — MUI's overload typing rejects
@@ -340,7 +526,19 @@ function PhotoListItem(props: {
         {...(editing ? { component: 'div' as const } : {})}
         // Two icon-buttons live in the right pad (rename + delete) when
         // not editing; one (save) when editing. pr: 7 covers the wider case.
-        sx={{ py: 0.5, gap: 1, pr: 7 }}
+        // Left border accent on selected rows so the variant selection is
+        // obvious even on rejected rows (which would otherwise have only
+        // the subtle MUI `selected` highlight to lean on).
+        sx={{
+          py: 0.5,
+          gap: 1,
+          pr: 7,
+          ...(selected && {
+            borderLeft: '3px solid',
+            borderLeftColor: 'secondary.main',
+            pl: 0.625, // standard ListItemButton pl is 16px; offset by border so text doesn't shift
+          }),
+        }}
       >
         <Box
           sx={{

--- a/frontend/map-corridors/src/components/usePhotoFullUrl.ts
+++ b/frontend/map-corridors/src/components/usePhotoFullUrl.ts
@@ -1,0 +1,68 @@
+// Full-resolution sibling of `usePhotoThumbUrl`. Used by PhotoCompareModal
+// (Phase 12 — photo variants) where the 40x30 thumb is too small for a
+// "pick the best of N" judgement call. Same URL.createObjectURL lifecycle
+// discipline as the thumb hook — revocation is keyed on the URL state so
+// React state and the live blob URL can never disagree in StrictMode.
+//
+// Kept separate from `usePhotoThumbUrl` (rather than parameterised) so the
+// existing thumb call sites — popup, tray, list — don't have to opt into a
+// new argument shape. The two hooks are a few lines each.
+
+import { useEffect, useState } from 'react'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+
+export type FullPhotoState = 'loading' | 'ready' | 'missing'
+
+export interface UsePhotoFullUrlResult {
+  url: string | null
+  state: FullPhotoState
+}
+
+export function usePhotoFullUrl(
+  storage: StorageInterface | null,
+  photosDir: DirectoryHandle | null,
+  photoId: string,
+): UsePhotoFullUrlResult {
+  const [url, setUrl] = useState<string | null>(null)
+  const [state, setState] = useState<FullPhotoState>('loading')
+
+  useEffect(() => {
+    let cancelled = false
+    if (!storage || !photosDir) {
+      setUrl(null)
+      setState('missing')
+      return
+    }
+    setUrl(null)
+    setState('loading')
+    void (async () => {
+      try {
+        const blob = await storage.getPhotoBlob(photosDir, photoId)
+        if (cancelled) return
+        if (!blob) {
+          // getPhotoBlob is typed to always resolve to a Blob, but the
+          // Electron path can return null when the file is missing — guard
+          // anyway so the UI shows "missing" rather than throwing.
+          setState('missing')
+          return
+        }
+        const next = URL.createObjectURL(blob)
+        setUrl(next)
+        setState('ready')
+      } catch (err) {
+        if (!cancelled) {
+          console.warn('[usePhotoFullUrl] full-res load failed:', err)
+          setState('missing')
+        }
+      }
+    })()
+    return () => { cancelled = true }
+  }, [storage, photosDir, photoId])
+
+  useEffect(() => {
+    if (!url) return
+    return () => { URL.revokeObjectURL(url) }
+  }, [url])
+
+  return { url, state }
+}

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -58,7 +58,19 @@
       "noGps": "Bez GPS",
       "expand": "Zobrazit seznam fotek",
       "collapse": "Skrýt seznam fotek",
-      "sendToEditor": "Poslat do editoru ({{count}})"
+      "sendToEditor": "Poslat do editoru ({{count}})",
+      "compareSelected": "Srovnat varianty ({{count}})",
+      "compareLimitTip": "Najednou lze srovnávat nejvýše {{max}} varianty",
+      "clearSelection": "Zrušit výběr"
+    },
+    "compare": {
+      "title": "Srovnání variant",
+      "shortcut": "Klávesy 1/2/3 vyberou variantu",
+      "pick": "Vybrat tuto",
+      "pickAria": "Vybrat variantu {{index}}: {{name}}",
+      "cancel": "Zrušit",
+      "loading": "Načítám fotku…",
+      "missing": "Fotku nelze načíst"
     },
     "deleteTooltip": "Smazat fotografii",
     "deleteConfirm": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -58,7 +58,19 @@
       "noGps": "No GPS",
       "expand": "Show photo list",
       "collapse": "Hide photo list",
-      "sendToEditor": "Send to editor ({{count}})"
+      "sendToEditor": "Send to editor ({{count}})",
+      "compareSelected": "Compare variants ({{count}})",
+      "compareLimitTip": "At most {{max}} variants can be compared at once",
+      "clearSelection": "Clear selection"
+    },
+    "compare": {
+      "title": "Compare variants",
+      "shortcut": "Press 1/2/3 to pick a variant",
+      "pick": "Pick this one",
+      "pickAria": "Pick variant {{index}}: {{name}}",
+      "cancel": "Cancel",
+      "loading": "Loading photo…",
+      "missing": "Couldn't load photo"
     },
     "deleteTooltip": "Delete photo",
     "deleteConfirm": {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -623,8 +623,11 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           when still at the capture point (= awaiting placement).
           Click → photo popup (Phase 5). Drag → onMarkerDragEnd updates
           subject coords. The ghost dot + dashed line in
-          PhotoOverlayLayers render only for moved photos. */}
-      {props.markers?.filter(m => !!m.photoId).map(m => {
+          PhotoOverlayLayers render only for moved photos.
+          Rejected photos (flag='reject') are hidden from the map
+          entirely — they remain in the list's "Odmítnuté" group as the
+          undo path. Variant resolution (Phase 12) reuses this. */}
+      {props.markers?.filter(m => !!m.photoId && m.flag !== 'reject').map(m => {
         const moved = !!m.capturedAt && (m.lng !== m.capturedAt.lng || m.lat !== m.capturedAt.lat)
         // Yellow = "labelled, answer-sheet ready" — matches the KML
         // marker color so a user scanning the map sees one consistent

--- a/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
+++ b/frontend/map-corridors/src/map/photoLayers/captureFeatures.ts
@@ -36,6 +36,7 @@ export function buildGhostFeatures(
   const features: FeatureCollection<Point, GhostProperties>['features'] = []
   for (const m of markers) {
     if (!m.capturedAt || !m.photoId) continue
+    if (m.flag === 'reject') continue
     if (!isPhotoMoved(m)) continue
     features.push({
       type: 'Feature',
@@ -62,6 +63,7 @@ export function buildDashedLineFeatures(
   const features: FeatureCollection<LineString, DashedLineProperties>['features'] = []
   for (const m of markers) {
     if (!m.capturedAt || !m.photoId) continue
+    if (m.flag === 'reject') continue
     if (!isPhotoMoved(m)) continue
     features.push({
       type: 'Feature',

--- a/frontend/map-corridors/src/photoVariants/resolveVariantFlags.ts
+++ b/frontend/map-corridors/src/photoVariants/resolveVariantFlags.ts
@@ -1,0 +1,30 @@
+// Phase 12 (photo variants) — pure reducer for the side-by-side compare
+// "pick a winner" action. Promotes the winner to flag='pick' and demotes
+// every loser to flag='reject', leaving all other markers untouched.
+//
+// Extracted from App.tsx so the invariant the feature relies on — winner
+// picked, losers rejected, everyone else identity-preserved — can be pinned
+// by a unit test without dragging in OPFS/persistMarkers.
+//
+// NOTE (regression guard): this is a *flag-only* mutation. It must NOT touch
+// `labelUpdatedAt`. That field is the authority for label "newer wins"
+// conflict resolution in `useEditorPicksSync` / `useMapPicksSync`; bumping it
+// on a flag change makes a flag edit masquerade as a newer label edit and can
+// clobber or freeze labels across the map↔editor handoff. Mirrors the
+// flag-only `setPhotoFlag` handler, which likewise leaves `labelUpdatedAt`
+// alone.
+
+import type { PhotoMarker } from '../types/markers'
+
+export function resolveVariantFlags(
+  markers: readonly PhotoMarker[],
+  winnerId: string,
+  loserIds: readonly string[],
+): readonly PhotoMarker[] {
+  const loserSet = new Set(loserIds)
+  return markers.map(m => {
+    if (m.id === winnerId) return { ...m, flag: 'pick' as const }
+    if (loserSet.has(m.id)) return { ...m, flag: 'reject' as const }
+    return m
+  })
+}


### PR DESCRIPTION
## Summary

- **Variant compare workflow.** Ctrl/Cmd+click rows in the photo list (Shift+click for ranges) to select 2–3 variants of the same turn point. New floating *Srovnat varianty (N)* button opens a side-by-side modal; picking a winner promotes it to `flag='pick'` and demotes the others to `flag='reject'` in a single atomic OPFS write. Keyboard shortcuts `1`/`2`/`3` pick by index.
- **Hide rejected markers from the map.** Rejected photos previously rendered as red pins (with their ghost capture dot + dashed line); they now disappear from the map entirely. The "Odmítnuté" list group remains as the undo path — files stay in OPFS.

Both behaviors are coupled because variant losers reuse the same hide pathway.

## Files

- New: `PhotoCompareModal.tsx`, `usePhotoFullUrl.ts`
- Touched: `PhotoListPanel.tsx` (multi-select + Srovnat button), `App.tsx` (modal owner + batch resolver), `MapProviderView.tsx`, `photoLayers/captureFeatures.ts` (reject filter), `locales/{cs,en}.json`
- Docs: `decisions.md` (new ADR-022; visual state matrix updated), `implementation-plan.md` (Phase 12)

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test` — 573 passed (added cases: reject filter in `captureFeatures`, `toggleSelection`, `computeRangeSelection`)
- [x] `pnpm build` green
- [ ] Smoke (Phase 12 addendum in implementation-plan.md): drop 3 GPS-clustered JPGs → Ctrl-click 3 rows → Srovnat varianty (3) → modal opens → press `2` → losers hidden from map but listed under Odmítnuté → reload preserves state → un-reject restores the marker
- [ ] *Send to editor* badge reflects the single picked variant; Photo Helper receives only the winner

🤖 Generated with [Claude Code](https://claude.com/claude-code)