### PR TITLE
feat(map-corridors): big photo preview + auto-fan overlapping dots; maximize window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.19.0] - 2026-05-30
+
+### Added
+- **Map Corridors:** double-click a photo to open a full-resolution preview
+  (single-photo lightbox). Works on the thumbnail inside a map dot's popup and
+  on a photo row in the right-side panel — press Esc or click outside to close.
+- **Map Corridors:** photos taken at the same or a nearby point no longer stack
+  into one unclickable blob. Overlapping dots now automatically fan out into a
+  small circle around their shared location, with thin leader lines tying each
+  one back to the spot, so every photo stays individually clickable. The fan
+  recomputes as you zoom and pan, and collapses once the dots are far enough
+  apart on their own.
+
+### Changed
+- **Desktop launcher:** the app now opens maximised (filling the screen) on
+  every launch instead of a fixed-size window.
+
 ## [2.18.0] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ new desktop release.
   one back to the spot, so every photo stays individually clickable. The fan
   recomputes as you zoom and pan, and collapses once the dots are far enough
   apart on their own.
+- **Map Corridors:** compare co-located photos straight from the map. Each
+  fanned cluster shows a small **⇄ N** pill at its centre — click it to open the
+  photos side-by-side and pick the best one (2–3 open immediately; larger groups
+  drop into a selection to trim down). You can also **Ctrl/Cmd/Shift-click** any
+  dots to multi-select them (highlighted with a ring); a floating **Compare**
+  bar then opens the side-by-side view. Both routes feed the existing compare
+  modal (winner stays, the rest move to Odmítnuté).
 
 ### Changed
 - **Desktop launcher:** the app now opens maximised (filling the screen) on

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -197,7 +197,19 @@ function createWindow() {
     },
     icon: path.join(__dirname, 'icons', 'icon.png'),
     title: 'AirQ Competition Helpers',
-    autoHideMenuBar: false
+    autoHideMenuBar: false,
+    // Start hidden so we can maximize before first paint — avoids the brief
+    // 1400x900 flash before the window snaps to full screen. The width/height
+    // above remain the restore size when the user un-maximizes.
+    show: false
+  });
+
+  // Maximize on first show (flash-free pattern). `ready-to-show` fires once the
+  // renderer has painted, so the window appears already maximized rather than
+  // resizing visibly after load.
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.maximize();
+    mainWindow.show();
   });
 
   // Load the landing page

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -1343,6 +1343,7 @@ function App() {
             activePhotoMarkerId={activePhotoMarkerId}
             onActivePhotoMarkerChange={setActivePhotoMarkerId}
             onPhotoPreview={handleOpenPhotoPreview}
+            onCompareVariants={handleCompareVariants}
             provisionalPlacement={provisionalPlacement}
             onProvisionalDrag={handleProvisionalDrag}
             onProvisionalCommit={handleProvisionalCommit}

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -40,6 +40,7 @@ import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
 import { PhotoCompareModal } from './components/PhotoCompareModal'
+import { PhotoPreviewModal } from './components/PhotoPreviewModal'
 import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
 import { resolveActivePhotoId } from './activePhoto/activePhoto'
 import { isProvisionalValid, type ProvisionalPlacement } from './provisionalPlacement/provisionalPlacement'
@@ -258,6 +259,12 @@ function App() {
   // closed. Owned at App level so the resolve handler can hit the same
   // `persistMarkers` setter used by every other flag mutation.
   const [compareVariants, setCompareVariants] = useState<readonly PhotoMarker[] | null>(null)
+  // Single-photo full-res preview (lightbox). Holds the photoId being viewed
+  // large; `null` = closed. Opened by double-clicking the map popup thumbnail
+  // or a photo-panel row. Keyed on photoId (not markerId) so it works for
+  // no-GPS photos too — those have no marker and aren't in `markers`. View-
+  // only — no marker mutation.
+  const [previewPhotoId, setPreviewPhotoId] = useState<string | null>(null)
   const answerSheetRef = useRef<HTMLDivElement | null>(null)
   const usedLabels = useMemo(() => {
     const set = new Set<PhotoLabel>()
@@ -736,6 +743,38 @@ function App() {
     if (selected.length < 2) return
     setCompareVariants(selected)
   }, [])
+
+  // Open the single-photo preview for a given photoId. The map popup, GPS
+  // panel rows and no-GPS panel rows all pass a photoId; the metadata is
+  // derived from the live `markers` / `noGpsPhotos` lists so a rename
+  // reflects without re-opening.
+  const handleOpenPhotoPreview = useCallback((photoId: string) => {
+    setPreviewPhotoId(photoId)
+  }, [])
+  // Resolve preview metadata from either a GPS marker or a no-GPS photo.
+  // `null` = nothing to preview (closed, or the photo vanished).
+  const previewPhoto = useMemo(() => {
+    if (!previewPhotoId) return null
+    const m = markers.find(mm => mm.photoId === previewPhotoId)
+    if (m) {
+      return {
+        photoId: previewPhotoId,
+        filename: photoMarkerDisplayName(m),
+        originalFilename: m.name,
+        timestamp: m.capturedAt?.timestamp,
+      }
+    }
+    const ng = (session?.noGpsPhotos ?? []).find(p => p.photoId === previewPhotoId)
+    if (ng) {
+      return {
+        photoId: previewPhotoId,
+        filename: noGpsPhotoDisplayName(ng),
+        originalFilename: ng.filename,
+        timestamp: undefined,
+      }
+    }
+    return null
+  }, [previewPhotoId, markers, session?.noGpsPhotos])
 
   // Phase 6 — drop-from-tray handler. Atomic: a single persistSession
   // mutates BOTH markers and noGpsPhotos in one write, so a partial
@@ -1303,6 +1342,7 @@ function App() {
             onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}
             activePhotoMarkerId={activePhotoMarkerId}
             onActivePhotoMarkerChange={setActivePhotoMarkerId}
+            onPhotoPreview={handleOpenPhotoPreview}
             provisionalPlacement={provisionalPlacement}
             onProvisionalDrag={handleProvisionalDrag}
             onProvisionalCommit={handleProvisionalCommit}
@@ -1316,6 +1356,7 @@ function App() {
             storage={storage}
             photosDir={photosDir}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
+            onPreview={handleOpenPhotoPreview}
           />
           {/* Phase 7 — right-side photo list panel. Auto-hides when there
               are no imported photos (KML-only sessions look unchanged). */}
@@ -1332,6 +1373,7 @@ function App() {
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}
             onCompareVariants={handleCompareVariants}
+            onPreviewPhoto={handleOpenPhotoPreview}
           />
         </Box>
       </Container>
@@ -1343,6 +1385,16 @@ function App() {
       photosDir={photosDir}
       onClose={() => setCompareVariants(null)}
       onResolve={handleCompareResolve}
+    />
+    <PhotoPreviewModal
+      open={previewPhoto !== null}
+      photoId={previewPhoto?.photoId ?? null}
+      filename={previewPhoto?.filename}
+      originalFilename={previewPhoto?.originalFilename}
+      timestamp={previewPhoto?.timestamp}
+      storage={storage}
+      photosDir={photosDir}
+      onClose={() => setPreviewPhotoId(null)}
     />
     <Dialog open={isAnswerSheetOpen} onClose={() => setAnswerSheetOpen(false)} maxWidth="sm" fullWidth>
       <DialogContent dividers sx={{ p: 1 }}>

--- a/frontend/map-corridors/src/__tests__/markerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerFan.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { clusterByProximity, computeMarkerFan, type ScreenPoint } from '../map/photoLayers/markerFan'
+
+// Pure screen-space maths behind the auto-fan of overlapping photo markers.
+// No map needed — points are already projected to pixels.
+
+const sp = (id: string, x: number, y: number): ScreenPoint => ({ id, x, y })
+
+describe('clusterByProximity', () => {
+  it('keeps far-apart points in singleton groups', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 100, 100)], 20)
+    expect(groups.map(g => g.length).sort()).toEqual([1, 1])
+  })
+
+  it('groups two points within the threshold', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 10, 0)], 20)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toHaveLength(2)
+  })
+
+  it('does not group points exactly beyond the threshold', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 21, 0)], 20)
+    expect(groups).toHaveLength(2)
+  })
+
+  it('chains transitively via single-link (a~b, b~c ⇒ one group)', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 15, 0), sp('c', 30, 0)], 20)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toHaveLength(3)
+  })
+})
+
+describe('computeMarkerFan', () => {
+  it('returns no offsets when nothing overlaps', () => {
+    const r = computeMarkerFan([sp('a', 0, 0), sp('b', 200, 0)], { thresholdPx: 20 })
+    expect(r.offsets.size).toBe(0)
+    expect(r.leaders).toHaveLength(0)
+  })
+
+  it('fans an overlapping pair: both get an offset and a leader', () => {
+    const r = computeMarkerFan([sp('a', 100, 100), sp('b', 105, 100)], { thresholdPx: 20 })
+    expect(r.offsets.size).toBe(2)
+    expect(r.offsets.has('a')).toBe(true)
+    expect(r.offsets.has('b')).toBe(true)
+    expect(r.leaders).toHaveLength(2)
+  })
+
+  it('places each fanned dot on a circle of the fan radius around the centroid', () => {
+    // Two coincident points → centroid is the shared point; each dot sits at
+    // exactly `radius` px from it. N=2 → radius = baseRadiusPx (16).
+    const r = computeMarkerFan([sp('a', 100, 100), sp('b', 100, 100)], {
+      thresholdPx: 20,
+      baseRadiusPx: 16,
+    })
+    for (const [, [dx, dy]] of r.offsets) {
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      expect(dist).toBeCloseTo(16, 5)
+    }
+    // Leader endpoints: `from` = centroid (the shared point), `to` = the dot.
+    for (const l of r.leaders) {
+      expect(l.from[0]).toBeCloseTo(100, 5)
+      expect(l.from[1]).toBeCloseTo(100, 5)
+      const r2 = Math.hypot(l.to[0] - 100, l.to[1] - 100)
+      expect(r2).toBeCloseTo(16, 5)
+    }
+  })
+
+  it('assigns a stable slot per id regardless of input order', () => {
+    const a = computeMarkerFan([sp('a', 0, 0), sp('b', 5, 0), sp('c', 0, 5)], { thresholdPx: 20 })
+    const b = computeMarkerFan([sp('c', 0, 5), sp('a', 0, 0), sp('b', 5, 0)], { thresholdPx: 20 })
+    // Offsets are derived from each marker's own point, so for identical inputs
+    // in different order the same id must land at the same target slot.
+    for (const id of ['a', 'b', 'c']) {
+      const oa = a.offsets.get(id)!
+      const ob = b.offsets.get(id)!
+      expect(oa[0]).toBeCloseTo(ob[0], 5)
+      expect(oa[1]).toBeCloseTo(ob[1], 5)
+    }
+  })
+
+  it('grows the fan radius with group size (clamped)', () => {
+    const pts = Array.from({ length: 8 }, (_, i) => sp(`p${i}`, 100, 100))
+    const r = computeMarkerFan(pts, {
+      thresholdPx: 20,
+      baseRadiusPx: 16,
+      radiusStepPx: 2,
+      maxRadiusPx: 40,
+    })
+    // N=8 → 16 + 2*(8-2) = 28 px, under the 40 cap.
+    for (const [, [dx, dy]] of r.offsets) {
+      expect(Math.hypot(dx, dy)).toBeCloseTo(28, 5)
+    }
+  })
+})

--- a/frontend/map-corridors/src/__tests__/markerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerFan.test.ts
@@ -78,6 +78,24 @@ describe('computeMarkerFan', () => {
     }
   })
 
+  it('reports clusters with member ids and centroid for each fanned group', () => {
+    // One overlapping pair + one solitary marker far away.
+    const r = computeMarkerFan(
+      [sp('a', 100, 100), sp('b', 108, 100), sp('solo', 400, 400)],
+      { thresholdPx: 20 },
+    )
+    expect(r.clusters).toHaveLength(1)
+    expect(r.clusters[0].ids.sort()).toEqual(['a', 'b'])
+    // Centroid is the average of the two members' screen points.
+    expect(r.clusters[0].centroid[0]).toBeCloseTo(104, 5)
+    expect(r.clusters[0].centroid[1]).toBeCloseTo(100, 5)
+  })
+
+  it('has no clusters when nothing overlaps', () => {
+    const r = computeMarkerFan([sp('a', 0, 0), sp('b', 300, 0)], { thresholdPx: 20 })
+    expect(r.clusters).toHaveLength(0)
+  })
+
   it('grows the fan radius with group size (clamped)', () => {
     const pts = Array.from({ length: 8 }, (_, i) => sp(`p${i}`, 100, 100))
     const r = computeMarkerFan(pts, {

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -37,11 +37,16 @@ export interface NoGpsTrayProps {
    * X badge on photo-helper grid tiles.
    */
   onPhotoDelete: (photoId: string) => void | Promise<void>
+  /**
+   * Double-clicking a tray thumbnail opens the full-resolution single-photo
+   * preview (lightbox). Undefined leaves the thumbnail drag-only.
+   */
+  onPreview?: (photoId: string) => void
 }
 
 export function NoGpsTray(props: NoGpsTrayProps) {
   const { t } = useI18n()
-  const { photos, open, onToggleOpen, storage, photosDir, onPhotoDelete } = props
+  const { photos, open, onToggleOpen, storage, photosDir, onPhotoDelete, onPreview } = props
 
   const sorted = useMemo(() => [...photos].sort(compareNoGpsPhotos), [photos])
 
@@ -94,6 +99,7 @@ export function NoGpsTray(props: NoGpsTrayProps) {
               dragHint={t('photo.tray.dragHint')}
               onDelete={onPhotoDelete}
               deleteTooltip={t('photo.deleteTooltip')}
+              onPreview={onPreview}
             />
           ))}
         </Box>
@@ -109,8 +115,9 @@ function NoGpsTrayThumb(props: {
   dragHint: string
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
+  onPreview?: (photoId: string) => void
 }) {
-  const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip } = props
+  const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip, onPreview } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photo.photoId)
   // Custom name when set, else the camera filename — shown in the tooltip,
   // a11y labels, and the no-thumb placeholder.
@@ -136,6 +143,7 @@ function NoGpsTrayThumb(props: {
             e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
             e.dataTransfer.effectAllowed = 'move'
           }}
+          onDoubleClick={onPreview ? () => onPreview(photo.photoId) : undefined}
           sx={{
             width: THUMB_WIDTH_PX,
             height: THUMB_HEIGHT_PX,

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -95,6 +95,14 @@ export interface PhotoListPanelProps {
    * category in the popup). Undefined leaves no-GPS rows non-interactive.
    */
   onNoGpsPhotoClick?: (photoId: string) => void
+  /**
+   * Double-clicking a photo row opens the full-resolution single-photo
+   * preview (lightbox). Receives the photoId. Works for both GPS rows and
+   * no-GPS rows. The plain single-clicks that precede the double-click still
+   * fire (GPS: select + fly-to + popup; no-GPS: start place-on-map) — that's
+   * harmless. Undefined disables the preview path.
+   */
+  onPreviewPhoto?: (photoId: string) => void
 }
 
 /**
@@ -112,7 +120,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick, onPreviewPhoto } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -191,6 +199,13 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
     clearSelection()
     onMarkerClick(markerId)
   }, [orderedSelectableIds, clearSelection, onMarkerClick])
+
+  // Double-click a row → open the full-res single-photo preview. Keyed on
+  // photoId so it works for GPS and no-GPS rows alike. The single-clicks that
+  // precede it are harmless.
+  const handleRowDoubleClick = useCallback((photoId: string) => {
+    onPreviewPhoto?.(photoId)
+  }, [onPreviewPhoto])
 
   const selectedMarkers = useMemo(() => {
     const byPhotoId = new Map<string, PhotoMarker>()
@@ -281,6 +296,7 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
                 storage,
                 photosDir,
                 onRowClick: handleRowClick,
+                onRowDoubleClick: onPreviewPhoto ? handleRowDoubleClick : undefined,
                 selectedIds,
                 activePhotoId: activePhotoId ?? null,
                 onPhotoDelete,
@@ -476,6 +492,7 @@ function renderGroupItems(
     storage: StorageInterface | null
     photosDir: DirectoryHandle | null
     onRowClick: (photoId: string, markerId: string, e: React.MouseEvent) => void
+    onRowDoubleClick?: (photoId: string) => void
     selectedIds: readonly string[]
     activePhotoId: string | null
     onPhotoDelete: (photoId: string) => void | Promise<void>
@@ -510,6 +527,8 @@ function renderGroupItems(
         // Phase 14 — clicking a no-GPS row starts placing it on the map
         // (provisional pin at map center). Not draggable-for-recat (no flag).
         onClick={ctx.onNoGpsPhotoClick ? () => ctx.onNoGpsPhotoClick!(p.photoId) : undefined}
+        // Double-click opens the full-res preview (same as GPS rows).
+        onDoubleClick={ctx.onRowDoubleClick ? () => ctx.onRowDoubleClick!(p.photoId) : undefined}
         selected={false}
         active={false}
         recatDraggable={false}
@@ -529,6 +548,7 @@ function renderGroupItems(
       storage={ctx.storage}
       photosDir={ctx.photosDir}
       onClick={(e) => ctx.onRowClick(m.photoId!, m.id, e)}
+      onDoubleClick={ctx.onRowDoubleClick ? () => ctx.onRowDoubleClick!(m.photoId!) : undefined}
       selected={selectedSet.has(m.photoId!)}
       active={m.photoId === ctx.activePhotoId}
       recatDraggable={ctx.recatEnabled}
@@ -582,6 +602,11 @@ function PhotoListItem(props: {
    * plain click → fly to marker). `undefined` disables the row entirely.
    */
   onClick: ((e: React.MouseEvent) => void) | undefined
+  /**
+   * Double-click opens the full-res preview. Independent of `onClick`; the
+   * preceding single-clicks still fire. `undefined` disables it.
+   */
+  onDoubleClick?: (e: React.MouseEvent) => void
   /** Whether this row is part of the variant-compare selection. */
   selected: boolean
   /**
@@ -605,7 +630,7 @@ function PhotoListItem(props: {
   renameSaveAria: string
 }) {
   const {
-    photoId, displayName, originalFilename, storage, photosDir, onClick, selected, active, onDelete, deleteTooltip,
+    photoId, displayName, originalFilename, storage, photosDir, onClick, onDoubleClick, selected, active, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
     recatDraggable, onRecatDragStart, onRecatDragEnd,
   } = props
@@ -660,7 +685,10 @@ function PhotoListItem(props: {
     >
       <ListItemButton
         onClick={editing ? undefined : onClick}
-        disabled={!editing && !onClick}
+        onDoubleClick={editing ? undefined : onDoubleClick}
+        // A disabled button swallows dblclick too, so only disable when the
+        // row has neither a click nor a double-click action.
+        disabled={!editing && !onClick && !onDoubleClick}
         selected={selected}
         // Edit mode renders as a div so the inner TextField isn't nested
         // inside a <button> (a11y violation + focus contention). Spread

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -36,6 +36,13 @@ export interface PhotoMarkerPopupProps {
   onInclude: () => void
   onSkip: () => void
   onReject: () => void
+  /**
+   * Double-clicking the thumbnail opens the full-resolution single-photo
+   * preview (lightbox). Undefined leaves the thumbnail non-interactive on
+   * double-click. The thumbnail here is only 200x150 — too small to judge a
+   * sign or read a label — so this is the path to "show me this one big".
+   */
+  onPreview?: () => void
 }
 
 const THUMB_WIDTH_PX = 200
@@ -75,6 +82,8 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   return (
     <Box sx={{ minWidth: THUMB_WIDTH_PX + 16 }}>
       <Box
+        onDoubleClick={props.onPreview}
+        title={props.onPreview ? t('photo.preview.title') : undefined}
         sx={{
           width: THUMB_WIDTH_PX,
           height: THUMB_HEIGHT_PX,
@@ -85,6 +94,7 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
           overflow: 'hidden',
           borderRadius: 1,
           mb: 1,
+          cursor: props.onPreview ? 'zoom-in' : undefined,
         }}
       >
         {loadState === 'loading' && <CircularProgress size={24} />}

--- a/frontend/map-corridors/src/components/PhotoPreviewModal.tsx
+++ b/frontend/map-corridors/src/components/PhotoPreviewModal.tsx
@@ -1,0 +1,141 @@
+// Single-photo lightbox. Double-clicking a photo — either the thumbnail in
+// the map dot popup (PhotoMarkerPopup) or a row in PhotoListPanel — opens this
+// to inspect that one photo full-resolution. It's the single-image sibling of
+// PhotoCompareModal (which weighs 2–3 variants against each other): same
+// MUI Dialog shell and the same `usePhotoFullUrl` loader, but view-only — no
+// pick/resolve, no marker mutation.
+
+import { useEffect } from 'react'
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { Close } from '@mui/icons-material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { useI18n } from '../contexts/I18nContext'
+import { usePhotoFullUrl } from './usePhotoFullUrl'
+
+export interface PhotoPreviewModalProps {
+  open: boolean
+  /** Photo to show. `null` keeps the dialog closed regardless of `open`. */
+  photoId: string | null
+  /** Primary name shown in the title bar — custom name if set, else filename. */
+  filename?: string
+  /** Camera filename, shown as a secondary line only when it differs. */
+  originalFilename?: string
+  /** Capture timestamp, rendered as-is. */
+  timestamp?: string
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  onClose: () => void
+}
+
+export function PhotoPreviewModal(props: PhotoPreviewModalProps) {
+  const { open, photoId, filename, originalFilename, timestamp, storage, photosDir, onClose } = props
+  const { t } = useI18n()
+
+  // Esc closes. The MUI Dialog already handles Escape via onClose, but the
+  // compare modal binds its own window listener for parity with its 1/2/3
+  // shortcuts; here a dedicated listener keeps Esc working even if focus is
+  // inside the image area before the Dialog has grabbed it.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [open, onClose])
+
+  if (!open || !photoId) return null
+  const showOriginal = !!originalFilename && originalFilename !== filename
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="lg"
+      keepMounted={false}
+      aria-labelledby="photo-preview-title"
+    >
+      <DialogTitle id="photo-preview-title" sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+        <Stack sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {filename || t('photo.preview.title')}
+          </Typography>
+          {(showOriginal || timestamp) && (
+            <Typography variant="caption" color="text.secondary" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {[showOriginal ? originalFilename : null, timestamp].filter(Boolean).join(' · ')}
+            </Typography>
+          )}
+        </Stack>
+        <IconButton size="small" onClick={onClose} aria-label={t('photo.preview.close')}>
+          <Close fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 1.5 }}>
+        <PreviewImage storage={storage} photosDir={photosDir} photoId={photoId} alt={filename || ''} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function PreviewImage(props: {
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  photoId: string
+  alt: string
+}) {
+  const { storage, photosDir, photoId, alt } = props
+  const { t } = useI18n()
+  const { url, state } = usePhotoFullUrl(storage, photosDir, photoId)
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        // Leave room for the title bar + dialog chrome so the image stays
+        // inside the viewport; native aspect ratio preserved via objectFit.
+        maxHeight: '80vh',
+        minHeight: 280,
+        bgcolor: 'grey.900',
+        borderRadius: 1,
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {state === 'ready' && url && (
+        <img
+          src={url}
+          alt={alt}
+          style={{ maxWidth: '100%', maxHeight: '80vh', objectFit: 'contain' }}
+        />
+      )}
+      {state === 'loading' && (
+        <Typography variant="caption" color="grey.300">
+          {t('photo.preview.loading')}
+        </Typography>
+      )}
+      {state === 'missing' && (
+        <Typography variant="caption" color="error.light">
+          {t('photo.preview.missing')}
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -44,6 +44,12 @@
       "labelSet": "Přiřadit štítek",
       "labelUsed": "Již použito"
     },
+    "preview": {
+      "title": "Fotka",
+      "close": "Zavřít",
+      "loading": "Načítání fotky…",
+      "missing": "Fotku se nepodařilo načíst"
+    },
     "tray": {
       "title": "Bez GPS ({{count}})",
       "dragHint": "Přetáhni na mapu pro umístění",

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -50,6 +50,10 @@
       "loading": "Načítání fotky…",
       "missing": "Fotku se nepodařilo načíst"
     },
+    "map": {
+      "comparePill": "Porovnat tyto fotky vedle sebe",
+      "compareAction": "Porovnat"
+    },
     "tray": {
       "title": "Bez GPS ({{count}})",
       "dragHint": "Přetáhni na mapu pro umístění",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -50,6 +50,10 @@
       "loading": "Loading photo…",
       "missing": "Couldn't load photo"
     },
+    "map": {
+      "comparePill": "Compare these photos side-by-side",
+      "compareAction": "Compare"
+    },
     "tray": {
       "title": "No GPS ({{count}})",
       "dragHint": "Drag onto the map to place",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -44,6 +44,12 @@
       "labelSet": "Set label",
       "labelUsed": "Already used"
     },
+    "preview": {
+      "title": "Photo",
+      "close": "Close",
+      "loading": "Loading photo…",
+      "missing": "Couldn't load photo"
+    },
     "tray": {
       "title": "No GPS ({{count}})",
       "dragHint": "Drag onto the map to place",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -12,6 +12,7 @@ import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
+import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
@@ -104,6 +105,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // `onActivePhotoMarkerChange`. `null` = no photo popup / nothing active.
   activePhotoMarkerId?: string | null
   onActivePhotoMarkerChange?: (id: string | null) => void
+  // Double-clicking the popup thumbnail opens the full-res single-photo
+  // preview. Receives the photoId (keyed the same as the panel rows).
+  onPhotoPreview?: (photoId: string) => void
   // Phase 14 — provisional placement of a no-GPS photo: a draggable pin at the
   // map center whose popup commits the photo to a chosen category. `null` =
   // no placement in progress.
@@ -131,6 +135,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   )
   const dragStartLngLatRef = useRef<Map<string, { lng: number, lat: number }>>(new Map())
   const dragMovedPxRef = useRef<Map<string, number>>(new Map())
+  // Auto-fan: which photo marker is mid-drag (excluded from fanning so its
+  // dot snaps to the cursor instead of sitting at its fan offset). `null` =
+  // none dragging. State (not a ref) so dropping its offset re-renders.
+  const [draggingPhotoMarkerId, setDraggingPhotoMarkerId] = useState<string | null>(null)
+  const photoFan = useMarkerFan({
+    mapRef,
+    isMapLoaded,
+    markers: props.markers,
+    draggingMarkerId: draggingPhotoMarkerId,
+  })
   // Attach native DnD listeners on the canvas to support custom marker drops
   useEffect(() => {
     if (!isMapLoaded || !mapRef.current) return
@@ -443,6 +457,23 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           photos the user has dragged (capturedAt ≠ lng/lat). Unmoved
           photos see only their live <Marker> pin. */}
       {props.markers && <CaptureDotsLayer markers={props.markers} />}
+      {/* Auto-fan leader lines: thin spokes from each overlapping cluster's
+          centroid out to the fanned dots, so a stack of photos at one point
+          reads as "these N belong here". Sits below the DOM markers (GL is
+          always under react-map-gl <Marker> elements), so no z-fighting. */}
+      {photoFan.leaders.features.length > 0 && (
+        <Source id="photo-fan-leaders" type="geojson" data={photoFan.leaders}>
+          <Layer
+            id="photo-fan-leaders"
+            type="line"
+            paint={{
+              'line-color': '#888888',
+              'line-width': 1,
+              'line-opacity': 0.7,
+            }}
+          />
+        </Source>
+      )}
       {/* KML / click-placed markers — existing render path. Photo
           markers (m.photoId !== undefined) are handled in the photo-
           pin block below to keep the click + popup semantics distinct
@@ -682,6 +713,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             longitude={m.lng}
             latitude={m.lat}
             draggable
+            // Auto-fan: nudge overlapping markers apart by a pixel offset
+            // (anchor stays at the true lng/lat). Suppressed while THIS marker
+            // is being dragged so its dot tracks the cursor without a jump.
+            offset={draggingPhotoMarkerId === m.id ? undefined : photoFan.offsets.get(m.id)}
             style={isActive ? { zIndex: 2 } : undefined}
             onClick={(ev: MarkerEvent<MouseEvent>) => {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
@@ -696,6 +731,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               const ll = ev.lngLat
               dragStartLngLatRef.current.set(m.id, { lng: ll.lng, lat: ll.lat })
               dragMovedPxRef.current.set(m.id, 0)
+              setDraggingPhotoMarkerId(m.id)
             }}
             onDrag={(ev: MarkerDragEvent) => {
               const start = dragStartLngLatRef.current.get(m.id)
@@ -711,6 +747,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
               dragStartLngLatRef.current.delete(m.id)
               dragMovedPxRef.current.delete(m.id)
+              // Clear the drag exclusion; the fan recomputes for the new
+              // position (a marker drag fires no map `moveend`, so the hook's
+              // dependency on `draggingMarkerId` is what triggers the recompute).
+              setDraggingPhotoMarkerId(null)
               if (movedPx < 8) {
                 // Treated as click — open photo popup without moving.
                 setActivePhotoMarkerId(m.id)
@@ -898,11 +938,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const marker = props.markers?.find(m => m.id === activePhotoMarkerId)
         if (!marker || !marker.capturedAt || !marker.photoId) return null
         const popupId = activePhotoMarkerId
+        // When the active marker is fanned, shift the popup by the same pixel
+        // offset so its tail points at the fanned dot the user clicked rather
+        // than the (now-empty) true GPS point under the cluster.
+        const fanOffset = photoFan.offsets.get(popupId)
         return (
           <Popup
             longitude={marker.lng}
             latitude={marker.lat}
             anchor="top"
+            offset={fanOffset}
             closeButton
             closeOnMove={false}
             // Default Mapbox Popup auto-closes on any map click, which
@@ -939,6 +984,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
                 props.onPhotoReject?.(popupId)
                 setActivePhotoMarkerId(null)
               }}
+              onPreview={props.onPhotoPreview ? () => props.onPhotoPreview?.(marker.photoId!) : undefined}
             />
           </Popup>
         )

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -14,6 +14,7 @@ import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
+import { MAX_COMPARE_VARIANTS } from '../components/PhotoListPanel'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
@@ -108,6 +109,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // Double-clicking the popup thumbnail opens the full-res single-photo
   // preview. Receives the photoId (keyed the same as the panel rows).
   onPhotoPreview?: (photoId: string) => void
+  // Compare 2–3 photos side-by-side (winner=pick, losers=reject). Same handler
+  // the side panel uses, so the cluster pill / map multi-select and the panel
+  // share one modal + resolve path. Undefined disables map-side comparison.
+  onCompareVariants?: (markers: readonly PhotoMarker[]) => void
   // Phase 14 — provisional placement of a no-GPS photo: a draggable pin at the
   // map center whose popup commits the photo to a chosen category. `null` =
   // no placement in progress.
@@ -145,6 +150,67 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     markers: props.markers,
     draggingMarkerId: draggingPhotoMarkerId,
   })
+
+  // Map-side multi-select for side-by-side compare. Holds markerIds in click
+  // order (mirrors PhotoListPanel's `selectedIds`). Driven by Ctrl/Cmd/Shift-
+  // click on dots and by the cluster pill; the floating bar compares 2–3.
+  const [selectedPhotoMarkerIds, setSelectedPhotoMarkerIds] = useState<readonly string[]>([])
+  const clearPhotoSelection = useCallback(() => setSelectedPhotoMarkerIds([]), [])
+  const togglePhotoSelection = useCallback((markerId: string) => {
+    setSelectedPhotoMarkerIds(prev =>
+      prev.includes(markerId) ? prev.filter(id => id !== markerId) : [...prev, markerId],
+    )
+  }, [])
+
+  // Resolve a list of markerIds to live PhotoMarkers in the given order,
+  // skipping any that have since vanished.
+  const markersByIdForCompare = useCallback((ids: readonly string[]): PhotoMarker[] => {
+    const byId = new Map<string, PhotoMarker>()
+    for (const m of props.markers ?? []) byId.set(m.id, m)
+    const out: PhotoMarker[] = []
+    for (const id of ids) {
+      const m = byId.get(id)
+      if (m) out.push(m)
+    }
+    return out
+  }, [props.markers])
+
+  // Prune selection when a selected marker disappears (deleted / demoted to a
+  // non-visible flag) so the floating bar count stays honest.
+  useEffect(() => {
+    setSelectedPhotoMarkerIds(prev => {
+      if (prev.length === 0) return prev
+      const valid = new Set((props.markers ?? []).filter(isPhotoMarkerVisible).map(m => m.id))
+      const next = prev.filter(id => valid.has(id))
+      return next.length === prev.length ? prev : next
+    })
+  }, [props.markers])
+
+  // Esc clears the map selection (parallels the panel's clear button).
+  useEffect(() => {
+    if (selectedPhotoMarkerIds.length === 0) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') clearPhotoSelection() }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [selectedPhotoMarkerIds.length, clearPhotoSelection])
+
+  const selectedCompareMarkers = useMemo(
+    () => markersByIdForCompare(selectedPhotoMarkerIds),
+    [markersByIdForCompare, selectedPhotoMarkerIds],
+  )
+
+  // Open the compare modal for a set of markers, or — when there are too many
+  // for the 2–3 modal — drop them into the selection so the user can trim via
+  // the floating bar. Shared by the cluster pill and (for ≤3) direct calls.
+  const compareOrSelect = useCallback((markers: readonly PhotoMarker[]) => {
+    if (markers.length < 2) return
+    if (markers.length <= MAX_COMPARE_VARIANTS) {
+      props.onCompareVariants?.(markers)
+      clearPhotoSelection()
+    } else {
+      setSelectedPhotoMarkerIds(markers.map(m => m.id))
+    }
+  }, [props, clearPhotoSelection])
   // Attach native DnD listeners on the canvas to support custom marker drops
   useEffect(() => {
     if (!isMapLoaded || !mapRef.current) return
@@ -416,6 +482,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       initialViewState={{ longitude: 14.42076, latitude: 50.08804, zoom: 6 }}
       style={{ width: '100%', height: '100%' }}
       onLoad={() => setIsMapLoaded(true)}
+      // A click on the empty map (not a marker — those are DOM overlays and
+      // don't raise the map's `click`) clears any pending compare selection,
+      // the same way clicking off a selection deselects elsewhere.
+      onClick={() => { if (selectedPhotoMarkerIds.length) clearPhotoSelection() }}
       ref={mapRef}
     >
       {geojsonOverlays?.map((ov) => (
@@ -707,6 +777,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         // Phase 13 — the active photo (popup open / selected in the side
         // panel) gets a glow + scale-up and is lifted above its neighbours.
         const isActive = activePhotoMarkerId === m.id
+        // Map-side compare selection (Ctrl/Cmd/Shift-click). Gets a distinct
+        // ring; can coexist with the active glow.
+        const isSelected = selectedPhotoMarkerIds.includes(m.id)
         return (
           <Marker
             key={m.id}
@@ -717,14 +790,23 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             // (anchor stays at the true lng/lat). Suppressed while THIS marker
             // is being dragged so its dot tracks the cursor without a jump.
             offset={draggingPhotoMarkerId === m.id ? undefined : photoFan.offsets.get(m.id)}
-            style={isActive ? { zIndex: 2 } : undefined}
+            style={isActive || isSelected ? { zIndex: 2 } : undefined}
             onClick={(ev: MarkerEvent<MouseEvent>) => {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
               dragStartLngLatRef.current.delete(m.id)
               dragMovedPxRef.current.delete(m.id)
               if (movedPx < 8) {
                 ev.originalEvent?.stopPropagation?.()
-                setActivePhotoMarkerId(m.id)
+                const oe = ev.originalEvent
+                // Ctrl/Cmd or Shift → toggle into the compare selection instead
+                // of opening the popup. Plain click → open popup AND drop any
+                // pending selection (don't leave the user in a hidden mode).
+                if (oe && (oe.ctrlKey || oe.metaKey || oe.shiftKey)) {
+                  togglePhotoSelection(m.id)
+                } else {
+                  clearPhotoSelection()
+                  setActivePhotoMarkerId(m.id)
+                }
               }
             }}
             onDragStart={(ev: MarkerDragEvent) => {
@@ -769,12 +851,15 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               borderRadius: '50%',
               background: bg,
               border: `2px solid ${ringColor}`,
-              // Active marker: white halo + blue glow so it reads on any
-              // basemap; otherwise the subtle drop shadow for moved photos.
-              boxShadow: isActive
-                ? '0 0 0 3px rgba(255,255,255,0.9), 0 0 10px 4px rgba(25,118,210,0.65)'
-                : moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
-              transform: isActive ? 'scale(1.3)' : undefined,
+              // Layered halos: active = white + blue glow; selected-for-compare
+              // = purple ring (distinct from the blue active glow, and the two
+              // stack when a marker is both). Else the subtle moved-photo shadow.
+              boxShadow: [
+                isSelected ? '0 0 0 3px #ffffff, 0 0 0 5px #9c27b0' : null,
+                isActive ? '0 0 0 3px rgba(255,255,255,0.9), 0 0 10px 4px rgba(25,118,210,0.65)' : null,
+                !isActive && !isSelected && moved ? '0 1px 2px rgba(0,0,0,0.25)' : null,
+              ].filter(Boolean).join(', ') || 'none',
+              transform: isActive ? 'scale(1.3)' : isSelected ? 'scale(1.15)' : undefined,
               transition: 'transform 120ms ease, box-shadow 120ms ease',
               cursor: 'pointer',
             }} />
@@ -795,6 +880,45 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           </Marker>
         )
       })}
+      {/* Cluster "Compare" pills — one per fanned group, anchored at the
+          centroid where the leader lines converge (no dot sits there, since
+          dots fan outward). Click compares the cluster's photos: ≤3 opens the
+          side-by-side modal directly; >3 drops them into the selection so the
+          floating bar can trim to 3. Only shown when comparison is wired. */}
+      {props.onCompareVariants && photoFan.clusters.map(c => (
+        <Marker
+          key={`fan-pill-${c.ids.join('-')}`}
+          longitude={c.centroidLngLat[0]}
+          latitude={c.centroidLngLat[1]}
+          style={{ zIndex: 3 }}
+        >
+          <button
+            type="button"
+            title={t('photo.map.comparePill')}
+            onClick={(e) => {
+              e.stopPropagation()
+              compareOrSelect(markersByIdForCompare(c.ids))
+            }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 3,
+              height: 22,
+              padding: '0 8px',
+              borderRadius: 11,
+              border: '1px solid #7b1fa2',
+              background: '#9c27b0',
+              color: '#ffffff',
+              fontSize: 12,
+              fontWeight: 700,
+              lineHeight: 1,
+              cursor: 'pointer',
+              boxShadow: '0 1px 4px rgba(0,0,0,0.35)',
+              whiteSpace: 'nowrap',
+            }}
+          >⇄ {c.count}</button>
+        </Marker>
+      ))}
       {/* Ground markers */}
       {props.groundMarkerProps?.groundMarkers.map(gm => {
         const gmp = props.groundMarkerProps!
@@ -1038,6 +1162,77 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               />
             </Popup>
           </React.Fragment>
+        )
+      })()}
+      {/* Floating compare bar — appears when ≥1 photo is map-selected
+          (Ctrl/Cmd/Shift-click or via a cluster pill of >3). Enabled for 2–3;
+          disabled with a hint when over the cap, mirroring the side panel. */}
+      {props.onCompareVariants && selectedCompareMarkers.length >= 1 && (() => {
+        const n = selectedCompareMarkers.length
+        const tooMany = n > MAX_COMPARE_VARIANTS
+        const ready = n >= 2 && !tooMany
+        return (
+          <div style={{
+            position: 'absolute',
+            bottom: 20,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 30,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            background: 'rgba(33,33,33,0.94)',
+            color: '#ffffff',
+            padding: '8px 10px 8px 14px',
+            borderRadius: 24,
+            boxShadow: '0 2px 10px rgba(0,0,0,0.4)',
+            fontSize: 13,
+          }}>
+            <span style={{ fontWeight: 600 }}>
+              {t('photo.list.compareSelected', { count: n })}
+            </span>
+            {tooMany && (
+              <span style={{ color: '#ffcc80', fontSize: 12 }}>
+                {t('photo.list.compareLimitTip', { max: MAX_COMPARE_VARIANTS })}
+              </span>
+            )}
+            <button
+              type="button"
+              disabled={!ready}
+              onClick={() => {
+                if (!ready) return
+                props.onCompareVariants?.(selectedCompareMarkers)
+                clearPhotoSelection()
+              }}
+              style={{
+                height: 28,
+                padding: '0 14px',
+                borderRadius: 14,
+                border: 'none',
+                background: ready ? '#9c27b0' : '#616161',
+                color: '#ffffff',
+                fontSize: 13,
+                fontWeight: 700,
+                cursor: ready ? 'pointer' : 'not-allowed',
+              }}
+            >⇄ {t('photo.map.compareAction')}</button>
+            <button
+              type="button"
+              onClick={clearPhotoSelection}
+              aria-label={t('photo.list.clearSelection')}
+              title={t('photo.list.clearSelection')}
+              style={{
+                height: 28,
+                width: 28,
+                borderRadius: '50%',
+                border: 'none',
+                background: 'transparent',
+                color: '#ffffff',
+                fontSize: 16,
+                cursor: 'pointer',
+              }}
+            >✕</button>
+          </div>
         )
       })()}
     </MapGL>

--- a/frontend/map-corridors/src/map/photoLayers/markerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerFan.ts
@@ -26,11 +26,21 @@ export interface LeaderSegment {
   to: [number, number]
 }
 
+/** A fanned cluster: its members (markerIds) and the screen-space centroid the
+ *  fan radiates from. Used to anchor the "Compare N" pill and to know which
+ *  photos a cluster gesture should compare. */
+export interface MarkerCluster {
+  ids: string[]
+  centroid: [number, number]
+}
+
 export interface MarkerFanResult {
   /** markerId → [dx, dy] pixel offset. Only members of a fanned group appear. */
   offsets: Map<string, [number, number]>
   /** One per fanned marker. Empty when nothing overlaps. */
   leaders: LeaderSegment[]
+  /** One per fanned group (size ≥ 2). Empty when nothing overlaps. */
+  clusters: MarkerCluster[]
 }
 
 export interface MarkerFanOptions {
@@ -116,6 +126,7 @@ export function computeMarkerFan(
   const opt = { ...DEFAULTS, ...options }
   const offsets = new Map<string, [number, number]>()
   const leaders: LeaderSegment[] = []
+  const clusters: MarkerCluster[] = []
 
   const groups = clusterByProximity(points, opt.thresholdPx)
   for (const group of groups) {
@@ -129,6 +140,7 @@ export function computeMarkerFan(
     const cx = members.reduce((s, p) => s + p.x, 0) / members.length
     const cy = members.reduce((s, p) => s + p.y, 0) / members.length
     const n = members.length
+    clusters.push({ ids: members.map(p => p.id), centroid: [cx, cy] })
     const radius = clamp(
       opt.baseRadiusPx + opt.radiusStepPx * (n - 2),
       opt.minRadiusPx,
@@ -147,5 +159,5 @@ export function computeMarkerFan(
     }
   }
 
-  return { offsets, leaders }
+  return { offsets, leaders, clusters }
 }

--- a/frontend/map-corridors/src/map/photoLayers/markerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerFan.ts
@@ -1,0 +1,151 @@
+// Pure geometry for the "auto-fan overlapping markers" feature.
+//
+// When several photo markers project to nearly the same screen pixel (e.g.
+// a stack of photos shot at one rally turning point), they collapse into an
+// unclickable blob. This module clusters markers by SCREEN-PIXEL proximity
+// and fans each cluster out into a tight circle around the group centroid,
+// returning a per-marker pixel offset plus the leader-line segments
+// (centroid → fanned dot) that visually tie the cluster back to its place.
+//
+// Kept free of any map/React dependency so the clustering + layout maths can
+// be unit-tested with plain numbers. The hook (`useMarkerFan`) supplies the
+// screen-projected points and turns the screen-space leader segments back
+// into lng/lat for the GL line layer.
+
+/** A marker projected to screen-pixel space. */
+export interface ScreenPoint {
+  id: string
+  x: number
+  y: number
+}
+
+/** A leader line in screen space: centroid (`from`) → fanned dot (`to`). */
+export interface LeaderSegment {
+  id: string
+  from: [number, number]
+  to: [number, number]
+}
+
+export interface MarkerFanResult {
+  /** markerId → [dx, dy] pixel offset. Only members of a fanned group appear. */
+  offsets: Map<string, [number, number]>
+  /** One per fanned marker. Empty when nothing overlaps. */
+  leaders: LeaderSegment[]
+}
+
+export interface MarkerFanOptions {
+  /** Two markers within this pixel distance are considered overlapping. */
+  thresholdPx?: number
+  /** Base fan radius for a 2-member group (px). */
+  baseRadiusPx?: number
+  /** Extra radius per member beyond 2 (px). */
+  radiusStepPx?: number
+  /** Lower/upper clamp on the fan radius (px). */
+  minRadiusPx?: number
+  maxRadiusPx?: number
+}
+
+const DEFAULTS = {
+  thresholdPx: 20,
+  baseRadiusPx: 16,
+  radiusStepPx: 2,
+  minRadiusPx: 16,
+  maxRadiusPx: 40,
+} as const
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v))
+}
+
+/**
+ * Single-link spatial clustering: any two points within `threshold` px are
+ * placed in the same group (transitively). O(n²) — fine for the few dozen
+ * markers a competition produces. Returns groups as arrays of indices into
+ * `points`.
+ */
+export function clusterByProximity(
+  points: readonly ScreenPoint[],
+  threshold: number,
+): number[][] {
+  const n = points.length
+  const parent = Array.from({ length: n }, (_, i) => i)
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]
+      i = parent[i]
+    }
+    return i
+  }
+  const union = (a: number, b: number) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  const t2 = threshold * threshold
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = points[i].x - points[j].x
+      const dy = points[i].y - points[j].y
+      if (dx * dx + dy * dy <= t2) union(i, j)
+    }
+  }
+
+  const groups = new Map<number, number[]>()
+  for (let i = 0; i < n; i++) {
+    const r = find(i)
+    const g = groups.get(r)
+    if (g) g.push(i)
+    else groups.set(r, [i])
+  }
+  return Array.from(groups.values())
+}
+
+/**
+ * Compute pixel offsets + leader segments that fan every overlapping group
+ * out into a circle around its centroid. Solitary markers get no offset.
+ *
+ * Members are laid out at evenly-spaced angles starting from straight up
+ * (-π/2), sorted by id so a given marker keeps a stable slot across
+ * recomputes (no angular jitter on pan/zoom).
+ */
+export function computeMarkerFan(
+  points: readonly ScreenPoint[],
+  options: MarkerFanOptions = {},
+): MarkerFanResult {
+  const opt = { ...DEFAULTS, ...options }
+  const offsets = new Map<string, [number, number]>()
+  const leaders: LeaderSegment[] = []
+
+  const groups = clusterByProximity(points, opt.thresholdPx)
+  for (const group of groups) {
+    if (group.length < 2) continue
+
+    const members = group
+      .map(i => points[i])
+      .slice()
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+
+    const cx = members.reduce((s, p) => s + p.x, 0) / members.length
+    const cy = members.reduce((s, p) => s + p.y, 0) / members.length
+    const n = members.length
+    const radius = clamp(
+      opt.baseRadiusPx + opt.radiusStepPx * (n - 2),
+      opt.minRadiusPx,
+      opt.maxRadiusPx,
+    )
+
+    for (let k = 0; k < n; k++) {
+      const p = members[k]
+      const theta = -Math.PI / 2 + (2 * Math.PI * k) / n
+      const tx = cx + radius * Math.cos(theta)
+      const ty = cy + radius * Math.sin(theta)
+      // Anchor stays at the marker's own projected point, so the offset must
+      // carry it from there to the target slot on the fan circle.
+      offsets.set(p.id, [tx - p.x, ty - p.y])
+      leaders.push({ id: p.id, from: [cx, cy], to: [tx, ty] })
+    }
+  }
+
+  return { offsets, leaders }
+}

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -1,0 +1,99 @@
+// React hook that drives the auto-fan of overlapping photo markers.
+//
+// It projects each visible marker to screen pixels, hands the points to the
+// pure `computeMarkerFan` clusterer, and exposes:
+//   • `offsets`  — markerId → [dx,dy] pixel offset, applied via the
+//                  react-map-gl `<Marker offset>` prop (anchor stays at the
+//                  true lng/lat, so drag still reports the real coords).
+//   • `leaders`  — a GeoJSON LineString FeatureCollection (centroid → fanned
+//                  dot) for a thin GL line layer that ties each cluster to its
+//                  place. Endpoints are unprojected back to lng/lat so the GL
+//                  layer tracks the map natively between recomputes.
+//
+// Overlap depends on zoom, so the fan recomputes on `moveend`/`zoomend` (the
+// settle events — not `move`/`zoom`, which fire every frame). It also
+// recomputes when the marker set changes or when a marker enters/leaves drag
+// (the dragged marker is excluded so its dot snaps cleanly to the cursor).
+
+import { useEffect, useMemo, useState } from 'react'
+import type { RefObject } from 'react'
+import type { MapRef } from 'react-map-gl/mapbox'
+import type { FeatureCollection, LineString } from 'geojson'
+import type { PhotoMarker } from '../../types/markers'
+import { isPhotoMarkerVisible } from './markerVisibility'
+import { computeMarkerFan, type ScreenPoint } from './markerFan'
+
+export interface UseMarkerFanResult {
+  offsets: Map<string, [number, number]>
+  leaders: FeatureCollection<LineString>
+}
+
+const EMPTY: UseMarkerFanResult = {
+  offsets: new Map(),
+  leaders: { type: 'FeatureCollection', features: [] },
+}
+
+export function useMarkerFan(params: {
+  mapRef: RefObject<MapRef | null>
+  isMapLoaded: boolean
+  markers: readonly PhotoMarker[] | undefined
+  /** Marker currently being dragged — excluded from fanning so it tracks the cursor. */
+  draggingMarkerId: string | null
+  thresholdPx?: number
+}): UseMarkerFanResult {
+  const { mapRef, isMapLoaded, markers, draggingMarkerId, thresholdPx } = params
+
+  // Bumped on every map settle so the memo below re-projects against the new
+  // viewport. A counter (not the camera state) keeps the dependency cheap.
+  const [settleTick, setSettleTick] = useState(0)
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return
+    const map = mapRef.current.getMap()
+    const bump = () => setSettleTick(t => t + 1)
+    map.on('moveend', bump)
+    map.on('zoomend', bump)
+    // Initial compute once the map is ready (no settle event fires on load).
+    bump()
+    return () => {
+      map.off('moveend', bump)
+      map.off('zoomend', bump)
+    }
+  }, [isMapLoaded, mapRef])
+
+  return useMemo<UseMarkerFanResult>(() => {
+    if (!isMapLoaded || !mapRef.current || !markers) return EMPTY
+    const visible = markers.filter(m => isPhotoMarkerVisible(m) && m.id !== draggingMarkerId)
+    if (visible.length < 2) return EMPTY
+
+    const map = mapRef.current.getMap()
+    const points: ScreenPoint[] = visible.map(m => {
+      const p = map.project([m.lng, m.lat])
+      return { id: m.id, x: p.x, y: p.y }
+    })
+
+    const fan = computeMarkerFan(points, thresholdPx ? { thresholdPx } : undefined)
+    if (fan.offsets.size === 0) return EMPTY
+
+    const features: FeatureCollection<LineString>['features'] = fan.leaders.map(l => {
+      const from = map.unproject(l.from)
+      const to = map.unproject(l.to)
+      return {
+        type: 'Feature',
+        id: l.id,
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [from.lng, from.lat],
+            [to.lng, to.lat],
+          ],
+        },
+        properties: {},
+      }
+    })
+
+    return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+    // settleTick intentionally in deps: it's the signal that the viewport
+    // moved and projections must be recomputed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMapLoaded, mapRef, markers, draggingMarkerId, thresholdPx, settleTick])
+}

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -23,14 +23,24 @@ import type { PhotoMarker } from '../../types/markers'
 import { isPhotoMarkerVisible } from './markerVisibility'
 import { computeMarkerFan, type ScreenPoint } from './markerFan'
 
+/** A fanned cluster surfaced to the map: members (markerIds), the centroid in
+ *  lng/lat (so the "Compare N" pill can be a <Marker>), and the member count. */
+export interface FanCluster {
+  ids: string[]
+  centroidLngLat: [number, number]
+  count: number
+}
+
 export interface UseMarkerFanResult {
   offsets: Map<string, [number, number]>
   leaders: FeatureCollection<LineString>
+  clusters: FanCluster[]
 }
 
 const EMPTY: UseMarkerFanResult = {
   offsets: new Map(),
   leaders: { type: 'FeatureCollection', features: [] },
+  clusters: [],
 }
 
 export function useMarkerFan(params: {
@@ -91,7 +101,12 @@ export function useMarkerFan(params: {
       }
     })
 
-    return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+    const clusters: FanCluster[] = fan.clusters.map(c => {
+      const ll = map.unproject(c.centroid)
+      return { ids: c.ids, centroidLngLat: [ll.lng, ll.lat], count: c.ids.length }
+    })
+
+    return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features }, clusters }
     // settleTick intentionally in deps: it's the signal that the viewport
     // moved and projections must be recomputed.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- **Desktop launcher:** opens **maximized** on every launch (flash-free `ready-to-show`; restore size unchanged).
- **Map Corridors — big photo preview:** double-click a photo (map dot popup thumbnail, GPS panel rows, no-GPS "Bez GPS" list group + bottom-left tray) opens a **full-resolution single-photo lightbox**. Keyed on `photoId` (resolved from `markers` or `noGpsPhotos`) so no-GPS photos preview too. Esc / backdrop closes.
- **Map Corridors — auto-fan overlapping dots:** photos at the same/nearby point fan out into a circle around their shared point with thin leader lines, recomputed on zoom/pan and suppressed for the dragged marker (drag still saves true coords).
- **Map Corridors — compare co-located photos from the map:** each fanned cluster shows a **⇄ N** pill at its centre → opens the photos side-by-side (2–3 directly; >3 → selection to trim). Also **Ctrl/Cmd/Shift-click** dots to multi-select (ringed) with a floating **Compare (N)** bar. Both reuse the existing `PhotoCompareModal` (winner=pick, losers=reject); map + panel share one modal.
- Versioning: CHANGELOG `2.19.0`, desktop `package.json` → `2.19.0`. `#minor`.

## Test plan
- [x] `tsc -b` clean
- [x] `vitest run` — 618 pass (38 files), incl. `markerFan` cluster tests
- [x] `vite build` succeeds
- [x] Portable `.exe` builds (`photo-helper-v2.19.0.exe`)
- [ ] App opens maximized; restore works
- [ ] Double-click opens preview from: map popup, GPS row, no-GPS row, no-GPS tray
- [ ] Stacked photos fan apart with leader lines; each clickable; fan collapses when zoomed in
- [ ] Dragging a fanned dot snaps to cursor and saves correct position
- [ ] Cluster ⇄N pill compares 2–3 directly; 4+ → selection + "max 3" hint
- [ ] Ctrl/Cmd/Shift-click multi-select → ringed dots + floating Compare bar → side-by-side
- [ ] Plain click / Esc / empty-map click clears selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)