### PR TITLE
docs(changelog): add 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.17.0] - 2026-05-24
+
+### Added
+- **Map Corridors:** the currently active photo is now highlighted on both the
+  map and the right-side list, kept in sync. Clicking a photo's marker (or its
+  list row) gives the marker a glow + slight zoom and tints its row; the list
+  scrolls to that row and expands its group if collapsed. Closing the popup
+  clears the highlight. Rejecting or deleting the active photo clears it too.
+
 ## [2.16.0] - 2026-05-24
 
 ### Added


### PR DESCRIPTION
Adds the `[2.17.0] - 2026-05-24` changelog section for the active-photo highlight feature (PR #77), matching the `desktop-v2.17.0` tag already cut on merge.

Docs-only, no version flag → patch (no new tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)