### PR TITLE
fix(deps): patch brace-expansion ReDoS (CVE-2026-45149)

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   yaml@<1.10.3: ^1.10.3
   brace-expansion@<1.1.13: ^1.1.13
   brace-expansion@>=2.0.0 <2.0.3: ^2.0.3
-  brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
+  brace-expansion@>=4.0.0 <5.0.6: ^5.0.6
   protocol-buffers-schema@<3.6.1: 3.6.1
   ip-address@<10.1.1: ^10.1.1
 
@@ -1969,8 +1969,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   brotli@1.3.3:
@@ -6642,7 +6642,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7912,7 +7912,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -41,7 +41,11 @@ overrides:
   'yaml@<1.10.3': '^1.10.3'
   'brace-expansion@<1.1.13': '^1.1.13'
   'brace-expansion@>=2.0.0 <2.0.3': '^2.0.3'
-  'brace-expansion@>=4.0.0 <5.0.5': '^5.0.5'
+  # CVE-2026-45149 / GHSA-jxxr-4gwj-5jf2 — a large numeric range defeats
+  # brace-expansion's documented `max` ReDoS protection. Vulnerable range
+  # >=5.0.0 <5.0.6, so the previous <5.0.5 pin no longer covered 5.0.5.
+  # Widened to <5.0.6 / ^5.0.6.
+  'brace-expansion@>=4.0.0 <5.0.6': '^5.0.6'
   'protocol-buffers-schema@<3.6.1': '3.6.1'
   # CVE-2026-42338 / GHSA-v2v4-37r5-5v8g — XSS in ip-address Address6
   # HTML-emitting methods. Patched in 10.1.1. We only pull this in


### PR DESCRIPTION
## Summary

Resolves Dependabot alert **#148** ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) / CVE-2026-45149, **medium**): a large numeric range defeats `brace-expansion`'s documented `max` ReDoS protection.

- Vulnerable range: `>=5.0.0 <5.0.6`. The transitive resolution had landed on **5.0.5**, which the existing `brace-expansion@>=4.0.0 <5.0.5` security override no longer covered.
- Widened the override in `frontend/pnpm-workspace.yaml` to `brace-expansion@>=4.0.0 <5.0.6` → `^5.0.6`, following the established conditional-override convention in that file.
- Lockfile regenerated: `brace-expansion@5.0.5` is gone, replaced by `5.0.6`.

Transitive build/test-tooling dependency (via glob/minimatch); no runtime app code calls it.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean (lockfile internally consistent)
- [x] `grep` confirms no `5.0.5` remains in lockfile; `5.0.6` resolved
- [x] map-corridors suite: 577 passed / 2 todo

Docs-only dep bump → no `#minor`/`#major` flag → patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)