### PR TITLE
fix(map-corridors): re-open rejected photo to un-reject (regression)

### DIFF
--- a/frontend/map-corridors/src/__tests__/activePhoto.test.ts
+++ b/frontend/map-corridors/src/__tests__/activePhoto.test.ts
@@ -3,11 +3,11 @@ import { shouldClearActivePhoto, resolveActivePhotoId } from '../activePhoto/act
 import type { PhotoMarker } from '../types/markers'
 
 // Phase 13 (active-photo highlight). Two load-bearing rules:
-//  - the active photo is dropped when its marker is deleted or rejected
-//    (rejected markers are hidden from the map — a lingering highlight would
-//    point at nothing);
-//  - the list-panel highlight resolves to the active photoId only while the
-//    marker is still visible, so a reject can't leave a one-render tint flash.
+//  - the active photo is dropped ONLY when its marker is deleted — NOT on
+//    reject, so a rejected photo's popup stays openable from the list and can
+//    be un-rejected (regression guard: clearing on reject broke re-opening);
+//  - the list-panel highlight resolves to the active photoId whenever the
+//    marker exists (rejected included, so the un-reject row highlights).
 
 function pm(over: Partial<PhotoMarker>): PhotoMarker {
   return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
@@ -33,8 +33,8 @@ describe('shouldClearActivePhoto', () => {
     expect(shouldClearActivePhoto(markers, 'gone')).toBe(true)
   })
 
-  it('true when the active marker became rejected (hidden from the map)', () => {
-    expect(shouldClearActivePhoto(markers, 'c')).toBe(true)
+  it('false when the active marker is rejected — popup must stay open to un-reject (regression guard)', () => {
+    expect(shouldClearActivePhoto(markers, 'c')).toBe(false)
   })
 })
 
@@ -48,8 +48,8 @@ describe('resolveActivePhotoId', () => {
     expect(resolveActivePhotoId(markers, 'b')).toBe('pb')
   })
 
-  it('null when the active marker is rejected (prevents tint flash on the reject row)', () => {
-    expect(resolveActivePhotoId(markers, 'c')).toBeNull()
+  it('returns the photoId of a rejected active marker (the un-reject row highlights)', () => {
+    expect(resolveActivePhotoId(markers, 'c')).toBe('pc')
   })
 
   it('null when the active marker was deleted', () => {

--- a/frontend/map-corridors/src/activePhoto/activePhoto.ts
+++ b/frontend/map-corridors/src/activePhoto/activePhoto.ts
@@ -4,32 +4,39 @@
 // mounting React:
 //
 //  - `shouldClearActivePhoto` — when MapProviderView's prune effect must drop
-//    the active state (marker deleted, or rejected → hidden from the map).
-//  - `resolveActivePhotoId` — the photoId the list panel should highlight,
-//    null unless the active marker still exists AND is visible (not rejected).
-//    Excluding rejected here prevents a one-render tint flash on a reject row
-//    before the prune effect fires.
+//    the active state. ONLY on deletion. NOT on reject — see below.
+//  - `resolveActivePhotoId` — the photoId the list panel should highlight.
+//
+// Active = "the marker whose popup is open", regardless of flag. A rejected
+// photo MUST be able to be active: clicking a rejected row in the side panel
+// opens its popup so the user can un-reject it (set it back to pick/neutral).
+// Clearing active on reject is exactly the bug that "broke re-opening
+// picks/rejects from the side-panel click" — rejecting *via the popup* is
+// closed by the explicit onReject handler, which is the only reject path that
+// should dismiss the popup.
 
 import type { PhotoMarker } from '../types/markers'
 
 /**
- * True when the active marker should be cleared: nothing is active is NOT a
- * reason to clear (returns false for a null id), but a set id that no longer
- * resolves to a visible marker (missing, or `flag === 'reject'`) is.
+ * True when the active marker should be cleared: only when the id no longer
+ * resolves to ANY marker (deleted elsewhere). A null id is not a reason to
+ * clear (returns false). Reject does NOT clear — a rejected photo stays
+ * openable so it can be un-rejected from the list.
  */
 export function shouldClearActivePhoto(
   markers: readonly PhotoMarker[],
   activeMarkerId: string | null,
 ): boolean {
   if (!activeMarkerId) return false
-  const m = markers.find(mm => mm.id === activeMarkerId)
-  return !m || m.flag === 'reject'
+  return !markers.some(mm => mm.id === activeMarkerId)
 }
 
 /**
  * The photoId of the active photo for the list-panel highlight, or null when
- * nothing is active or the active marker is gone/rejected (hidden) or lacks a
- * photoId (KML markers are never photo-active).
+ * nothing is active, the active marker is gone, or it lacks a photoId (KML
+ * markers are never photo-active). Rejected photos DO resolve — their row
+ * highlights while the popup is open so the user sees which one they're
+ * un-rejecting.
  */
 export function resolveActivePhotoId(
   markers: readonly PhotoMarker[],
@@ -37,6 +44,5 @@ export function resolveActivePhotoId(
 ): string | null {
   if (!activeMarkerId) return null
   const m = markers.find(mm => mm.id === activeMarkerId)
-  if (!m || m.flag === 'reject') return null
-  return m.photoId ?? null
+  return m?.photoId ?? null
 }

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -182,14 +182,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // "every-photo-is-a-Marker" model — clicks land directly on the
   // <Marker> div, not on a GeoJSON layer feature.
 
-  // Close the photo popup (and clear the App-level active highlight) when the
-  // active marker disappears entirely (deleted elsewhere) OR becomes rejected
-  // — rejected markers are hidden from the map (Phase 12), so a lingering
-  // popup/highlight would point at a pin that isn't drawn. The Include/Skip/
-  // Reject handlers below also clear explicitly; this effect covers the paths
-  // that don't (e.g. variant-compare rejecting the active photo). We must NOT
-  // close on other flag/label transitions — that broke re-opening picks from
-  // the side-panel click.
+  // Close the photo popup ONLY when the active marker disappears entirely
+  // (deleted elsewhere). We must NOT close on flag/label transitions —
+  // including reject — because clicking a rejected row in the side panel
+  // re-opens its popup so the user can un-reject it; closing on reject breaks
+  // that. Rejecting *via this popup* is dismissed by the explicit onReject
+  // handler below, not here.
   useEffect(() => {
     if (shouldClearActivePhoto(props.markers ?? [], activePhotoMarkerId)) {
       setActivePhotoMarkerId(null)


### PR DESCRIPTION
## Summary

Regression from v2.17.0 (Phase 13 active-photo highlight). The prune effect cleared the active photo when its `flag` became `reject`, so clicking a rejected photo's row in the side panel opened its popup and then **immediately closed it** — making it impossible to un-reject a photo. This is the exact failure the pre-Phase-13 comment warned against.

**Fix:** `shouldClearActivePhoto` clears the active photo **only on deletion**, never on reject. Rejecting *via the popup* is still dismissed by the explicit `onReject` handler (the one path that should close it). `resolveActivePhotoId` now also resolves rejected markers, so the row highlights while its popup is open during an un-reject.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run` — green (reject-no-longer-clears + reject-resolves cases updated)
- [ ] Smoke: reject a photo via popup → it moves to Odmítnuté + leaves the map; click its Odmítnuté row → popup re-opens → Vybrané/Neutrální restores it to the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)