### PR TITLE
feat(map-corridors): unify photo-action labels (Přeskočit → Neutrální)

### DIFF
--- a/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { isPhotoMarkerVisible } from '../map/photoLayers/markerVisibility'
+import type { PhotoMarker } from '../types/markers'
+
+// The live-pin filter for the map. Rejecting a photo must remove its pin (it
+// then lives only in the side panel's "Odmítnuté" group); picks and neutrals
+// stay drawn. KML markers (no photoId) are not photo pins.
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
+}
+
+describe('isPhotoMarkerVisible', () => {
+  it('shows a neutral photo (no flag)', () => {
+    expect(isPhotoMarkerVisible(pm({}))).toBe(true)
+  })
+
+  it('shows a picked photo', () => {
+    expect(isPhotoMarkerVisible(pm({ flag: 'pick' }))).toBe(true)
+  })
+
+  it('hides a rejected photo (disappears from the map)', () => {
+    expect(isPhotoMarkerVisible(pm({ flag: 'reject' }))).toBe(false)
+  })
+
+  it('hides a marker without a photoId (KML/click-placed, not a photo pin)', () => {
+    expect(isPhotoMarkerVisible(pm({ photoId: undefined }))).toBe(false)
+  })
+})

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -36,9 +36,9 @@
       "noCompetition": "Před importem fotek otevři soutěž z hlavního menu"
     },
     "popup": {
-      "include": "Vybrat",
-      "skip": "Přeskočit",
-      "reject": "Odmítnout",
+      "include": "Vybrané",
+      "skip": "Neutrální",
+      "reject": "Odmítnuté",
       "thumbMissing": "Náhled není k dispozici",
       "label": "Štítek",
       "labelSet": "Přiřadit štítek",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -36,9 +36,9 @@
       "noCompetition": "Open a competition from the launcher before importing photos"
     },
     "popup": {
-      "include": "Include",
-      "skip": "Skip",
-      "reject": "Reject",
+      "include": "Picked",
+      "skip": "Neutral",
+      "reject": "Rejected",
       "thumbMissing": "Thumbnail unavailable",
       "label": "Label",
       "labelSet": "Set label",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -6,6 +6,7 @@ import type { LngLatBoundsLike, LngLatLike, StyleSpecification } from 'mapbox-gl
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useI18n } from '../contexts/I18nContext'
 import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
+import { isPhotoMarkerVisible } from './photoLayers/markerVisibility'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
@@ -645,7 +646,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           Rejected photos (flag='reject') are hidden from the map
           entirely — they remain in the list's "Odmítnuté" group as the
           undo path. Variant resolution (Phase 12) reuses this. */}
-      {props.markers?.filter(m => !!m.photoId && m.flag !== 'reject').map(m => {
+      {props.markers?.filter(isPhotoMarkerVisible).map(m => {
         const moved = !!m.capturedAt && (m.lng !== m.capturedAt.lng || m.lat !== m.capturedAt.lat)
         // Yellow = "labelled, answer-sheet ready" — matches the KML
         // marker color so a user scanning the map sees one consistent

--- a/frontend/map-corridors/src/map/photoLayers/markerVisibility.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerVisibility.ts
@@ -1,0 +1,12 @@
+// Single source of truth for "does this photo marker draw a live pin on the
+// map?". A marker is visible iff it is a photo marker (has a `photoId`) and is
+// NOT rejected — rejected photos are hidden from the map entirely and live
+// only in the side panel's "Odmítnuté" group (Phase 12 / ADR-022). The capture
+// ghost-dot + dashed-line projections in `captureFeatures` apply the same
+// reject rule so the whole marker visual disappears together.
+
+import type { PhotoMarker } from '../../types/markers'
+
+export function isPhotoMarkerVisible(m: PhotoMarker): boolean {
+  return !!m.photoId && m.flag !== 'reject'
+}


### PR DESCRIPTION
## Summary

Sjednocení názvů akcí s názvy skupin v seznamu.

**1. Label unification.** The marker-popup action buttons used verbs while the side-panel groups used state words. The buttons now match the groups:

| | Before | After |
|---|---|---|
| cs | Vybrat / **Přeskočit** / Odmítnout | Vybrané / **Neutrální** / Odmítnuté |
| en | Include / Skip / Reject | Picked / Neutral / Rejected |

Label-only — the underlying `flag` values (`pick`/`reject`/`null`) are unchanged.

**2. Reject hides from map.** This was already implemented (Phase 12 / `desktop-v2.16.0`): rejecting a photo moves it to the "Odmítnuté" group and removes its pin from the map. This PR extracts that live-pin rule into `isPhotoMarkerVisible` (photoId present AND not rejected), DRY'ing the inline filter and adding a unit test — addressing the crit-6 coverage gap from the PR #77 review.

## Files
- `locales/{cs,en}.json` — popup label values
- `map/photoLayers/markerVisibility.ts` (new) + `MapProviderView.tsx` — extracted predicate
- `__tests__/markerVisibility.test.ts` (new)

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 595 passed / 2 todo (4 new `isPhotoMarkerVisible` cases)
- [ ] Smoke: popup buttons read Vybrané/Neutrální/Odmítnuté; clicking Odmítnuté removes the pin + moves the row to the Odmítnuté group

🤖 Generated with [Claude Code](https://claude.com/claude-code)