### PR TITLE
feat(map-corridors): no-GPS click-to-place + drag-to-recategorize #minor

### DIFF
--- a/docs/photo-map-culling/decisions.md
+++ b/docs/photo-map-culling/decisions.md
@@ -939,6 +939,42 @@ lifecycle surface.
 
 ---
 
+## ADR-024 — Panel interactions: no-GPS provisional placement + drag-to-recategorize
+
+**Context.** Field feedback (2026-05-24): (1) no-GPS photos render greyed/inert
+in the list and the only way to place them was dragging from the tray, which
+users found unobvious; (2) changing a photo's category required opening the map
+popup. Users wanted to click a no-GPS row to place it, and to drag a row between
+groups to recategorize.
+
+**Decision.**
+
+1. **No-GPS placement is provisional, committed by category choice.** Clicking a
+   no-GPS row drops a **draggable provisional pin** at the current map center
+   (`MapProviderViewHandle.getCenter`) and opens a popup. The photo **stays in
+   "Bez GPS"** until the user picks a category (Vybrané/Neutrální/Odmítnuté) in
+   that popup — only then is it committed (`placeNoGpsPhoto(photoId, lng, lat,
+   flag)`, extended to take an initial flag; default `pick` keeps the tray
+   drag-drop path unchanged). Closing the popup cancels with no change. One
+   provisional placement at a time.
+
+2. **Drag-to-recategorize drops onto a group section.** GPS rows are
+   HTML5-draggable; each group section (Vybrané/Neutrální/Odmítnuté) is a drop
+   target that sets the dropped photo's flag via `flagForGroup`. Validity is
+   `canRecategorize` (same-group and any no-GPS source/target are no-ops). The
+   no-GPS group is not a recategorize target — no-GPS photos use placement (1).
+   Dragging recategorizes only the dragged row, even within a variant
+   multi-selection. Plain click (fly) and Ctrl/Shift (variant select) are
+   unaffected — HTML5 drag fires only on real motion.
+
+**Why provisional (not place-immediately).** Honors "keep in no-GPS until the
+user explicitly chooses a category" — the placement is a preview the user can
+drag and cancel before committing.
+
+**Files implementing this ADR.** See Phase 14 in `implementation-plan.md`.
+
+---
+
 ## Decisions explicitly deferred to v2
 
 These are recorded so they're not re-debated during v1 review.

--- a/docs/photo-map-culling/implementation-plan.md
+++ b/docs/photo-map-culling/implementation-plan.md
@@ -916,15 +916,16 @@ untouched and stays visually distinct (left border vs. fill).
   callback, so list clicks update the highlight for free.
 - `frontend/map-corridors/src/map/MapProviderView.tsx` — now controlled (reads
   `props.activePhotoMarkerId`, requests via `onActivePhotoMarkerChange`); marker
-  glow + `scale(1.3)` + `zIndex` when active; prune effect extended to clear on
-  `flag === 'reject'` as well as deletion.
+  glow + `scale(1.3)` + `zIndex` when active; prune effect clears the active
+  photo only on deletion (a follow-up fix removed reject-clearing — see Phase 14
+  note — so a rejected photo can be re-opened from the list to un-reject it).
 - `frontend/map-corridors/src/components/PhotoListPanel.tsx` — `activePhotoId`
   prop; row tint (`alpha(primary, 0.14)`); `scrollIntoView` on the active row;
   group auto-expand effect; new exported pure helper `groupKeyForPhotoId`.
 - `frontend/map-corridors/src/activePhoto/activePhoto.ts` — pure helpers
-  `shouldClearActivePhoto` (drives the prune-on-delete/reject effect) and
-  `resolveActivePhotoId` (the list highlight's photoId; null for a gone/rejected
-  marker so no one-render tint flash on a reject row).
+  `shouldClearActivePhoto` (clears only on deletion — see Phase 14 note) and
+  `resolveActivePhotoId` (the list highlight's photoId; resolves rejected
+  markers too so the row highlights while its popup is open during un-reject).
 
 **Tests.**
 - `__tests__/groupKeyForPhotoId.test.ts` — picks/neutral/rejects mapping,
@@ -945,3 +946,55 @@ e. Reject the active photo (popup or variant compare) → marker vanishes and th
    highlight clears (no orphan tint).
 f. Ctrl-click rows for variant compare → left-border accent still reads
    distinctly from the active fill (a row can show both).
+
+---
+
+## Phase 14 — Panel interactions (no-GPS placement + drag-to-recategorize)
+
+**Why now.** Field feedback: no-GPS photos looked inert (greyed) and the only
+placement path (drag from tray) was unobvious; and recategorizing required the
+map popup. See [ADR-024](decisions.md#adr-024--panel-interactions-no-gps-provisional-placement--drag-to-recategorize).
+
+**Reject-reopen fix (prerequisite, shipped separately as `desktop-v2.17.2`).**
+Phase 13's prune effect cleared the active photo on `flag === 'reject'`, which
+closed the popup the instant a rejected row was clicked — making un-reject
+impossible. `shouldClearActivePhoto` now clears ONLY on deletion;
+`resolveActivePhotoId` resolves rejected markers so the un-reject row
+highlights. Rejecting *via the popup* is still closed by the explicit onReject
+handler.
+
+**Feature A — no-GPS provisional placement.**
+- Click a no-GPS list row → drop a draggable provisional pin at the map center
+  (`MapProviderViewHandle.getCenter`) + open a popup; photo stays in "Bez GPS".
+- Drag the pin to the right spot; pick a category in the popup → commit via
+  `placeNoGpsPhoto(photoId, lng, lat, flag)` (extended to take an initial flag,
+  default `pick` for the tray path). Close/Esc → cancel, no change.
+- Files: `App.tsx` (`provisionalPlacement` state + commit/cancel/drag handlers,
+  `onNoGpsPhotoClick`), `MapProviderView.tsx` (`getCenter`, provisional
+  `<Marker>` + commit popup), `PhotoListPanel.tsx` (no-GPS rows clickable →
+  un-greyed), `useCorridorSessionOPFS.ts` (`placeNoGpsPhoto` flag param),
+  `locales/{cs,en}.json` (`photo.tray.placeFailed`).
+
+**Feature B — drag-to-recategorize.**
+- GPS rows HTML5-draggable; group sections are drop targets that set the flag
+  via `flagForGroup`; `canRecategorize` rejects same-group / no-GPS drops.
+- Files: `PhotoListPanel.tsx` (`GroupSection` drop target + highlight, draggable
+  `PhotoListItem`, `onPhotoSetFlag`/`onNoGpsPhotoClick` props), `App.tsx`
+  (`handlePhotoSetFlag` → `setPhotoFlag`), new
+  `recategorize/recategorize.ts` (`flagForGroup` / `canRecategorize`).
+
+**Tests.**
+- `__tests__/recategorize.test.ts` — `flagForGroup` (pick/neutral=null/reject/
+  noGps=undefined) and `canRecategorize` (same-group, no-GPS source/target).
+- `__tests__/activePhoto.test.ts` updated: reject no longer clears / now resolves.
+
+**Smoke addendum.**
+
+a. No-GPS row is no longer greyed → click it → provisional dashed pin appears at
+   map center + popup; the photo is still listed under "Bez GPS".
+b. Drag the pin to a location → press Vybrané → photo commits to Vybrané at the
+   dragged spot and leaves "Bez GPS". Close without choosing → stays in Bez GPS.
+c. Drag a Vybrané row onto the Odmítnuté section → it recategorizes (leaves the
+   map). Dropping onto its own group or onto "Bez GPS" does nothing.
+d. Reject a photo via popup → re-open it from the Odmítnuté list → Vybrané/
+   Neutrální restores it (reject-reopen fix).

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -42,6 +42,7 @@ import { PhotoListPanel } from './components/PhotoListPanel'
 import { PhotoCompareModal } from './components/PhotoCompareModal'
 import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
 import { resolveActivePhotoId } from './activePhoto/activePhoto'
+import { isProvisionalValid, type ProvisionalPlacement } from './provisionalPlacement/provisionalPlacement'
 import type { PhotoMarker } from './types/markers'
 import {
   buildMapPicks,
@@ -243,7 +244,7 @@ function App() {
   // drops a draggable pin at the map center; the photo stays in "Bez GPS"
   // until the user commits a category in the popup. `null` = no placement in
   // progress.
-  const [provisionalPlacement, setProvisionalPlacement] = useState<{ photoId: string; filename: string; lng: number; lat: number } | null>(null)
+  const [provisionalPlacement, setProvisionalPlacement] = useState<ProvisionalPlacement | null>(null)
   const [isAnswerSheetOpen, setAnswerSheetOpen] = useState(false)
   // User feedback 2026-05-17: the X badge on every photo row deletes
   // without confirmation. The new rename pencil sits adjacent and a
@@ -762,12 +763,22 @@ function App() {
     if (!center) return
     const photo = (session?.noGpsPhotos ?? []).find(p => p.photoId === photoId)
     if (!photo) return
-    setProvisionalPlacement({
-      photoId,
-      filename: photo.displayName ?? photo.filename,
-      lng: center.lng,
-      lat: center.lat,
-    })
+    // Re-clicking the row of an already-provisional photo must NOT reset the
+    // pin — that would silently discard the location the user already dragged
+    // it to. Keep the existing placement; only a different photo starts fresh.
+    setProvisionalPlacement(prev => (
+      prev?.photoId === photoId
+        ? prev
+        : { photoId, filename: photo.displayName ?? photo.filename, lng: center.lng, lat: center.lat }
+    ))
+  }, [session?.noGpsPhotos])
+
+  // Cancel a provisional placement if its photo leaves "Bez GPS" by another
+  // path while the pin is still up (placed via the tray, or deleted) — without
+  // this the orphan pin commits against a missing entry and shows a false
+  // "placement failed" error.
+  useEffect(() => {
+    setProvisionalPlacement(prev => (isProvisionalValid(prev, session?.noGpsPhotos ?? []) ? prev : null))
   }, [session?.noGpsPhotos])
 
   const handleProvisionalDrag = useCallback((lng: number, lat: number) => {

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -239,6 +239,11 @@ function App() {
   // from MapProviderView so both the map (marker glow) and the right-side
   // PhotoListPanel (row highlight) read one source of truth. `null` = none.
   const [activePhotoMarkerId, setActivePhotoMarkerId] = useState<string | null>(null)
+  // Phase 14 — provisional placement of a no-GPS photo. Clicking a no-GPS row
+  // drops a draggable pin at the map center; the photo stays in "Bez GPS"
+  // until the user commits a category in the popup. `null` = no placement in
+  // progress.
+  const [provisionalPlacement, setProvisionalPlacement] = useState<{ photoId: string; filename: string; lng: number; lat: number } | null>(null)
   const [isAnswerSheetOpen, setAnswerSheetOpen] = useState(false)
   // User feedback 2026-05-17: the X badge on every photo row deletes
   // without confirmation. The new rename pencil sits adjacent and a
@@ -743,6 +748,50 @@ function App() {
     }
   }, [placeNoGpsPhoto])
 
+  // Phase 14 — drag-to-recategorize: a row dropped on another group sets its
+  // flag. Reuses the same setter the popup buttons use.
+  const handlePhotoSetFlag = useCallback((markerId: string, flag: 'pick' | 'reject' | null) => {
+    void setPhotoFlag(markerId, flag)
+  }, [setPhotoFlag])
+
+  // Phase 14 — start placing a no-GPS photo: drop a provisional pin at the
+  // current map center. Nothing is committed; the photo stays in the tray /
+  // "Bez GPS" group until the user picks a category in the provisional popup.
+  const handleNoGpsPhotoClick = useCallback((photoId: string) => {
+    const center = mapRef.current?.getCenter()
+    if (!center) return
+    const photo = (session?.noGpsPhotos ?? []).find(p => p.photoId === photoId)
+    if (!photo) return
+    setProvisionalPlacement({
+      photoId,
+      filename: photo.displayName ?? photo.filename,
+      lng: center.lng,
+      lat: center.lat,
+    })
+  }, [session?.noGpsPhotos])
+
+  const handleProvisionalDrag = useCallback((lng: number, lat: number) => {
+    setProvisionalPlacement(prev => (prev ? { ...prev, lng, lat } : prev))
+  }, [])
+
+  const handleProvisionalCancel = useCallback(() => setProvisionalPlacement(null), [])
+
+  // Commit the provisional placement at the dragged location with the chosen
+  // category. Atomic via placeNoGpsPhoto (single persist write); on success the
+  // photo leaves "Bez GPS" and becomes a marker.
+  const handleProvisionalCommit = useCallback(async (flag: 'pick' | 'reject' | null) => {
+    const p = provisionalPlacement
+    if (!p) return
+    setProvisionalPlacement(null)
+    try {
+      const ok = await placeNoGpsPhoto(p.photoId, p.lng, p.lat, flag)
+      if (!ok) setSnack({ severity: 'error', text: t('photo.tray.placeFailed') })
+    } catch (err) {
+      console.error('provisional placeNoGpsPhoto failed:', err)
+      setSnack({ severity: 'error', text: err instanceof Error ? err.message : String(err) })
+    }
+  }, [provisionalPlacement, placeNoGpsPhoto, t])
+
   const handleDragOver = useCallback((e: React.DragEvent) => {
     const types = e.dataTransfer?.types ? Array.from(e.dataTransfer.types as any) : []
     const isMarkerDrag = types.includes('application/x-photo-marker') || types.includes('application/x-ground-marker')
@@ -1243,6 +1292,10 @@ function App() {
             onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}
             activePhotoMarkerId={activePhotoMarkerId}
             onActivePhotoMarkerChange={setActivePhotoMarkerId}
+            provisionalPlacement={provisionalPlacement}
+            onProvisionalDrag={handleProvisionalDrag}
+            onProvisionalCommit={handleProvisionalCommit}
+            onProvisionalCancel={handleProvisionalCancel}
           />
           {/* Phase 6 — no-GPS tray, pinned to bottom-left of the map. */}
           <NoGpsTray
@@ -1262,6 +1315,8 @@ function App() {
             photosDir={photosDir}
             onMarkerClick={(markerId) => mapRef.current?.flyToPhotoMarker(markerId)}
             activePhotoId={resolveActivePhotoId(markers, activePhotoMarkerId)}
+            onPhotoSetFlag={handlePhotoSetFlag}
+            onNoGpsPhotoClick={handleNoGpsPhotoClick}
             onSendToEditor={competitionId ? handleSendToEditor : undefined}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}

--- a/frontend/map-corridors/src/__tests__/provisionalPlacement.test.ts
+++ b/frontend/map-corridors/src/__tests__/provisionalPlacement.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { isProvisionalValid, type ProvisionalPlacement } from '../provisionalPlacement/provisionalPlacement'
+import type { NoGpsPhoto } from '../types/markers'
+
+// Phase 14 — the provisional no-GPS placement must be cancelled when its photo
+// leaves the "Bez GPS" list (placed via the tray, or deleted) while the pin is
+// still up. Otherwise the orphan pin commits against a missing entry and shows
+// a false "placement failed" error.
+
+const prov: ProvisionalPlacement = { photoId: 'p1', filename: 'a.jpg', lng: 14, lat: 50 }
+const noGps = (...ids: string[]): NoGpsPhoto[] => ids.map(id => ({ photoId: id, filename: `${id}.jpg` } as NoGpsPhoto))
+
+describe('isProvisionalValid', () => {
+  it('valid while the photo is still awaiting placement', () => {
+    expect(isProvisionalValid(prov, noGps('p1', 'p2'))).toBe(true)
+  })
+
+  it('invalid once the photo has left noGpsPhotos (placed or deleted)', () => {
+    expect(isProvisionalValid(prov, noGps('p2'))).toBe(false)
+    expect(isProvisionalValid(prov, noGps())).toBe(false)
+  })
+
+  it('null provisional is trivially invalid', () => {
+    expect(isProvisionalValid(null, noGps('p1'))).toBe(false)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/recategorize.test.ts
+++ b/frontend/map-corridors/src/__tests__/recategorize.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { flagForGroup, canRecategorize } from '../recategorize/recategorize'
+
+// Phase 14 (drag-to-recategorize). Dropping a row onto a group must map to the
+// right flag, and invalid drops (same group, or the no-GPS tray) must be
+// rejected so the drop handler can no-op cleanly.
+
+describe('flagForGroup', () => {
+  it('picks → pick', () => expect(flagForGroup('picks')).toBe('pick'))
+  it('rejects → reject', () => expect(flagForGroup('rejects')).toBe('reject'))
+  it('neutral → null (flag cleared)', () => expect(flagForGroup('neutral')).toBeNull())
+  it('noGps → undefined (not a recategorize target)', () => expect(flagForGroup('noGps')).toBeUndefined())
+})
+
+describe('canRecategorize', () => {
+  it('allows pick → reject', () => expect(canRecategorize('picks', 'rejects')).toBe(true))
+  it('allows neutral → picks', () => expect(canRecategorize('neutral', 'picks')).toBe(true))
+  it('rejects same-group drop (no-op)', () => expect(canRecategorize('picks', 'picks')).toBe(false))
+  it('rejects dropping onto the no-GPS tray', () => expect(canRecategorize('picks', 'noGps')).toBe(false))
+  it('rejects dragging a no-GPS photo (no flag to change)', () => expect(canRecategorize('noGps', 'picks')).toBe(false))
+})

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -26,6 +26,11 @@ import { noGpsPhotoDisplayName, photoMarkerDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
 import { groupPhotosByFlag } from './groupPhotosByFlag'
+import { flagForGroup, canRecategorize } from '../recategorize/recategorize'
+import type { PhotoFlag } from '../types/markers'
+
+/** Drag MIME for recategorizing a photo row by dropping it on another group. */
+const RECAT_MIME = 'application/x-airq-photo-recat'
 
 const THUMB_W_PX = 40
 const THUMB_H_PX = 30
@@ -79,6 +84,17 @@ export interface PhotoListPanelProps {
    * border) — a row can be both. `null`/undefined = nothing active.
    */
   activePhotoId?: string | null
+  /**
+   * Phase 14 — drag-to-recategorize. Set a GPS photo's flag when its row is
+   * dropped onto another group section. `null` = neutral (flag cleared).
+   */
+  onPhotoSetFlag?: (markerId: string, flag: PhotoFlag | null) => void
+  /**
+   * Phase 14 — click a no-GPS row to start placing it on the map (provisional
+   * pin at map center; the photo stays in "Bez GPS" until the user commits a
+   * category in the popup). Undefined leaves no-GPS rows non-interactive.
+   */
+  onNoGpsPhotoClick?: (photoId: string) => void
 }
 
 /**
@@ -96,7 +112,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -111,6 +127,9 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
   // an array (not a Set) so iteration is stable and order survives toggle.
   const [selectedIds, setSelectedIds] = useState<readonly string[]>([])
   const lastAnchorRef = useRef<string | null>(null)
+  // Phase 14 — which group the row currently being dragged belongs to. Drives
+  // both drop validation (canRecategorize) and the drop-target highlight.
+  const [dragSourceGroup, setDragSourceGroup] = useState<GroupKey | null>(null)
 
   const groups = useMemo(() => groupPhotosByFlag(markers, noGpsPhotos), [markers, noGpsPhotos])
 
@@ -250,6 +269,14 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
               count={groupCount(groups, key)}
               collapsed={collapsedGroups[key]}
               onToggle={() => toggleGroup(key)}
+              // Phase 14 — drop target for drag-to-recategorize. Highlight only
+              // when a drag is in progress from a different, valid group.
+              isDropTarget={!!onPhotoSetFlag && dragSourceGroup !== null && canRecategorize(dragSourceGroup, key)}
+              onDropPhoto={(markerId) => {
+                const flag = flagForGroup(key)
+                if (flag !== undefined) onPhotoSetFlag?.(markerId, flag)
+              }}
+              recatMime={RECAT_MIME}
               items={renderGroupItems(groups, key, {
                 storage,
                 photosDir,
@@ -262,6 +289,12 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
                 renameTooltip: t('photo.renameTooltip'),
                 renamePlaceholder: t('photo.renamePlaceholder'),
                 renameSaveAria: t('photo.renameSaveAria'),
+                // Phase 14 — recat drag (GPS rows) + no-GPS click-to-place.
+                recatMime: RECAT_MIME,
+                recatEnabled: !!onPhotoSetFlag,
+                onRowDragStart: (g) => setDragSourceGroup(g),
+                onRowDragEnd: () => setDragSourceGroup(null),
+                onNoGpsPhotoClick,
               })}
             />
           ))}
@@ -384,10 +417,40 @@ function GroupSection(props: {
   collapsed: boolean
   onToggle: () => void
   items: React.ReactNode
+  // Phase 14 — drag-to-recategorize drop target.
+  isDropTarget: boolean
+  onDropPhoto: (markerId: string) => void
+  recatMime: string
 }) {
-  const { title, count, collapsed, onToggle, items } = props
+  const { title, count, collapsed, onToggle, items, isDropTarget, onDropPhoto, recatMime } = props
+  const [dragOver, setDragOver] = useState(false)
+
+  // Drop handlers live on the whole section (header + body) so an empty or
+  // collapsed group still accepts a dropped row. preventDefault on dragOver is
+  // what makes the element a valid drop target.
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!isDropTarget) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    if (!dragOver) setDragOver(true)
+  }
+  const handleDrop = (e: React.DragEvent) => {
+    setDragOver(false)
+    if (!isDropTarget) return
+    const markerId = e.dataTransfer.getData(recatMime)
+    if (markerId) {
+      e.preventDefault()
+      onDropPhoto(markerId)
+    }
+  }
+
   return (
-    <Box>
+    <Box
+      onDragOver={handleDragOver}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={handleDrop}
+      sx={dragOver ? { outline: '2px dashed', outlineColor: 'primary.main', outlineOffset: '-2px', bgcolor: 'action.hover' } : undefined}
+    >
       <ListItemButton
         onClick={onToggle}
         sx={{ py: 0.5, bgcolor: 'grey.50' }}
@@ -421,6 +484,11 @@ function renderGroupItems(
     renameTooltip: string
     renamePlaceholder: string
     renameSaveAria: string
+    recatMime: string
+    recatEnabled: boolean
+    onRowDragStart: (group: GroupKey) => void
+    onRowDragEnd: () => void
+    onNoGpsPhotoClick?: (photoId: string) => void
   },
 ): React.ReactNode {
   const commonRenameCtx = {
@@ -439,12 +507,12 @@ function renderGroupItems(
         originalFilename={p.filename}
         storage={ctx.storage}
         photosDir={ctx.photosDir}
-        // No marker yet — clicking is a no-op for v1. User drags from tray.
-        // Also intentionally not selectable for variant-compare: variants
-        // need GPS markers to associate the loser's hidden position with.
-        onClick={undefined}
+        // Phase 14 — clicking a no-GPS row starts placing it on the map
+        // (provisional pin at map center). Not draggable-for-recat (no flag).
+        onClick={ctx.onNoGpsPhotoClick ? () => ctx.onNoGpsPhotoClick!(p.photoId) : undefined}
         selected={false}
         active={false}
+        recatDraggable={false}
         onDelete={ctx.onPhotoDelete}
         deleteTooltip={ctx.deleteTooltip}
         {...commonRenameCtx}
@@ -463,6 +531,13 @@ function renderGroupItems(
       onClick={(e) => ctx.onRowClick(m.photoId!, m.id, e)}
       selected={selectedSet.has(m.photoId!)}
       active={m.photoId === ctx.activePhotoId}
+      recatDraggable={ctx.recatEnabled}
+      onRecatDragStart={(e) => {
+        e.dataTransfer.setData(ctx.recatMime, m.id)
+        e.dataTransfer.effectAllowed = 'move'
+        ctx.onRowDragStart(key)
+      }}
+      onRecatDragEnd={ctx.onRowDragEnd}
       onDelete={ctx.onPhotoDelete}
       deleteTooltip={ctx.deleteTooltip}
       {...commonRenameCtx}
@@ -514,6 +589,14 @@ function PhotoListItem(props: {
    * filled tint and scrolls the row into view. Independent of `selected`.
    */
   active: boolean
+  /**
+   * Phase 14 — whether this row can be dragged onto another group to
+   * recategorize it (GPS rows only; no-GPS rows have no flag). When true and
+   * not editing, the row root is HTML5-draggable.
+   */
+  recatDraggable?: boolean
+  onRecatDragStart?: (e: React.DragEvent) => void
+  onRecatDragEnd?: () => void
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
   onRename: (photoId: string, newName: string) => void | Promise<void>
@@ -524,6 +607,7 @@ function PhotoListItem(props: {
   const {
     photoId, displayName, originalFilename, storage, photosDir, onClick, selected, active, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
+    recatDraggable, onRecatDragStart, onRecatDragEnd,
   } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photoId)
   const rowRef = useRef<HTMLDivElement | null>(null)
@@ -558,6 +642,13 @@ function PhotoListItem(props: {
   return (
     <Box
       ref={rowRef}
+      // Phase 14 — recat drag. Disabled while editing so the rename field
+      // stays text-selectable. Click/selection still work (drag only fires on
+      // real motion). The thumbnail <img> sets draggable={false} so the photo
+      // itself isn't what gets dragged.
+      draggable={!!recatDraggable && !editing}
+      onDragStart={recatDraggable && !editing ? onRecatDragStart : undefined}
+      onDragEnd={recatDraggable && !editing ? onRecatDragEnd : undefined}
       sx={{
         position: 'relative',
         // Reveal full delete-button opacity on hover anywhere on the row,

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { GeoJSON } from 'geojson'
 import type { Discipline } from '../corridors/preciseCorridor'
-import type { NoGpsPhoto, PhotoMarker, GroundMarker } from '../types/markers'
+import type { NoGpsPhoto, PhotoMarker, GroundMarker, PhotoFlag } from '../types/markers'
 import { sanitizeGroundMarkers, sanitizeNoGpsPhotos, sanitizePhotoMarkers } from '../types/markers'
 import {
   deletePhotoThumb,
@@ -391,7 +391,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   // Replaces the previous two-await sequence which could leave the photo
   // duplicated in both lists if the second write failed (quota, transient
   // I/O). Returns true on success, false when the entry isn't found.
-  const placeNoGpsPhoto = useCallback(async (photoId: string, lng: number, lat: number): Promise<boolean> => {
+  const placeNoGpsPhoto = useCallback(async (photoId: string, lng: number, lat: number, flag: PhotoFlag | null = 'pick'): Promise<boolean> => {
     const current = sessionRef.current
     if (!current) return false
     const entry = (current.noGpsPhotos || []).find(p => p.photoId === photoId)
@@ -405,7 +405,10 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
       // Carry the custom name across so dragging a renamed tray photo onto
       // the map keeps its label (and still preserves the original filename).
       ...(entry.displayName ? { displayName: entry.displayName } : {}),
-      flag: 'pick',
+      // Phase 14 — caller may commit straight to a chosen category (provisional
+      // placement). `null` = neutral, so omit the flag field. Tray drag-drop
+      // keeps the historical default of 'pick'.
+      ...(flag ? { flag } : {}),
     }
     await persistSession({
       ...current,

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -48,7 +48,8 @@
       "title": "Bez GPS ({{count}})",
       "dragHint": "Přetáhni na mapu pro umístění",
       "expand": "Zobrazit fotky bez GPS",
-      "collapse": "Skrýt fotky bez GPS"
+      "collapse": "Skrýt fotky bez GPS",
+      "placeFailed": "Umístění fotky se nezdařilo"
     },
     "list": {
       "title": "Fotky",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -48,7 +48,8 @@
       "title": "No GPS ({{count}})",
       "dragHint": "Drag onto the map to place",
       "expand": "Show no-GPS photos",
-      "collapse": "Hide no-GPS photos"
+      "collapse": "Hide no-GPS photos",
+      "placeFailed": "Failed to place photo"
     },
     "list": {
       "title": "Photos",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -42,6 +42,11 @@ export type MapProviderViewHandle = {
    * markers without coordinates we can land on.
    */
   flyToPhotoMarker: (markerId: string) => void
+  /**
+   * Phase 14 — current map center in lng/lat, or null if the map isn't ready.
+   * Used to drop a provisional no-GPS placement pin at the view center.
+   */
+  getCenter: () => { lng: number; lat: number } | null
 }
 
 export const MapProviderView = forwardRef<MapProviderViewHandle, {
@@ -99,6 +104,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // `onActivePhotoMarkerChange`. `null` = no photo popup / nothing active.
   activePhotoMarkerId?: string | null
   onActivePhotoMarkerChange?: (id: string | null) => void
+  // Phase 14 — provisional placement of a no-GPS photo: a draggable pin at the
+  // map center whose popup commits the photo to a chosen category. `null` =
+  // no placement in progress.
+  provisionalPlacement?: { photoId: string; filename: string; lng: number; lat: number } | null
+  onProvisionalDrag?: (lng: number, lat: number) => void
+  onProvisionalCommit?: (flag: 'pick' | 'reject' | null) => void
+  onProvisionalCancel?: () => void
 }>(function MapProviderView(props, ref) {
   const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
 
@@ -323,6 +335,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       if (marker.photoId && marker.capturedAt) {
         setActivePhotoMarkerId(markerId)
       }
+    },
+    getCenter() {
+      const map = mapRef.current?.getMap()
+      if (!map) return null
+      const c = map.getCenter()
+      return { lng: c.lng, lat: c.lat }
     },
   }), [geojsonOverlays, props.markers, props.groundMarkerProps?.groundMarkers, mapStyle, mapboxAccessToken, setActivePhotoMarkerId])
 
@@ -923,6 +941,57 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               }}
             />
           </Popup>
+        )
+      })()}
+      {/* Phase 14 — provisional no-GPS placement: a draggable pin at the map
+          center whose popup commits the photo to a chosen category. The photo
+          stays in "Bez GPS" until a category button is pressed; closing the
+          popup cancels. Distinct dashed ring marks it as not-yet-placed. */}
+      {(() => {
+        const prov = props.provisionalPlacement
+        if (!prov) return null
+        if (!props.photoStorage || !props.photoDir) return null
+        return (
+          <React.Fragment key="provisional-placement">
+            <Marker
+              longitude={prov.lng}
+              latitude={prov.lat}
+              draggable
+              onDragEnd={(ev: MarkerDragEvent) => {
+                props.onProvisionalDrag?.(ev.lngLat.lng, ev.lngLat.lat)
+              }}
+            >
+              <div style={{
+                width: 16,
+                height: 16,
+                borderRadius: '50%',
+                background: 'rgba(25,118,210,0.25)',
+                border: '2px dashed #1976d2',
+                boxShadow: '0 0 0 3px rgba(255,255,255,0.9)',
+                cursor: 'grab',
+              }} />
+            </Marker>
+            <Popup
+              longitude={prov.lng}
+              latitude={prov.lat}
+              anchor="top"
+              closeButton
+              closeOnMove={false}
+              closeOnClick={false}
+              onClose={() => props.onProvisionalCancel?.()}
+              maxWidth="240px"
+            >
+              <PhotoMarkerPopup
+                photoId={prov.photoId}
+                filename={prov.filename}
+                storage={props.photoStorage}
+                photosDir={props.photoDir}
+                onInclude={() => props.onProvisionalCommit?.('pick')}
+                onSkip={() => props.onProvisionalCommit?.(null)}
+                onReject={() => props.onProvisionalCommit?.('reject')}
+              />
+            </Popup>
+          </React.Fragment>
         )
       })()}
     </MapGL>

--- a/frontend/map-corridors/src/provisionalPlacement/provisionalPlacement.ts
+++ b/frontend/map-corridors/src/provisionalPlacement/provisionalPlacement.ts
@@ -1,0 +1,28 @@
+// Phase 14 — provisional placement of a no-GPS photo (a draggable pin at the
+// map center, committed to a category via its popup). The photo stays in
+// `noGpsPhotos` until commit, so the provisional state can be invalidated out
+// from under us if that photo leaves the list by another path (placed via the
+// tray, or deleted). This pure predicate drives the reconcile effect that
+// cancels a now-stale provisional, preventing an orphan pin + a misleading
+// "placement failed" snack on a photo that was actually placed/removed.
+
+import type { NoGpsPhoto } from '../types/markers'
+
+export interface ProvisionalPlacement {
+  photoId: string
+  filename: string
+  lng: number
+  lat: number
+}
+
+/**
+ * A provisional placement is still valid only while its photo is still
+ * awaiting placement (present in `noGpsPhotos`). Null is trivially invalid.
+ */
+export function isProvisionalValid(
+  provisional: ProvisionalPlacement | null,
+  noGpsPhotos: readonly NoGpsPhoto[],
+): boolean {
+  if (!provisional) return false
+  return noGpsPhotos.some(p => p.photoId === provisional.photoId)
+}

--- a/frontend/map-corridors/src/recategorize/recategorize.ts
+++ b/frontend/map-corridors/src/recategorize/recategorize.ts
@@ -1,0 +1,33 @@
+// Phase 14 — drag-to-recategorize helpers. Dropping a photo row onto a group
+// section changes the photo's flag to that group's flag. Pure + unit-tested so
+// the rules (which group maps to which flag, and which drops are valid) can't
+// drift from the drop handler.
+
+import type { PhotoFlag } from '../types/markers'
+
+export type PanelGroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
+
+/**
+ * The flag a photo takes when dropped into a group. `null` = neutral (flag
+ * cleared). `undefined` = not a valid recategorize target (the no-GPS tray —
+ * you can't strip a photo's GPS by dropping it there).
+ */
+export function flagForGroup(key: PanelGroupKey): PhotoFlag | null | undefined {
+  switch (key) {
+    case 'picks': return 'pick'
+    case 'neutral': return null
+    case 'rejects': return 'reject'
+    default: return undefined // noGps — not a recategorize target
+  }
+}
+
+/**
+ * Whether a drag from `fromKey` onto `toKey` is a meaningful recategorize:
+ * same group is a no-op, and no-GPS is never a valid source or target (no-GPS
+ * photos have no marker/flag — they are placed via Feature A instead).
+ */
+export function canRecategorize(fromKey: PanelGroupKey, toKey: PanelGroupKey): boolean {
+  if (fromKey === toKey) return false
+  if (fromKey === 'noGps' || toKey === 'noGps') return false
+  return true
+}


### PR DESCRIPTION
## Summary

Phase 14 — two photo-panel interactions ([ADR-024](../blob/main/docs/photo-map-culling/decisions.md)).

**A — No-GPS provisional placement.** No-GPS rows are no longer greyed. Clicking one drops a draggable provisional pin at the **current map center** and opens a popup; the photo **stays in "Bez GPS"** until the user picks a category (Vybrané/Neutrální/Odmítnuté), which commits it at the dragged location. Close/Esc cancels. New `MapProviderViewHandle.getCenter`; `placeNoGpsPhoto` extended with an initial-flag param (tray drag-drop still defaults to `pick`).

**B — Drag-to-recategorize.** GPS rows are HTML5-draggable; each group section is a drop target that sets the dropped photo's flag. Pure helpers `flagForGroup` / `canRecategorize` (same-group and no-GPS drops are no-ops). Plain click (fly) and Ctrl/Shift (variant select) unaffected.

Builds on the reject-reopen fix already shipped in `desktop-v2.17.2`.

## Files
- `App.tsx`, `map/MapProviderView.tsx`, `components/PhotoListPanel.tsx`, `hooks/useCorridorSessionOPFS.ts`, `locales/{cs,en}.json`
- New: `recategorize/recategorize.ts` + test
- Docs: ADR-024, Phase 14

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 604 passed / 2 todo (new `recategorize` cases)
- [ ] Smoke (Phase 14 addendum): no-GPS row un-greyed → click → provisional pin + popup, still under Bez GPS → drag pin → Vybrané commits at the spot; close → stays. Drag a Vybrané row onto Odmítnuté → recategorizes; same-group/Bez-GPS drops do nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)