### PR TITLE
feat(map-corridors): highlight active photo on map + in list panel #minor

### DIFF
--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -895,6 +895,50 @@ typical screen widths, and field reports cap at 2–3 shots per point.
 
 ---
 
+## ADR-023 — Active-photo highlight (map marker + list row sync)
+
+**Context.** Field feedback: when scanning many photos, users lose track of
+which photo on the map corresponds to which row in the side panel (and vice
+versa). Clicking a marker opened its popup but gave the list no signal; clicking
+a list row flew the camera but left the row visually unchanged.
+
+**Decision.**
+
+1. **One "active photo", lifted to App.** The active photo = the one whose
+   map popup is open. The `activePhotoMarkerId` state, previously private to
+   `MapProviderView`, is lifted to `App.tsx` as the single source of truth.
+   `MapProviderView` becomes **controlled** (`activePhotoMarkerId` prop +
+   `onActivePhotoMarkerChange` callback). The side panel reads the same state
+   (as a photoId), so map↔list highlight sync is bidirectional by construction.
+
+2. **Visual split, kept distinct from variant selection.** Map marker: white
+   halo + blue glow + ~1.3× scale, raised above neighbours (`zIndex`). List
+   row: filled primary tint (`alpha(primary, 0.14)`). This is deliberately
+   *different* from the variant-compare `selectedIds` accent (secondary-colour
+   left border, [ADR-022](#adr-022--variant-compare-side-by-side-modal--reject-hides-marker))
+   so a row can be both active and in a compare selection without ambiguity.
+
+3. **Lifecycle is popup-tied.** Closing the popup (or clicking empty map)
+   clears both highlights. The existing prune effect in `MapProviderView` is
+   extended to also clear when the active photo is **deleted** or becomes
+   **rejected** (rejected markers are hidden from the map per
+   [ADR-022](#adr-022--variant-compare-side-by-side-modal--reject-hides-marker),
+   so a lingering highlight would point at nothing).
+
+4. **List affordances.** Clicking a marker on the map auto-expands the active
+   photo's group (`groupKeyForPhotoId`) and scrolls its row into view
+   (`scrollIntoView({ block: 'nearest' })`). No-GPS tray photos have no marker
+   and can never be active.
+
+**Why not a separate "selected" concept distinct from the popup.** A second
+selection state would need its own clear/sync rules and could disagree with the
+popup. Reusing "popup open = active" keeps one intuitive concept and zero new
+lifecycle surface.
+
+**Files implementing this ADR.** See Phase 13 in `implementation-plan.md`.
+
+---
+
 ## Decisions explicitly deferred to v2
 
 These are recorded so they're not re-debated during v1 review.

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -921,9 +921,17 @@ untouched and stays visually distinct (left border vs. fill).
 - `frontend/map-corridors/src/components/PhotoListPanel.tsx` — `activePhotoId`
   prop; row tint (`alpha(primary, 0.14)`); `scrollIntoView` on the active row;
   group auto-expand effect; new exported pure helper `groupKeyForPhotoId`.
+- `frontend/map-corridors/src/activePhoto/activePhoto.ts` — pure helpers
+  `shouldClearActivePhoto` (drives the prune-on-delete/reject effect) and
+  `resolveActivePhotoId` (the list highlight's photoId; null for a gone/rejected
+  marker so no one-render tint flash on a reject row).
 
-**Tests.** `__tests__/groupKeyForPhotoId.test.ts` — picks/neutral/rejects
-mapping, unknown id → null, no-GPS photo → null.
+**Tests.**
+- `__tests__/groupKeyForPhotoId.test.ts` — picks/neutral/rejects mapping,
+  unknown id → null, no-GPS photo → null.
+- `__tests__/activePhoto.test.ts` — `shouldClearActivePhoto` (clears on
+  delete/reject, keeps on visible/null) and `resolveActivePhotoId`
+  (visible → photoId; rejected/deleted/no-photoId/null → null).
 
 **Smoke addendum.**
 

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -889,3 +889,51 @@ d. Press `2` (or click "Vybrat tuto" on tile 2) → modal closes.
 e. Hard reload → state survives.
 f. Un-reject one loser from the panel → its marker reappears.
 g. Click "Send to editor (1)" → Photo Helper receives only the winner.
+
+---
+
+## Phase 13 — Active-photo highlight (map ↔ list sync)
+
+**Why now.** Users lose track of which map marker maps to which side-panel
+row. We already had `activePhotoMarkerId` (the photo whose popup is open) but
+it was private to `MapProviderView`, so the list couldn't reflect it. See
+[ADR-023](decisions.md#adr-023--active-photo-highlight-map-marker--list-row-sync).
+
+**Scope.** Lift `activePhotoMarkerId` to `App.tsx` as one source of truth.
+Highlight the active photo on both surfaces: glow + scale on the map marker,
+filled tint on the list row (auto-scroll + group auto-expand). Lifecycle is
+popup-tied; clears on close, delete, or reject. Variant `selectedIds` is
+untouched and stays visually distinct (left border vs. fill).
+
+**Out of scope.**
+- A persistent selection separate from the popup (rejected — one concept).
+- Highlighting no-GPS tray photos (they have no marker).
+
+**Files touched.**
+- `frontend/map-corridors/src/App.tsx` — owns `activePhotoMarkerId`; passes it
+  + `onActivePhotoMarkerChange` to `MapProviderView` and a derived `activePhotoId`
+  to `PhotoListPanel`. `onMarkerClick` (→ `flyToPhotoMarker`) sets it via the
+  callback, so list clicks update the highlight for free.
+- `frontend/map-corridors/src/map/MapProviderView.tsx` — now controlled (reads
+  `props.activePhotoMarkerId`, requests via `onActivePhotoMarkerChange`); marker
+  glow + `scale(1.3)` + `zIndex` when active; prune effect extended to clear on
+  `flag === 'reject'` as well as deletion.
+- `frontend/map-corridors/src/components/PhotoListPanel.tsx` — `activePhotoId`
+  prop; row tint (`alpha(primary, 0.14)`); `scrollIntoView` on the active row;
+  group auto-expand effect; new exported pure helper `groupKeyForPhotoId`.
+
+**Tests.** `__tests__/groupKeyForPhotoId.test.ts` — picks/neutral/rejects
+mapping, unknown id → null, no-GPS photo → null.
+
+**Smoke addendum.**
+
+a. Import several GPS photos → markers + list rows appear.
+b. Click a marker on the map → its list row tints and scrolls into view; the
+   row's group expands if it was collapsed.
+c. Click a different list row → camera flies, old highlight clears, the new
+   marker glows + scales above its neighbours.
+d. Close the popup / click empty map → both highlights clear.
+e. Reject the active photo (popup or variant compare) → marker vanishes and the
+   highlight clears (no orphan tint).
+f. Ctrl-click rows for variant compare → left-border accent still reads
+   distinctly from the active fill (a row can show both).

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -41,6 +41,7 @@ import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
 import { PhotoCompareModal } from './components/PhotoCompareModal'
 import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
+import { resolveActivePhotoId } from './activePhoto/activePhoto'
 import type { PhotoMarker } from './types/markers'
 import {
   buildMapPicks,
@@ -1260,7 +1261,7 @@ function App() {
             storage={storage}
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
-            activePhotoId={markers.find(m => m.id === activePhotoMarkerId)?.photoId ?? null}
+            activePhotoId={resolveActivePhotoId(markers, activePhotoMarkerId)}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -234,6 +234,10 @@ function App() {
   const mapRef = useRef<MapProviderViewHandle | null>(null)
   const markers = session?.markers ?? []
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null)
+  // Phase 13 — the active photo marker (its map popup is open). Lifted here
+  // from MapProviderView so both the map (marker glow) and the right-side
+  // PhotoListPanel (row highlight) read one source of truth. `null` = none.
+  const [activePhotoMarkerId, setActivePhotoMarkerId] = useState<string | null>(null)
   const [isAnswerSheetOpen, setAnswerSheetOpen] = useState(false)
   // User feedback 2026-05-17: the X badge on every photo row deletes
   // without confirmation. The new rename pencil sits adjacent and a
@@ -1236,6 +1240,8 @@ function App() {
             onPhotoSkip={handlePhotoSkip}
             onPhotoReject={handlePhotoReject}
             onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}
+            activePhotoMarkerId={activePhotoMarkerId}
+            onActivePhotoMarkerChange={setActivePhotoMarkerId}
           />
           {/* Phase 6 — no-GPS tray, pinned to bottom-left of the map. */}
           <NoGpsTray
@@ -1254,6 +1260,7 @@ function App() {
             storage={storage}
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
+            activePhotoId={markers.find(m => m.id === activePhotoMarkerId)?.photoId ?? null}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}

--- a/frontend/map-corridors/src/__tests__/activePhoto.test.ts
+++ b/frontend/map-corridors/src/__tests__/activePhoto.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { shouldClearActivePhoto, resolveActivePhotoId } from '../activePhoto/activePhoto'
+import type { PhotoMarker } from '../types/markers'
+
+// Phase 13 (active-photo highlight). Two load-bearing rules:
+//  - the active photo is dropped when its marker is deleted or rejected
+//    (rejected markers are hidden from the map — a lingering highlight would
+//    point at nothing);
+//  - the list-panel highlight resolves to the active photoId only while the
+//    marker is still visible, so a reject can't leave a one-render tint flash.
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
+}
+
+const pick = pm({ id: 'a', photoId: 'pa', flag: 'pick' })
+const neutral = pm({ id: 'b', photoId: 'pb' })
+const rejected = pm({ id: 'c', photoId: 'pc', flag: 'reject' })
+const kml = pm({ id: 'k', photoId: undefined }) // KML marker, no photoId
+const markers = [pick, neutral, rejected, kml]
+
+describe('shouldClearActivePhoto', () => {
+  it('false when nothing is active (null id is not a reason to clear)', () => {
+    expect(shouldClearActivePhoto(markers, null)).toBe(false)
+  })
+
+  it('false when the active marker still exists and is visible', () => {
+    expect(shouldClearActivePhoto(markers, 'a')).toBe(false)
+    expect(shouldClearActivePhoto(markers, 'b')).toBe(false)
+  })
+
+  it('true when the active marker was deleted (no longer present)', () => {
+    expect(shouldClearActivePhoto(markers, 'gone')).toBe(true)
+  })
+
+  it('true when the active marker became rejected (hidden from the map)', () => {
+    expect(shouldClearActivePhoto(markers, 'c')).toBe(true)
+  })
+})
+
+describe('resolveActivePhotoId', () => {
+  it('null when nothing is active', () => {
+    expect(resolveActivePhotoId(markers, null)).toBeNull()
+  })
+
+  it('returns the photoId of a visible active marker', () => {
+    expect(resolveActivePhotoId(markers, 'a')).toBe('pa')
+    expect(resolveActivePhotoId(markers, 'b')).toBe('pb')
+  })
+
+  it('null when the active marker is rejected (prevents tint flash on the reject row)', () => {
+    expect(resolveActivePhotoId(markers, 'c')).toBeNull()
+  })
+
+  it('null when the active marker was deleted', () => {
+    expect(resolveActivePhotoId(markers, 'gone')).toBeNull()
+  })
+
+  it('null for a marker without a photoId (KML marker is never photo-active)', () => {
+    expect(resolveActivePhotoId(markers, 'k')).toBeNull()
+  })
+})

--- a/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { groupKeyForPhotoId } from '../components/PhotoListPanel'
+import { groupPhotosByFlag } from '../components/groupPhotosByFlag'
+import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
+
+// Phase 13 (active-photo highlight). `groupKeyForPhotoId` drives the
+// auto-expand of the active photo's group when its marker is clicked on the
+// map — so it must map a photoId to picks/neutral/rejects, and return null for
+// anything that has no GPS marker (unknown id, or a no-GPS tray photo).
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
+}
+
+const markers: PhotoMarker[] = [
+  pm({ id: 'a', photoId: 'a', name: 'a.jpg', flag: 'pick' }),
+  pm({ id: 'b', photoId: 'b', name: 'b.jpg' }), // neutral (no flag)
+  pm({ id: 'c', photoId: 'c', name: 'c.jpg', flag: 'reject' }),
+]
+const noGps: NoGpsPhoto[] = [{ photoId: 'n', filename: 'n.jpg' } as NoGpsPhoto]
+const groups = groupPhotosByFlag(markers, noGps)
+
+describe('groupKeyForPhotoId', () => {
+  it('returns "picks" for a pick marker', () => {
+    expect(groupKeyForPhotoId(groups, 'a')).toBe('picks')
+  })
+
+  it('returns "neutral" for an unflagged marker', () => {
+    expect(groupKeyForPhotoId(groups, 'b')).toBe('neutral')
+  })
+
+  it('returns "rejects" for a rejected marker', () => {
+    expect(groupKeyForPhotoId(groups, 'c')).toBe('rejects')
+  })
+
+  it('returns null for an unknown photoId', () => {
+    expect(groupKeyForPhotoId(groups, 'ghost')).toBeNull()
+  })
+
+  it('returns null for a no-GPS tray photo (no marker, never active)', () => {
+    expect(groupKeyForPhotoId(groups, 'n')).toBeNull()
+  })
+})

--- a/frontend/map-corridors/src/activePhoto/activePhoto.ts
+++ b/frontend/map-corridors/src/activePhoto/activePhoto.ts
@@ -1,0 +1,42 @@
+// Phase 13 (active-photo highlight) — pure helpers for the "currently active
+// photo" (the one whose map popup is open). Extracted from App.tsx /
+// MapProviderView so the two load-bearing rules can be unit-tested without
+// mounting React:
+//
+//  - `shouldClearActivePhoto` — when MapProviderView's prune effect must drop
+//    the active state (marker deleted, or rejected → hidden from the map).
+//  - `resolveActivePhotoId` — the photoId the list panel should highlight,
+//    null unless the active marker still exists AND is visible (not rejected).
+//    Excluding rejected here prevents a one-render tint flash on a reject row
+//    before the prune effect fires.
+
+import type { PhotoMarker } from '../types/markers'
+
+/**
+ * True when the active marker should be cleared: nothing is active is NOT a
+ * reason to clear (returns false for a null id), but a set id that no longer
+ * resolves to a visible marker (missing, or `flag === 'reject'`) is.
+ */
+export function shouldClearActivePhoto(
+  markers: readonly PhotoMarker[],
+  activeMarkerId: string | null,
+): boolean {
+  if (!activeMarkerId) return false
+  const m = markers.find(mm => mm.id === activeMarkerId)
+  return !m || m.flag === 'reject'
+}
+
+/**
+ * The photoId of the active photo for the list-panel highlight, or null when
+ * nothing is active or the active marker is gone/rejected (hidden) or lacks a
+ * photoId (KML markers are never photo-active).
+ */
+export function resolveActivePhotoId(
+  markers: readonly PhotoMarker[],
+  activeMarkerId: string | null,
+): string | null {
+  if (!activeMarkerId) return null
+  const m = markers.find(mm => mm.id === activeMarkerId)
+  if (!m || m.flag === 'reject') return null
+  return m.photoId ?? null
+}

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 import { Check, ChevronLeft, ChevronRight, Close, CompareArrows, EditOutlined, ExpandLess, ExpandMore, SendOutlined } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
@@ -71,6 +72,13 @@ export interface PhotoListPanelProps {
    * selection order so the modal can show them in a stable layout.
    */
   onCompareVariants?: (markers: readonly PhotoMarker[]) => void
+  /**
+   * Phase 13 — photoId of the currently active photo (the one whose map popup
+   * is open). Its row gets a filled tint and auto-scrolls into view; its group
+   * auto-expands. Distinct from the variant-compare `selectedIds` (left
+   * border) — a row can be both. `null`/undefined = nothing active.
+   */
+  activePhotoId?: string | null
 }
 
 /**
@@ -88,7 +96,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -131,6 +139,17 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
       return next
     })
   }, [orderedSelectableIds])
+
+  // Phase 13 — when a photo becomes active (e.g. its marker was clicked on
+  // the map), expand its group so the highlighted row is reachable. The row
+  // itself handles scrollIntoView; this only un-collapses. No-op for no-GPS
+  // photos (they have no marker and can't be active).
+  useEffect(() => {
+    if (!activePhotoId) return
+    const key = groupKeyForPhotoId(groups, activePhotoId)
+    if (!key) return
+    setCollapsedGroups(prev => (prev[key] ? { ...prev, [key]: false } : prev))
+  }, [activePhotoId, groups])
 
   const clearSelection = useCallback(() => {
     setSelectedIds([])
@@ -236,6 +255,7 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
                 photosDir,
                 onRowClick: handleRowClick,
                 selectedIds,
+                activePhotoId: activePhotoId ?? null,
                 onPhotoDelete,
                 onPhotoRename,
                 deleteTooltip: t('photo.deleteTooltip'),
@@ -341,6 +361,22 @@ function groupCount(g: ReturnType<typeof groupPhotosByFlag>, key: GroupKey): num
   return g[key].length
 }
 
+/**
+ * Which marker group (picks/neutral/rejects) a photoId lives in, or `null` if
+ * it isn't a GPS marker (unknown id, or a no-GPS tray photo — those have no
+ * marker and can't be the active photo). Exported for unit testing; drives the
+ * Phase-13 auto-expand of the active photo's group.
+ */
+export function groupKeyForPhotoId(
+  g: ReturnType<typeof groupPhotosByFlag>,
+  photoId: string,
+): Exclude<GroupKey, 'noGps'> | null {
+  if (g.picks.some(m => m.photoId === photoId)) return 'picks'
+  if (g.neutral.some(m => m.photoId === photoId)) return 'neutral'
+  if (g.rejects.some(m => m.photoId === photoId)) return 'rejects'
+  return null
+}
+
 function GroupSection(props: {
   groupKey: GroupKey
   title: string
@@ -378,6 +414,7 @@ function renderGroupItems(
     photosDir: DirectoryHandle | null
     onRowClick: (photoId: string, markerId: string, e: React.MouseEvent) => void
     selectedIds: readonly string[]
+    activePhotoId: string | null
     onPhotoDelete: (photoId: string) => void | Promise<void>
     onPhotoRename: (photoId: string, newName: string) => void | Promise<void>
     deleteTooltip: string
@@ -407,6 +444,7 @@ function renderGroupItems(
         // need GPS markers to associate the loser's hidden position with.
         onClick={undefined}
         selected={false}
+        active={false}
         onDelete={ctx.onPhotoDelete}
         deleteTooltip={ctx.deleteTooltip}
         {...commonRenameCtx}
@@ -424,6 +462,7 @@ function renderGroupItems(
       photosDir={ctx.photosDir}
       onClick={(e) => ctx.onRowClick(m.photoId!, m.id, e)}
       selected={selectedSet.has(m.photoId!)}
+      active={m.photoId === ctx.activePhotoId}
       onDelete={ctx.onPhotoDelete}
       deleteTooltip={ctx.deleteTooltip}
       {...commonRenameCtx}
@@ -470,6 +509,11 @@ function PhotoListItem(props: {
   onClick: ((e: React.MouseEvent) => void) | undefined
   /** Whether this row is part of the variant-compare selection. */
   selected: boolean
+  /**
+   * Whether this is the active photo (its map popup is open). Renders a
+   * filled tint and scrolls the row into view. Independent of `selected`.
+   */
+  active: boolean
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
   onRename: (photoId: string, newName: string) => void | Promise<void>
@@ -478,10 +522,17 @@ function PhotoListItem(props: {
   renameSaveAria: string
 }) {
   const {
-    photoId, displayName, originalFilename, storage, photosDir, onClick, selected, onDelete, deleteTooltip,
+    photoId, displayName, originalFilename, storage, photosDir, onClick, selected, active, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
   } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
+  const rowRef = useRef<HTMLDivElement | null>(null)
+  // Bring the active row into view when it becomes active (e.g. the user
+  // clicked its marker on the map). `block: 'nearest'` avoids yanking the
+  // scroll when the row is already visible.
+  useEffect(() => {
+    if (active) rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [active])
   const [editing, setEditing] = useState(false)
   // `draft` is the in-progress text. Seeded with the current display value on
   // every entry into edit mode so a previous cancel doesn't leak into the
@@ -506,6 +557,7 @@ function PhotoListItem(props: {
 
   return (
     <Box
+      ref={rowRef}
       sx={{
         position: 'relative',
         // Reveal full delete-button opacity on hover anywhere on the row,
@@ -537,6 +589,12 @@ function PhotoListItem(props: {
             borderLeft: '3px solid',
             borderLeftColor: 'secondary.main',
             pl: 0.625, // standard ListItemButton pl is 16px; offset by border so text doesn't shift
+          }),
+          // Active photo (map popup open): filled primary tint. Distinct from
+          // the variant `selected` left-border accent so a row can show both.
+          ...(active && {
+            backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.14),
+            '&:hover': { backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.2) },
           }),
         }}
       >

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import MapGL, { Layer, Source, Marker, Popup } from 'react-map-gl/mapbox'
 import type { MapRef, MarkerDragEvent, MarkerEvent } from 'react-map-gl/mapbox'
 import type { GeoJSON, Geometry, Position } from 'geojson'
@@ -91,6 +91,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // Phase 6 — fires when a no-GPS thumbnail from NoGpsTray is dropped
   // on the map. Receives the photoId and the unprojected drop coords.
   onNoGpsPhotoPlaced?: (photoId: string, lng: number, lat: number) => void
+  // Phase 13 — the active photo (its popup is open) is now lifted to App so
+  // the side panel can highlight the same photo. This component is controlled:
+  // it reads `activePhotoMarkerId` and requests changes via
+  // `onActivePhotoMarkerChange`. `null` = no photo popup / nothing active.
+  activePhotoMarkerId?: string | null
+  onActivePhotoMarkerChange?: (id: string | null) => void
 }>(function MapProviderView(props, ref) {
   const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
 
@@ -99,8 +105,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   const mapRef = useRef<MapRef | null>(null)
   const [isMapLoaded, setIsMapLoaded] = useState(false)
   const [confirmDeleteForId, setConfirmDeleteForId] = useState<string | null>(null)
-  // Phase 5: which photo marker has its popup open. Null = no photo popup.
-  const [activePhotoMarkerId, setActivePhotoMarkerId] = useState<string | null>(null)
+  // Phase 5/13: which photo marker has its popup open. Lifted to App (Phase
+  // 13) so the side panel can highlight the same photo — this component is now
+  // controlled. Aliased to the same names the rest of the file already uses so
+  // the read/set call sites below stay unchanged. Null = no photo popup.
+  const activePhotoMarkerId = props.activePhotoMarkerId ?? null
+  const onActivePhotoMarkerChange = props.onActivePhotoMarkerChange
+  const setActivePhotoMarkerId = useCallback(
+    (id: string | null) => { onActivePhotoMarkerChange?.(id) },
+    [onActivePhotoMarkerChange],
+  )
   const dragStartLngLatRef = useRef<Map<string, { lng: number, lat: number }>>(new Map())
   const dragMovedPxRef = useRef<Map<string, number>>(new Map())
   // Attach native DnD listeners on the canvas to support custom marker drops
@@ -166,16 +180,19 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // "every-photo-is-a-Marker" model — clicks land directly on the
   // <Marker> div, not on a GeoJSON layer feature.
 
-  // Close the photo popup only when the marker disappears entirely
-  // (deleted elsewhere). The Include/Skip/Reject handlers below call
-  // setActivePhotoMarkerId(null) explicitly — that path doesn't need
-  // this effect. Previously this also closed on flag/label transitions,
-  // which broke re-opening picks/rejects from the side-panel click.
+  // Close the photo popup (and clear the App-level active highlight) when the
+  // active marker disappears entirely (deleted elsewhere) OR becomes rejected
+  // — rejected markers are hidden from the map (Phase 12), so a lingering
+  // popup/highlight would point at a pin that isn't drawn. The Include/Skip/
+  // Reject handlers below also clear explicitly; this effect covers the paths
+  // that don't (e.g. variant-compare rejecting the active photo). We must NOT
+  // close on other flag/label transitions — that broke re-opening picks from
+  // the side-panel click.
   useEffect(() => {
     if (!activePhotoMarkerId) return
-    const exists = props.markers?.some(m => m.id === activePhotoMarkerId)
-    if (!exists) setActivePhotoMarkerId(null)
-  }, [props.markers, activePhotoMarkerId])
+    const m = props.markers?.find(mm => mm.id === activePhotoMarkerId)
+    if (!m || m.flag === 'reject') setActivePhotoMarkerId(null)
+  }, [props.markers, activePhotoMarkerId, setActivePhotoMarkerId])
 
   const uploadedGeojson = useMemo(() => {
     return geojsonOverlays?.find((o) => o.id === 'uploaded-geojson')?.data
@@ -638,12 +655,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           : m.flag === 'reject' ? '#d32f2f'
           : '#616161'
         const bg = moved ? ringColor : '#ffffff'
+        // Phase 13 — the active photo (popup open / selected in the side
+        // panel) gets a glow + scale-up and is lifted above its neighbours.
+        const isActive = activePhotoMarkerId === m.id
         return (
           <Marker
             key={m.id}
             longitude={m.lng}
             latitude={m.lat}
             draggable
+            style={isActive ? { zIndex: 2 } : undefined}
             onClick={(ev: MarkerEvent<MouseEvent>) => {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
               dragStartLngLatRef.current.delete(m.id)
@@ -690,7 +711,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               borderRadius: '50%',
               background: bg,
               border: `2px solid ${ringColor}`,
-              boxShadow: moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
+              // Active marker: white halo + blue glow so it reads on any
+              // basemap; otherwise the subtle drop shadow for moved photos.
+              boxShadow: isActive
+                ? '0 0 0 3px rgba(255,255,255,0.9), 0 0 10px 4px rgba(25,118,210,0.65)'
+                : moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
+              transform: isActive ? 'scale(1.3)' : undefined,
+              transition: 'transform 120ms ease, box-shadow 120ms ease',
               cursor: 'pointer',
             }} />
             {m.label && (

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -5,6 +5,7 @@ import type { GeoJSON, Geometry, Position } from 'geojson'
 import type { LngLatBoundsLike, LngLatLike, StyleSpecification } from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useI18n } from '../contexts/I18nContext'
+import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
@@ -189,9 +190,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // close on other flag/label transitions — that broke re-opening picks from
   // the side-panel click.
   useEffect(() => {
-    if (!activePhotoMarkerId) return
-    const m = props.markers?.find(mm => mm.id === activePhotoMarkerId)
-    if (!m || m.flag === 'reject') setActivePhotoMarkerId(null)
+    if (shouldClearActivePhoto(props.markers ?? [], activePhotoMarkerId)) {
+      setActivePhotoMarkerId(null)
+    }
   }, [props.markers, activePhotoMarkerId, setActivePhotoMarkerId])
 
   const uploadedGeojson = useMemo(() => {
@@ -324,7 +325,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         setActivePhotoMarkerId(markerId)
       }
     },
-  }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken])
+  }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken, setActivePhotoMarkerId])
 
   if (needsToken) {
     return (


### PR DESCRIPTION
## Summary

Zvýraznění právě vybrané fotky na mapě i v pravém seznamu. Lifts the existing `activePhotoMarkerId` (the photo whose map popup is open) from `MapProviderView` up to `App.tsx` as one source of truth, so both surfaces highlight the same photo — bidirectionally.

- **Map marker:** white halo + blue glow + ~1.3× scale, raised above neighbours via `zIndex`.
- **List row:** filled primary tint (distinct from variant-compare's secondary left-border — a row can show both), `scrollIntoView`, and its group auto-expands when the photo becomes active.
- **Lifecycle:** popup-tied. Closing the popup / clicking empty map clears both. The prune effect now also clears on **reject** (hidden marker) as well as **delete**, so no orphan highlight.

`MapProviderView` is now controlled (`activePhotoMarkerId` prop + `onActivePhotoMarkerChange` callback). The variant `selectedIds` multi-select is untouched.

## Files
- `App.tsx` — state owner + wiring
- `map/MapProviderView.tsx` — controlled state, marker glow, extended prune
- `components/PhotoListPanel.tsx` (+`PhotoListItem`) — row tint, scroll, group expand, new `groupKeyForPhotoId` helper
- Docs: ADR-023 + Phase 13

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 582 passed / 2 todo (5 new `groupKeyForPhotoId` cases)
- [ ] Smoke (Phase 13 addendum): click marker → row tints + scrolls + group expands → click another row → camera flies, old clears, new glows → close popup clears → reject active clears → variant left-border still distinct from active fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)