### PR TITLE
docs(changelog): release 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [Unreleased]
+## [2.16.0] - 2026-05-24
 
 ### Added
 - **Map Corridors:** side-by-side variant compare. When organisers shoot the


### PR DESCRIPTION
Retitle the `[Unreleased]` changelog section to `[2.16.0] - 2026-05-24`, matching the `desktop-v2.16.0` tag auto-created when PR #74 merged.

Docs-only, no version flag → stays a patch (no new tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)