### PR TITLE
UX pass: markers, editor layout, modal nav, launcher rename, TP routing #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.19.0] - 2026-05-30
+
+### Added
+- **Map Corridors:** double-click a photo to open a full-resolution preview
+  (single-photo lightbox). Works on the thumbnail inside a map dot's popup and
+  on a photo row in the right-side panel — press Esc or click outside to close.
+- **Map Corridors:** photos taken at the same or a nearby point no longer stack
+  into one unclickable blob. Overlapping dots now automatically fan out into a
+  small circle around their shared location, with thin leader lines tying each
+  one back to the spot, so every photo stays individually clickable. The fan
+  recomputes as you zoom and pan, and collapses once the dots are far enough
+  apart on their own.
+
+### Changed
+- **Desktop launcher:** the app now opens maximised (filling the screen) on
+  every launch instead of a fixed-size window.
+
 ## [2.18.0] - 2026-05-24
 
 ### Added

--- a/docs/photo-map-culling/track-turning-categorization-plan.md
+++ b/docs/photo-map-culling/track-turning-categorization-plan.md
@@ -1,0 +1,176 @@
+# Plan: Categorize map picks as Track vs Turning-Point photos
+
+**Status:** NOT STARTED — ready to implement in a fresh session.
+**Owner feedback (2026-05-30):** "it would be good in corridors app, to be able to
+distinguish between track and TP photos by categorizing them to track
+photos/turning photos category, once they are selected" + auto-route those into
+the photo editor's track vs turning-point sets.
+
+This is the **A3** item from the 2026-05-30 UX pass. The other items (C1, B5, B3,
+A1, A2, C2, B4, B2) shipped on branch `feat/ux-pass-markers-editor-launcher`.
+A3 was attempted there and **reverted** because the editing channel became
+unreliable mid-session; it must be redone cleanly. Nothing about A3 is committed.
+
+## Design decisions (already approved by the user)
+
+1. **Replace the single `pick` flag with two pick categories:** `pick-track`
+   and `pick-turning`. `reject` and neutral (absent flag) stay as-is.
+2. **Legacy migration:** an existing persisted `flag: 'pick'` becomes
+   `pick-track` (the common case; the user re-categorizes turning-point photos
+   via the popup). Lossless and reversible.
+3. **Auto-route through the handoff:** the category rides on the cross-app
+   handoff so the editor knows track vs turning. Do **NOT** silently auto-promote
+   arriving picks into the editor's print sets (that would move photos into a
+   mode bucket hidden from the current view). The category travels on the
+   candidate's flag; the existing tray "Send to Set" / "Send to TP photos"
+   controls (shipped in B2) do the actual placement.
+
+## Visual language
+
+- Track pick marker ring: blue `#1976d2` (current pick color — keep).
+- Turning-point pick marker ring: purple `#7b1fa2`.
+- Neutral: amber `#fb8c00` (shipped in A1). Reject: red `#d32f2f`. Label: gold `#facc15`.
+
+---
+
+## Change surface (exhaustive — file : what)
+
+### 1. Flag type — `frontend/map-corridors/src/types/markers.ts`
+- `export type PhotoFlag = 'pick' | 'reject'` → `'pick-track' | 'pick-turning' | 'reject'`.
+- `PHOTO_FLAG_SET` set: `['pick','reject']` → `['pick-track','pick-turning','reject']`.
+- **Add** an exported migration helper (append at end of file):
+  ```ts
+  /** v1 stored a bare `flag: 'pick'`; the flag was split into pick-track /
+   *  pick-turning. A legacy `pick` becomes `pick-track`. MUST run BEFORE the
+   *  isPhotoMarker guard on load or previously-picked photos get dropped. */
+  export function migrateLegacyPhotoFlag(m: unknown): unknown {
+    if (m && typeof m === 'object' && (m as { flag?: unknown }).flag === 'pick') {
+      return { ...(m as object), flag: 'pick-track' }
+    }
+    return m
+  }
+  ```
+
+### 2. OPFS load migration — `frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts`
+- Import `migrateLegacyPhotoFlag` from `../types/markers`.
+- In `sanitizeMarkers` (the `raw.filter(isPhotoMarker)` path), map FIRST:
+  `return raw.map(migrateLegacyPhotoFlag).filter(isPhotoMarker)`.
+  Without this, a v1 session's `flag:'pick'` markers fail the guard and are
+  silently dropped on load.
+
+### 3. Grouping — `frontend/map-corridors/src/components/groupPhotosByFlag.ts`
+- `if (m.flag === 'pick') picks.push(m)` →
+  `if (m.flag === 'pick-track' || m.flag === 'pick-turning') picks.push(m)`.
+  (Both categories count as "picks"; the existing 4-group panel stays.)
+
+### 4. Recategorize — `frontend/map-corridors/src/recategorize/recategorize.ts`
+- `flagForGroup`: `case 'picks': return 'pick'` → `return 'pick-track'`
+  (dropping into the picks panel section defaults to track; re-categorize via popup).
+
+### 5. Variant resolution — `frontend/map-corridors/src/photoVariants/resolveVariantFlags.ts`
+- Winner: `flag: 'pick' as const` → keep the winner's existing category if it was
+  already a pick, else default to track:
+  `flag: (m.flag === 'pick-turning' ? 'pick-turning' : 'pick-track') as const`.
+
+### 6. Popup UI — `frontend/map-corridors/src/components/PhotoMarkerPopup.tsx`
+- Props: replace `onInclude: () => void` with
+  `onIncludeTrack: () => void` + `onIncludeTurning: () => void`.
+- Destructure both; compute `isPickTrack`/`isPickTurning` from `marker.flag`.
+- Replace the single "Picked" button with two:
+  - Track: `<Check/>` icon, `color={isPickTrack ? 'primary' : 'default'}`,
+    label `t('photo.popup.pickTrack')`.
+  - Turning: `<Flag/>` icon (add to `@mui/icons-material` import),
+    `color={isPickTurning ? 'secondary' : 'default'}`,
+    label `t('photo.popup.pickTurning')`.
+  - Keep Skip + Reject unchanged.
+
+### 7. App handlers — `frontend/map-corridors/src/App.tsx`
+- Import `PhotoFlag` from `./types/markers` (type-only).
+- `setPhotoFlag(markerId, flag: 'pick' | 'reject' | null)` → `flag: PhotoFlag | null`.
+- Split `handlePhotoInclude` into `handlePhotoIncludeTrack` (sets `'pick-track'`)
+  and `handlePhotoIncludeTurning` (sets `'pick-turning'`). Keep skip/reject.
+- `handlePhotoSetFlag` signature → `PhotoFlag | null`.
+- `handleProvisionalCommit(flag: 'pick' | 'reject' | null)` → `PhotoFlag | null`.
+- Pass `onPhotoIncludeTrack` / `onPhotoIncludeTurning` to `<MapProviderView>`
+  (replacing `onPhotoInclude`).
+
+### 8. MapProviderView — `frontend/map-corridors/src/map/MapProviderView.tsx`
+- Import `PhotoFlag` (type-only) from `../types/markers`.
+- Props: `onPhotoInclude?` → `onPhotoIncludeTrack?` + `onPhotoIncludeTurning?`.
+- `onProvisionalCommit?: (flag: 'pick' | 'reject' | null)` → `(flag: PhotoFlag | null)`.
+- Popup wiring: `onInclude={() => props.onPhotoInclude?.(m.id)}` →
+  `onIncludeTrack` / `onIncludeTurning` calling the respective props.
+- flyTo center: `marker.flag === 'pick'` → `(marker.flag === 'pick-track' || marker.flag === 'pick-turning')`.
+- ring color: `: m.flag === 'pick' ? '#1976d2'` →
+  `: m.flag === 'pick-track' ? '#1976d2'\n: m.flag === 'pick-turning' ? '#7b1fa2'`.
+- Provisional commit default button: `onProvisionalCommit?.('pick')` → `('pick-track')`.
+
+### 9. Handoff writer — `frontend/map-corridors/src/handoff/mapPicksWriter.ts`
+- `if (m.flag !== 'pick') continue` →
+  `if (m.flag !== 'pick-track' && m.flag !== 'pick-turning') continue`.
+  (The `flag` value itself is then written through as-is.)
+
+### 10. Shared handoff wire type — `frontend/shared-handoff/src/`
+- `types.ts`: `WireFlag = 'pick' | 'neutral' | 'reject'` →
+  `'pick' | 'pick-track' | 'pick-turning' | 'neutral' | 'reject'`.
+  **Keep bare `pick`** for backward compat (old `map-picks.json` files).
+- `guards.ts`: `WIRE_FLAGS` set gains `'pick-track'`, `'pick-turning'`.
+
+### 11. Photo-helper candidate flag — `frontend/photo-helper/src/types/api.ts`
+- `CandidateFlag = 'pick' | 'neutral' | 'reject'` →
+  `'pick' | 'pick-track' | 'pick-turning' | 'neutral' | 'reject'` (keep `pick` for back-compat).
+
+### 12. Photo-helper handoff consume — `frontend/photo-helper/src/hooks/useMapPicksSync.ts`
+- Normalize legacy on read: when building/reconciling a candidate from a
+  `MapPickEntry`, map `entry.flag === 'pick'` → `'pick-track'` so a candidate
+  always carries an explicit category after crossing the handoff. Use that
+  normalized value in both the create path and the `setCandidateFlag` reconcile.
+
+### 13. i18n — `frontend/map-corridors/src/locales/{en,cs}.json`
+- Add under `photo.popup`:
+  - en: `pickTrack: "Track photo"`, `pickTurning: "Turning-point photo"`.
+  - cs: `pickTrack: "Fotka trati"`, `pickTurning: "Fotka otočného bodu"` (diacritics!).
+- The old `photo.popup.include` key can stay (harmless) or be removed.
+
+### 14. Tests
+- **Update** every flag-assertion suite in `frontend/map-corridors/src/__tests__/`
+  that uses `flag: 'pick'` → `'pick-track'` (or `'pick-turning'` where testing
+  the turning path): `groupPhotosByFlag`, `mapPicksWriter`, `recategorize`,
+  `resolveVariantFlags`, `markersDisplay`, `markerSanitize`,
+  `provisionalPlacement`, `activePhoto`, `groupKeyForPhotoId`, `markerVisibility`,
+  `handoffRoundTrip`. (tsc will list every site — run `npx tsc -b` and fix what
+  it flags.)
+- **Add** `migrateLegacyPhotoFlag.test.ts`: legacy `pick`→`pick-track`; reject /
+  the two new categories / neutral untouched; non-objects pass through; and a
+  "guard now accepts the migrated marker (no data loss)" case.
+- **Add** a `groupPhotosByFlag` case asserting BOTH categories land in `picks`.
+- Photo-helper: confirm `useMapPicksSync` tests still pass; add a legacy-`pick`
+  normalization case if one doesn't exist.
+
+---
+
+## Order of work (each step compiles + tests green before the next)
+
+1. shared-handoff `WireFlag` + `WIRE_FLAGS` (no consumers break — additive).
+2. markers.ts `PhotoFlag` + `PHOTO_FLAG_SET` + `migrateLegacyPhotoFlag`.
+   → `npx tsc -b` in map-corridors now lists every break (≈30 sites) — that list
+   IS your worklist for steps 3–9.
+3. OPFS migration (step 2 above, #2).
+4. Logic sites: groupPhotosByFlag, recategorize, resolveVariantFlags,
+   mapPicksWriter, MapProviderView flyTo + ring (#3,4,5,9,8-partial).
+5. Popup UI + App handlers + MapProviderView props/wiring (#6,7,8).
+6. i18n keys (#13).
+7. photo-helper CandidateFlag + useMapPicksSync normalize (#11,12).
+8. Tests (#14).
+9. Full green gate: `npx tsc -b` (map-corridors), `npx tsc --noEmit -p tsconfig.json`
+   (photo-helper), `npx vitest run` in map-corridors + photo-helper + desktop.
+
+## Risk notes
+- Biggest risk is the **shared-handoff contract** — both apps consume it from
+  source, so a mismatch compile-fails (good). Keeping bare `pick` in the union
+  preserves old handoff files.
+- The **OPFS migration ordering** (migrate before guard) is the data-loss
+  trap — get it right and unit-test it.
+- This change touches ~14 files + ~11 test files. Do it in small verified
+  commits, not one batch. Verify each `Edit` landed (the 2026-05-30 session lost
+  several edits to a flaky tool channel — re-read after editing).

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -863,6 +863,48 @@ safeHandle('competition-set-discipline', async (event, id, discipline) => {
   return target;
 });
 
+// Rename a competition. Updates the index metadata `name` (what the launcher
+// dropdown and all menu shortcuts display) and, when present, the per-
+// competition session.json `competition_name` so photo-helper's internal copy
+// stays in sync. Feedback 2026-05-30: "on homepage it is not possible to
+// rename an existing competition".
+safeHandle('competition-rename', async (event, id, name) => {
+  if (typeof id !== 'string' || !id) throw new Error('Invalid competition id');
+  if (typeof name !== 'string') throw new Error('Invalid competition name');
+  // Mirror the create form's constraints: non-empty after trim, capped at the
+  // same 60 chars the name input enforces (maxlength="60").
+  const trimmed = name.trim().slice(0, 60);
+  if (!trimmed) throw new Error('Competition name must not be empty');
+
+  const index = readCompetitionsIndex();
+  const target = index.competitions.find(c => c.id === id);
+  if (!target) {
+    throw new Error(`Competition not found: ${id}`);
+  }
+  target.name = trimmed;
+  target.lastModified = new Date().toISOString();
+  writeCompetitionsIndex(index);
+
+  // Keep session.json's competition_name in sync (best-effort — a missing or
+  // unreadable session file must not fail the rename, since the index is the
+  // source of truth for the displayed name).
+  try {
+    const competitionsDir = path.join(getPhotoSessionsPath(), 'competitions');
+    const compDir = validateStoragePath(path.join(competitionsDir, sanitizeFileName(id)));
+    const sessionPath = path.join(compDir, 'session.json');
+    if (fs.existsSync(sessionPath)) {
+      const session = JSON.parse(fs.readFileSync(sessionPath, 'utf8'));
+      session.competition_name = trimmed;
+      session.updatedAt = new Date().toISOString();
+      fs.writeFileSync(sessionPath, JSON.stringify(session, null, 2), 'utf8');
+    }
+  } catch (e) {
+    console.error('competition-rename: failed to sync session.json name:', e);
+  }
+
+  return target;
+});
+
 // Delete a competition
 safeHandle('competition-delete', async (event, id) => {
   const index = readCompetitionsIndex();

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -197,7 +197,19 @@ function createWindow() {
     },
     icon: path.join(__dirname, 'icons', 'icon.png'),
     title: 'AirQ Competition Helpers',
-    autoHideMenuBar: false
+    autoHideMenuBar: false,
+    // Start hidden so we can maximize before first paint — avoids the brief
+    // 1400x900 flash before the window snaps to full screen. The width/height
+    // above remain the restore size when the user un-maximizes.
+    show: false
+  });
+
+  // Maximize on first show (flash-free pattern). `ready-to-show` fires once the
+  // renderer has painted, so the window appears already maximized rather than
+  // resizing visibly after load.
+  mainWindow.once('ready-to-show', () => {
+    mainWindow.maximize();
+    mainWindow.show();
   });
 
   // Load the landing page

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -34,6 +34,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     create: (name, workingDir) => ipcRenderer.invoke('competition-create', name, workingDir),
     setActive: (id) => ipcRenderer.invoke('competition-set-active', id),
     setDiscipline: (id, discipline) => ipcRenderer.invoke('competition-set-discipline', id, discipline),
+    rename: (id, name) => ipcRenderer.invoke('competition-rename', id, name),
     delete: (id) => ipcRenderer.invoke('competition-delete', id),
     // Per-competition working folder: every export dialog defaults here
     // (feedback 2026-04-25). Persisted in the competitions index.

--- a/frontend/desktop/renderer/app.js
+++ b/frontend/desktop/renderer/app.js
@@ -15,6 +15,11 @@ const translations = {
     'competition.defaultName': 'Soutěž',
     'competition.selectFirst': 'Nejdříve vyberte soutěž',
     'competition.deleteBtn': 'Smazat',
+    'competition.renameBtn': 'Přejmenovat',
+    'competition.renameTitle': 'Přejmenovat soutěž',
+    'competition.renamePrompt': 'Nový název soutěže:',
+    'competition.renameConfirm': 'Uložit',
+    'competition.renameFailed': 'Přejmenování soutěže selhalo: {error}',
     'competition.confirmDelete': 'Smazat',
     'competition.cancelDelete': 'Zrušit',
     'competition.deleteConfirmText': 'Opravdu smazat "{name}"? Toto nelze vrátit.',
@@ -53,6 +58,11 @@ const translations = {
     'competition.defaultName': 'Competition',
     'competition.selectFirst': 'Select a competition first',
     'competition.deleteBtn': 'Delete',
+    'competition.renameBtn': 'Rename',
+    'competition.renameTitle': 'Rename competition',
+    'competition.renamePrompt': 'New competition name:',
+    'competition.renameConfirm': 'Save',
+    'competition.renameFailed': 'Failed to rename competition: {error}',
     'competition.confirmDelete': 'Delete',
     'competition.cancelDelete': 'Cancel',
     'competition.deleteConfirmText': 'Delete "{name}"? This cannot be undone.',
@@ -252,6 +262,8 @@ function updateCardsState() {
   });
   const delBtn = document.getElementById('competition-delete');
   if (delBtn) delBtn.disabled = !hasComp;
+  const renBtn = document.getElementById('competition-rename');
+  if (renBtn) renBtn.disabled = !hasComp;
 }
 
 // Competition change handler
@@ -517,6 +529,62 @@ async function confirmDelete() {
 deleteBtn.addEventListener('click', showDeleteConfirm);
 deleteCancelBtn.addEventListener('click', hideDeleteConfirm);
 deleteConfirmBtn.addEventListener('click', confirmDelete);
+
+// ============================================================================
+// Rename competition — inline form (feedback 2026-05-30)
+// ============================================================================
+
+const renameBtn = document.getElementById('competition-rename');
+const barRename = document.getElementById('competition-bar-rename');
+const renameInput = document.getElementById('competition-rename-input');
+const renameConfirmBtn = document.getElementById('competition-rename-confirm');
+const renameCancelBtn = document.getElementById('competition-rename-cancel');
+let renameInFlight = false;
+
+function showRenameForm() {
+  if (!activeCompetitionId) return;
+  const comp = competitionsList.find(c => c.id === activeCompetitionId);
+  barSelect.classList.add('hidden');
+  barRename.classList.remove('hidden');
+  // Prefill with the current name (not the "name (date)" select label) so the
+  // user edits the real value, not the decorated dropdown text.
+  renameInput.value = (comp && comp.name) || '';
+  renameInput.focus();
+  renameInput.select();
+}
+
+function hideRenameForm() {
+  barRename.classList.add('hidden');
+  barSelect.classList.remove('hidden');
+}
+
+async function confirmRename() {
+  if (renameInFlight) return;
+  if (!activeCompetitionId || !window.electronAPI?.competitions) return;
+  const name = renameInput.value.trim();
+  if (!name) return;
+  renameInFlight = true;
+  try {
+    await window.electronAPI.competitions.rename(activeCompetitionId, name);
+    hideRenameForm();
+    // Reload so the dropdown label + lastModified sort order reflect the
+    // new name; loadCompetitions re-selects the active competition.
+    await loadCompetitions();
+  } catch (err) {
+    console.error('Failed to rename competition:', err);
+    showError('competition.renameFailed', { error: err instanceof Error ? err.message : String(err) });
+  } finally {
+    renameInFlight = false;
+  }
+}
+
+renameBtn.addEventListener('click', showRenameForm);
+renameCancelBtn.addEventListener('click', hideRenameForm);
+renameConfirmBtn.addEventListener('click', confirmRename);
+renameInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') confirmRename();
+  if (e.key === 'Escape') hideRenameForm();
+});
 
 // ============================================================================
 // Cleanup suggestions

--- a/frontend/desktop/renderer/index.html
+++ b/frontend/desktop/renderer/index.html
@@ -45,7 +45,17 @@
           <button class="discipline-btn active" data-discipline="rally" data-i18n="discipline.rally">Rally</button>
         </div>
         <button id="competition-new" class="btn btn-new" data-i18n="competition.new" title="Nova soutez">+ Nova soutez</button>
+        <button id="competition-rename" class="btn btn-rename" data-i18n="competition.renameBtn" title="Prejmenovat" disabled>Prejmenovat</button>
         <button id="competition-delete" class="btn btn-delete" data-i18n="competition.deleteBtn" title="Smazat" disabled>X</button>
+      </div>
+      <div class="competition-create-card hidden" id="competition-bar-rename">
+        <h2 class="competition-create-title" data-i18n="competition.renameTitle">Přejmenovat soutěž</h2>
+        <label class="competition-create-label" data-i18n="competition.renamePrompt" for="competition-rename-input">Nový název soutěže:</label>
+        <input id="competition-rename-input" class="competition-create-input" type="text" maxlength="60" autocomplete="off" />
+        <div class="competition-create-actions">
+          <button id="competition-rename-cancel" class="btn" data-i18n="competition.cancelDelete">Zrušit</button>
+          <button id="competition-rename-confirm" class="btn btn-new" data-i18n="competition.renameConfirm">Uložit</button>
+        </div>
       </div>
       <div class="competition-create-card hidden" id="competition-bar-create">
         <h2 class="competition-create-title" data-i18n="competition.createTitle">Nová soutěž</h2>

--- a/frontend/desktop/renderer/styles.css
+++ b/frontend/desktop/renderer/styles.css
@@ -307,6 +307,22 @@ header p {
   background: #DBEAFE;
 }
 
+.btn-rename {
+  border-color: #1976D2;
+  color: #1976D2;
+  background: #fff;
+}
+
+.btn-rename:hover {
+  background: #EBF5FF;
+}
+
+.btn-rename:disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
 .btn-delete {
   border-color: #E53E3E;
   color: #E53E3E;

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -1201,17 +1201,22 @@ function App() {
                 <Home />
               </IconButton>
             )}
-            <Place sx={{ fontSize: 28 }} />
+            {competitionId && window.electronAPI && (
+              <Button
+                size="small"
+                variant="outlined"
+                onClick={() => window.electronAPI?.navigateToApp?.('photo-helper', competitionId)}
+                startIcon={<PhotoCamera sx={{ fontSize: 18 }} />}
+                sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)', textTransform: 'none', mr: 0.5, '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' } }}
+              >
+                {t('app.openEditor')}
+              </Button>
+            )}
             <Typography variant="h6" sx={{ fontWeight: 600, color: 'white' }}>{t('app.title')}</Typography>
             {competitionName && (
               <Chip label={competitionName} size="small" sx={{ ml: 1, bgcolor: 'rgba(255,255,255,0.2)', color: 'white' }} />
             )}
           </Box>
-          {competitionId && window.electronAPI && (
-            <IconButton size="small" onClick={() => window.electronAPI?.navigateToApp?.('photo-helper', competitionId)} sx={{ color: 'white' }} title="Photo Editor">
-              <PhotoCamera />
-            </IconButton>
-          )}
         </Box>
         {/* Controls row */}
         <Box sx={{

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -40,6 +40,7 @@ import type { ImportFailureReason, ImportFailure } from './photoImport/types'
 import { NoGpsTray } from './components/NoGpsTray'
 import { PhotoListPanel } from './components/PhotoListPanel'
 import { PhotoCompareModal } from './components/PhotoCompareModal'
+import { PhotoPreviewModal } from './components/PhotoPreviewModal'
 import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
 import { resolveActivePhotoId } from './activePhoto/activePhoto'
 import { isProvisionalValid, type ProvisionalPlacement } from './provisionalPlacement/provisionalPlacement'
@@ -258,6 +259,12 @@ function App() {
   // closed. Owned at App level so the resolve handler can hit the same
   // `persistMarkers` setter used by every other flag mutation.
   const [compareVariants, setCompareVariants] = useState<readonly PhotoMarker[] | null>(null)
+  // Single-photo full-res preview (lightbox). Holds the photoId being viewed
+  // large; `null` = closed. Opened by double-clicking the map popup thumbnail
+  // or a photo-panel row. Keyed on photoId (not markerId) so it works for
+  // no-GPS photos too — those have no marker and aren't in `markers`. View-
+  // only — no marker mutation.
+  const [previewPhotoId, setPreviewPhotoId] = useState<string | null>(null)
   const answerSheetRef = useRef<HTMLDivElement | null>(null)
   const usedLabels = useMemo(() => {
     const set = new Set<PhotoLabel>()
@@ -736,6 +743,38 @@ function App() {
     if (selected.length < 2) return
     setCompareVariants(selected)
   }, [])
+
+  // Open the single-photo preview for a given photoId. The map popup, GPS
+  // panel rows and no-GPS panel rows all pass a photoId; the metadata is
+  // derived from the live `markers` / `noGpsPhotos` lists so a rename
+  // reflects without re-opening.
+  const handleOpenPhotoPreview = useCallback((photoId: string) => {
+    setPreviewPhotoId(photoId)
+  }, [])
+  // Resolve preview metadata from either a GPS marker or a no-GPS photo.
+  // `null` = nothing to preview (closed, or the photo vanished).
+  const previewPhoto = useMemo(() => {
+    if (!previewPhotoId) return null
+    const m = markers.find(mm => mm.photoId === previewPhotoId)
+    if (m) {
+      return {
+        photoId: previewPhotoId,
+        filename: photoMarkerDisplayName(m),
+        originalFilename: m.name,
+        timestamp: m.capturedAt?.timestamp,
+      }
+    }
+    const ng = (session?.noGpsPhotos ?? []).find(p => p.photoId === previewPhotoId)
+    if (ng) {
+      return {
+        photoId: previewPhotoId,
+        filename: noGpsPhotoDisplayName(ng),
+        originalFilename: ng.filename,
+        timestamp: undefined,
+      }
+    }
+    return null
+  }, [previewPhotoId, markers, session?.noGpsPhotos])
 
   // Phase 6 — drop-from-tray handler. Atomic: a single persistSession
   // mutates BOTH markers and noGpsPhotos in one write, so a partial
@@ -1303,6 +1342,7 @@ function App() {
             onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}
             activePhotoMarkerId={activePhotoMarkerId}
             onActivePhotoMarkerChange={setActivePhotoMarkerId}
+            onPhotoPreview={handleOpenPhotoPreview}
             provisionalPlacement={provisionalPlacement}
             onProvisionalDrag={handleProvisionalDrag}
             onProvisionalCommit={handleProvisionalCommit}
@@ -1316,6 +1356,7 @@ function App() {
             storage={storage}
             photosDir={photosDir}
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
+            onPreview={handleOpenPhotoPreview}
           />
           {/* Phase 7 — right-side photo list panel. Auto-hides when there
               are no imported photos (KML-only sessions look unchanged). */}
@@ -1332,6 +1373,7 @@ function App() {
             onPhotoDelete={(photoId) => { setPendingDeletePhoto(photoId) }}
             onPhotoRename={(photoId, newName) => { void renamePhoto(photoId, newName) }}
             onCompareVariants={handleCompareVariants}
+            onPreviewPhoto={handleOpenPhotoPreview}
           />
         </Box>
       </Container>
@@ -1343,6 +1385,16 @@ function App() {
       photosDir={photosDir}
       onClose={() => setCompareVariants(null)}
       onResolve={handleCompareResolve}
+    />
+    <PhotoPreviewModal
+      open={previewPhoto !== null}
+      photoId={previewPhoto?.photoId ?? null}
+      filename={previewPhoto?.filename}
+      originalFilename={previewPhoto?.originalFilename}
+      timestamp={previewPhoto?.timestamp}
+      storage={storage}
+      photosDir={photosDir}
+      onClose={() => setPreviewPhotoId(null)}
     />
     <Dialog open={isAnswerSheetOpen} onClose={() => setAnswerSheetOpen(false)} maxWidth="sm" fullWidth>
       <DialogContent dividers sx={{ p: 1 }}>

--- a/frontend/map-corridors/src/__tests__/markerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerFan.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { clusterByProximity, computeMarkerFan, type ScreenPoint } from '../map/photoLayers/markerFan'
+
+// Pure screen-space maths behind the auto-fan of overlapping photo markers.
+// No map needed — points are already projected to pixels.
+
+const sp = (id: string, x: number, y: number): ScreenPoint => ({ id, x, y })
+
+describe('clusterByProximity', () => {
+  it('keeps far-apart points in singleton groups', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 100, 100)], 20)
+    expect(groups.map(g => g.length).sort()).toEqual([1, 1])
+  })
+
+  it('groups two points within the threshold', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 10, 0)], 20)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toHaveLength(2)
+  })
+
+  it('does not group points exactly beyond the threshold', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 21, 0)], 20)
+    expect(groups).toHaveLength(2)
+  })
+
+  it('chains transitively via single-link (a~b, b~c ⇒ one group)', () => {
+    const groups = clusterByProximity([sp('a', 0, 0), sp('b', 15, 0), sp('c', 30, 0)], 20)
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toHaveLength(3)
+  })
+})
+
+describe('computeMarkerFan', () => {
+  it('returns no offsets when nothing overlaps', () => {
+    const r = computeMarkerFan([sp('a', 0, 0), sp('b', 200, 0)], { thresholdPx: 20 })
+    expect(r.offsets.size).toBe(0)
+    expect(r.leaders).toHaveLength(0)
+  })
+
+  it('fans an overlapping pair: both get an offset and a leader', () => {
+    const r = computeMarkerFan([sp('a', 100, 100), sp('b', 105, 100)], { thresholdPx: 20 })
+    expect(r.offsets.size).toBe(2)
+    expect(r.offsets.has('a')).toBe(true)
+    expect(r.offsets.has('b')).toBe(true)
+    expect(r.leaders).toHaveLength(2)
+  })
+
+  it('places each fanned dot on a circle of the fan radius around the centroid', () => {
+    // Two coincident points → centroid is the shared point; each dot sits at
+    // exactly `radius` px from it. N=2 → radius = baseRadiusPx (16).
+    const r = computeMarkerFan([sp('a', 100, 100), sp('b', 100, 100)], {
+      thresholdPx: 20,
+      baseRadiusPx: 16,
+    })
+    for (const [, [dx, dy]] of r.offsets) {
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      expect(dist).toBeCloseTo(16, 5)
+    }
+    // Leader endpoints: `from` = centroid (the shared point), `to` = the dot.
+    for (const l of r.leaders) {
+      expect(l.from[0]).toBeCloseTo(100, 5)
+      expect(l.from[1]).toBeCloseTo(100, 5)
+      const r2 = Math.hypot(l.to[0] - 100, l.to[1] - 100)
+      expect(r2).toBeCloseTo(16, 5)
+    }
+  })
+
+  it('assigns a stable slot per id regardless of input order', () => {
+    const a = computeMarkerFan([sp('a', 0, 0), sp('b', 5, 0), sp('c', 0, 5)], { thresholdPx: 20 })
+    const b = computeMarkerFan([sp('c', 0, 5), sp('a', 0, 0), sp('b', 5, 0)], { thresholdPx: 20 })
+    // Offsets are derived from each marker's own point, so for identical inputs
+    // in different order the same id must land at the same target slot.
+    for (const id of ['a', 'b', 'c']) {
+      const oa = a.offsets.get(id)!
+      const ob = b.offsets.get(id)!
+      expect(oa[0]).toBeCloseTo(ob[0], 5)
+      expect(oa[1]).toBeCloseTo(ob[1], 5)
+    }
+  })
+
+  it('grows the fan radius with group size (clamped)', () => {
+    const pts = Array.from({ length: 8 }, (_, i) => sp(`p${i}`, 100, 100))
+    const r = computeMarkerFan(pts, {
+      thresholdPx: 20,
+      baseRadiusPx: 16,
+      radiusStepPx: 2,
+      maxRadiusPx: 40,
+    })
+    // N=8 → 16 + 2*(8-2) = 28 px, under the 40 cap.
+    for (const [, [dx, dy]] of r.offsets) {
+      expect(Math.hypot(dx, dy)).toBeCloseTo(28, 5)
+    }
+  })
+})

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -37,11 +37,16 @@ export interface NoGpsTrayProps {
    * X badge on photo-helper grid tiles.
    */
   onPhotoDelete: (photoId: string) => void | Promise<void>
+  /**
+   * Double-clicking a tray thumbnail opens the full-resolution single-photo
+   * preview (lightbox). Undefined leaves the thumbnail drag-only.
+   */
+  onPreview?: (photoId: string) => void
 }
 
 export function NoGpsTray(props: NoGpsTrayProps) {
   const { t } = useI18n()
-  const { photos, open, onToggleOpen, storage, photosDir, onPhotoDelete } = props
+  const { photos, open, onToggleOpen, storage, photosDir, onPhotoDelete, onPreview } = props
 
   const sorted = useMemo(() => [...photos].sort(compareNoGpsPhotos), [photos])
 
@@ -94,6 +99,7 @@ export function NoGpsTray(props: NoGpsTrayProps) {
               dragHint={t('photo.tray.dragHint')}
               onDelete={onPhotoDelete}
               deleteTooltip={t('photo.deleteTooltip')}
+              onPreview={onPreview}
             />
           ))}
         </Box>
@@ -109,8 +115,9 @@ function NoGpsTrayThumb(props: {
   dragHint: string
   onDelete: (photoId: string) => void | Promise<void>
   deleteTooltip: string
+  onPreview?: (photoId: string) => void
 }) {
-  const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip } = props
+  const { photo, storage, photosDir, dragHint, onDelete, deleteTooltip, onPreview } = props
   const { url, state } = usePhotoThumbUrl(storage, photosDir, photo.photoId)
   // Custom name when set, else the camera filename — shown in the tooltip,
   // a11y labels, and the no-thumb placeholder.
@@ -136,6 +143,7 @@ function NoGpsTrayThumb(props: {
             e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, photo.photoId)
             e.dataTransfer.effectAllowed = 'move'
           }}
+          onDoubleClick={onPreview ? () => onPreview(photo.photoId) : undefined}
           sx={{
             width: THUMB_WIDTH_PX,
             height: THUMB_HEIGHT_PX,

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -95,6 +95,14 @@ export interface PhotoListPanelProps {
    * category in the popup). Undefined leaves no-GPS rows non-interactive.
    */
   onNoGpsPhotoClick?: (photoId: string) => void
+  /**
+   * Double-clicking a photo row opens the full-resolution single-photo
+   * preview (lightbox). Receives the photoId. Works for both GPS rows and
+   * no-GPS rows. The plain single-clicks that precede the double-click still
+   * fire (GPS: select + fly-to + popup; no-GPS: start place-on-map) — that's
+   * harmless. Undefined disables the preview path.
+   */
+  onPreviewPhoto?: (photoId: string) => void
 }
 
 /**
@@ -112,7 +120,7 @@ const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps'
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
-  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick } = props
+  const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick, onPreviewPhoto } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
     picks: false,
@@ -191,6 +199,13 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
     clearSelection()
     onMarkerClick(markerId)
   }, [orderedSelectableIds, clearSelection, onMarkerClick])
+
+  // Double-click a row → open the full-res single-photo preview. Keyed on
+  // photoId so it works for GPS and no-GPS rows alike. The single-clicks that
+  // precede it are harmless.
+  const handleRowDoubleClick = useCallback((photoId: string) => {
+    onPreviewPhoto?.(photoId)
+  }, [onPreviewPhoto])
 
   const selectedMarkers = useMemo(() => {
     const byPhotoId = new Map<string, PhotoMarker>()
@@ -281,6 +296,7 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
                 storage,
                 photosDir,
                 onRowClick: handleRowClick,
+                onRowDoubleClick: onPreviewPhoto ? handleRowDoubleClick : undefined,
                 selectedIds,
                 activePhotoId: activePhotoId ?? null,
                 onPhotoDelete,
@@ -476,6 +492,7 @@ function renderGroupItems(
     storage: StorageInterface | null
     photosDir: DirectoryHandle | null
     onRowClick: (photoId: string, markerId: string, e: React.MouseEvent) => void
+    onRowDoubleClick?: (photoId: string) => void
     selectedIds: readonly string[]
     activePhotoId: string | null
     onPhotoDelete: (photoId: string) => void | Promise<void>
@@ -510,6 +527,8 @@ function renderGroupItems(
         // Phase 14 — clicking a no-GPS row starts placing it on the map
         // (provisional pin at map center). Not draggable-for-recat (no flag).
         onClick={ctx.onNoGpsPhotoClick ? () => ctx.onNoGpsPhotoClick!(p.photoId) : undefined}
+        // Double-click opens the full-res preview (same as GPS rows).
+        onDoubleClick={ctx.onRowDoubleClick ? () => ctx.onRowDoubleClick!(p.photoId) : undefined}
         selected={false}
         active={false}
         recatDraggable={false}
@@ -529,6 +548,7 @@ function renderGroupItems(
       storage={ctx.storage}
       photosDir={ctx.photosDir}
       onClick={(e) => ctx.onRowClick(m.photoId!, m.id, e)}
+      onDoubleClick={ctx.onRowDoubleClick ? () => ctx.onRowDoubleClick!(m.photoId!) : undefined}
       selected={selectedSet.has(m.photoId!)}
       active={m.photoId === ctx.activePhotoId}
       recatDraggable={ctx.recatEnabled}
@@ -582,6 +602,11 @@ function PhotoListItem(props: {
    * plain click → fly to marker). `undefined` disables the row entirely.
    */
   onClick: ((e: React.MouseEvent) => void) | undefined
+  /**
+   * Double-click opens the full-res preview. Independent of `onClick`; the
+   * preceding single-clicks still fire. `undefined` disables it.
+   */
+  onDoubleClick?: (e: React.MouseEvent) => void
   /** Whether this row is part of the variant-compare selection. */
   selected: boolean
   /**
@@ -605,7 +630,7 @@ function PhotoListItem(props: {
   renameSaveAria: string
 }) {
   const {
-    photoId, displayName, originalFilename, storage, photosDir, onClick, selected, active, onDelete, deleteTooltip,
+    photoId, displayName, originalFilename, storage, photosDir, onClick, onDoubleClick, selected, active, onDelete, deleteTooltip,
     onRename, renameTooltip, renamePlaceholder, renameSaveAria,
     recatDraggable, onRecatDragStart, onRecatDragEnd,
   } = props
@@ -660,7 +685,10 @@ function PhotoListItem(props: {
     >
       <ListItemButton
         onClick={editing ? undefined : onClick}
-        disabled={!editing && !onClick}
+        onDoubleClick={editing ? undefined : onDoubleClick}
+        // A disabled button swallows dblclick too, so only disable when the
+        // row has neither a click nor a double-click action.
+        disabled={!editing && !onClick && !onDoubleClick}
         selected={selected}
         // Edit mode renders as a div so the inner TextField isn't nested
         // inside a <button> (a11y violation + focus contention). Spread

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -36,6 +36,13 @@ export interface PhotoMarkerPopupProps {
   onInclude: () => void
   onSkip: () => void
   onReject: () => void
+  /**
+   * Double-clicking the thumbnail opens the full-resolution single-photo
+   * preview (lightbox). Undefined leaves the thumbnail non-interactive on
+   * double-click. The thumbnail here is only 200x150 — too small to judge a
+   * sign or read a label — so this is the path to "show me this one big".
+   */
+  onPreview?: () => void
 }
 
 const THUMB_WIDTH_PX = 200
@@ -75,6 +82,8 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   return (
     <Box sx={{ minWidth: THUMB_WIDTH_PX + 16 }}>
       <Box
+        onDoubleClick={props.onPreview}
+        title={props.onPreview ? t('photo.preview.title') : undefined}
         sx={{
           width: THUMB_WIDTH_PX,
           height: THUMB_HEIGHT_PX,
@@ -85,6 +94,7 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
           overflow: 'hidden',
           borderRadius: 1,
           mb: 1,
+          cursor: props.onPreview ? 'zoom-in' : undefined,
         }}
       >
         {loadState === 'loading' && <CircularProgress size={24} />}

--- a/frontend/map-corridors/src/components/PhotoPreviewModal.tsx
+++ b/frontend/map-corridors/src/components/PhotoPreviewModal.tsx
@@ -1,0 +1,141 @@
+// Single-photo lightbox. Double-clicking a photo — either the thumbnail in
+// the map dot popup (PhotoMarkerPopup) or a row in PhotoListPanel — opens this
+// to inspect that one photo full-resolution. It's the single-image sibling of
+// PhotoCompareModal (which weighs 2–3 variants against each other): same
+// MUI Dialog shell and the same `usePhotoFullUrl` loader, but view-only — no
+// pick/resolve, no marker mutation.
+
+import { useEffect } from 'react'
+import {
+  Box,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { Close } from '@mui/icons-material'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { useI18n } from '../contexts/I18nContext'
+import { usePhotoFullUrl } from './usePhotoFullUrl'
+
+export interface PhotoPreviewModalProps {
+  open: boolean
+  /** Photo to show. `null` keeps the dialog closed regardless of `open`. */
+  photoId: string | null
+  /** Primary name shown in the title bar — custom name if set, else filename. */
+  filename?: string
+  /** Camera filename, shown as a secondary line only when it differs. */
+  originalFilename?: string
+  /** Capture timestamp, rendered as-is. */
+  timestamp?: string
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  onClose: () => void
+}
+
+export function PhotoPreviewModal(props: PhotoPreviewModalProps) {
+  const { open, photoId, filename, originalFilename, timestamp, storage, photosDir, onClose } = props
+  const { t } = useI18n()
+
+  // Esc closes. The MUI Dialog already handles Escape via onClose, but the
+  // compare modal binds its own window listener for parity with its 1/2/3
+  // shortcuts; here a dedicated listener keeps Esc working even if focus is
+  // inside the image area before the Dialog has grabbed it.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [open, onClose])
+
+  if (!open || !photoId) return null
+  const showOriginal = !!originalFilename && originalFilename !== filename
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="lg"
+      keepMounted={false}
+      aria-labelledby="photo-preview-title"
+    >
+      <DialogTitle id="photo-preview-title" sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1 }}>
+        <Stack sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {filename || t('photo.preview.title')}
+          </Typography>
+          {(showOriginal || timestamp) && (
+            <Typography variant="caption" color="text.secondary" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {[showOriginal ? originalFilename : null, timestamp].filter(Boolean).join(' · ')}
+            </Typography>
+          )}
+        </Stack>
+        <IconButton size="small" onClick={onClose} aria-label={t('photo.preview.close')}>
+          <Close fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 1.5 }}>
+        <PreviewImage storage={storage} photosDir={photosDir} photoId={photoId} alt={filename || ''} />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function PreviewImage(props: {
+  storage: StorageInterface | null
+  photosDir: DirectoryHandle | null
+  photoId: string
+  alt: string
+}) {
+  const { storage, photosDir, photoId, alt } = props
+  const { t } = useI18n()
+  const { url, state } = usePhotoFullUrl(storage, photosDir, photoId)
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        // Leave room for the title bar + dialog chrome so the image stays
+        // inside the viewport; native aspect ratio preserved via objectFit.
+        maxHeight: '80vh',
+        minHeight: 280,
+        bgcolor: 'grey.900',
+        borderRadius: 1,
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      {state === 'ready' && url && (
+        <img
+          src={url}
+          alt={alt}
+          style={{ maxWidth: '100%', maxHeight: '80vh', objectFit: 'contain' }}
+        />
+      )}
+      {state === 'loading' && (
+        <Typography variant="caption" color="grey.300">
+          {t('photo.preview.loading')}
+        </Typography>
+      )}
+      {state === 'missing' && (
+        <Typography variant="caption" color="error.light">
+          {t('photo.preview.missing')}
+        </Typography>
+      )}
+    </Box>
+  )
+}

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -44,6 +44,12 @@
       "labelSet": "Přiřadit štítek",
       "labelUsed": "Již použito"
     },
+    "preview": {
+      "title": "Fotka",
+      "close": "Zavřít",
+      "loading": "Načítání fotky…",
+      "missing": "Fotku se nepodařilo načíst"
+    },
     "tray": {
       "title": "Bez GPS ({{count}})",
       "dragHint": "Přetáhni na mapu pro umístění",

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -18,7 +18,8 @@
     },
     "printMap": "Tisk mapy",
     "dragToPlaceGround": "Přetáhni pro umístění znaku",
-    "backToMenu": "Zpět do hlavního menu"
+    "backToMenu": "Zpět do hlavního menu",
+    "openEditor": "Editor fotek"
   },
   "photo": {
     "import": {

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -44,6 +44,12 @@
       "labelSet": "Set label",
       "labelUsed": "Already used"
     },
+    "preview": {
+      "title": "Photo",
+      "close": "Close",
+      "loading": "Loading photo…",
+      "missing": "Couldn't load photo"
+    },
     "tray": {
       "title": "No GPS ({{count}})",
       "dragHint": "Drag onto the map to place",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -18,7 +18,8 @@
     },
     "printMap": "Print Map",
     "dragToPlaceGround": "Drag to place ground marker",
-    "backToMenu": "Back to main menu"
+    "backToMenu": "Back to main menu",
+    "openEditor": "Photo Editor"
   },
   "photo": {
     "import": {

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -12,6 +12,7 @@ import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
+import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
@@ -104,6 +105,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // `onActivePhotoMarkerChange`. `null` = no photo popup / nothing active.
   activePhotoMarkerId?: string | null
   onActivePhotoMarkerChange?: (id: string | null) => void
+  // Double-clicking the popup thumbnail opens the full-res single-photo
+  // preview. Receives the photoId (keyed the same as the panel rows).
+  onPhotoPreview?: (photoId: string) => void
   // Phase 14 — provisional placement of a no-GPS photo: a draggable pin at the
   // map center whose popup commits the photo to a chosen category. `null` =
   // no placement in progress.
@@ -131,6 +135,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   )
   const dragStartLngLatRef = useRef<Map<string, { lng: number, lat: number }>>(new Map())
   const dragMovedPxRef = useRef<Map<string, number>>(new Map())
+  // Auto-fan: which photo marker is mid-drag (excluded from fanning so its
+  // dot snaps to the cursor instead of sitting at its fan offset). `null` =
+  // none dragging. State (not a ref) so dropping its offset re-renders.
+  const [draggingPhotoMarkerId, setDraggingPhotoMarkerId] = useState<string | null>(null)
+  const photoFan = useMarkerFan({
+    mapRef,
+    isMapLoaded,
+    markers: props.markers,
+    draggingMarkerId: draggingPhotoMarkerId,
+  })
   // Attach native DnD listeners on the canvas to support custom marker drops
   useEffect(() => {
     if (!isMapLoaded || !mapRef.current) return
@@ -443,6 +457,23 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           photos the user has dragged (capturedAt ≠ lng/lat). Unmoved
           photos see only their live <Marker> pin. */}
       {props.markers && <CaptureDotsLayer markers={props.markers} />}
+      {/* Auto-fan leader lines: thin spokes from each overlapping cluster's
+          centroid out to the fanned dots, so a stack of photos at one point
+          reads as "these N belong here". Sits below the DOM markers (GL is
+          always under react-map-gl <Marker> elements), so no z-fighting. */}
+      {photoFan.leaders.features.length > 0 && (
+        <Source id="photo-fan-leaders" type="geojson" data={photoFan.leaders}>
+          <Layer
+            id="photo-fan-leaders"
+            type="line"
+            paint={{
+              'line-color': '#888888',
+              'line-width': 1,
+              'line-opacity': 0.7,
+            }}
+          />
+        </Source>
+      )}
       {/* KML / click-placed markers — existing render path. Photo
           markers (m.photoId !== undefined) are handled in the photo-
           pin block below to keep the click + popup semantics distinct
@@ -682,6 +713,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             longitude={m.lng}
             latitude={m.lat}
             draggable
+            // Auto-fan: nudge overlapping markers apart by a pixel offset
+            // (anchor stays at the true lng/lat). Suppressed while THIS marker
+            // is being dragged so its dot tracks the cursor without a jump.
+            offset={draggingPhotoMarkerId === m.id ? undefined : photoFan.offsets.get(m.id)}
             style={isActive ? { zIndex: 2 } : undefined}
             onClick={(ev: MarkerEvent<MouseEvent>) => {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
@@ -696,6 +731,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               const ll = ev.lngLat
               dragStartLngLatRef.current.set(m.id, { lng: ll.lng, lat: ll.lat })
               dragMovedPxRef.current.set(m.id, 0)
+              setDraggingPhotoMarkerId(m.id)
             }}
             onDrag={(ev: MarkerDragEvent) => {
               const start = dragStartLngLatRef.current.get(m.id)
@@ -711,6 +747,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               const movedPx = dragMovedPxRef.current.get(m.id) || 0
               dragStartLngLatRef.current.delete(m.id)
               dragMovedPxRef.current.delete(m.id)
+              // Clear the drag exclusion; the fan recomputes for the new
+              // position (a marker drag fires no map `moveend`, so the hook's
+              // dependency on `draggingMarkerId` is what triggers the recompute).
+              setDraggingPhotoMarkerId(null)
               if (movedPx < 8) {
                 // Treated as click — open photo popup without moving.
                 setActivePhotoMarkerId(m.id)
@@ -898,11 +938,16 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const marker = props.markers?.find(m => m.id === activePhotoMarkerId)
         if (!marker || !marker.capturedAt || !marker.photoId) return null
         const popupId = activePhotoMarkerId
+        // When the active marker is fanned, shift the popup by the same pixel
+        // offset so its tail points at the fanned dot the user clicked rather
+        // than the (now-empty) true GPS point under the cluster.
+        const fanOffset = photoFan.offsets.get(popupId)
         return (
           <Popup
             longitude={marker.lng}
             latitude={marker.lat}
             anchor="top"
+            offset={fanOffset}
             closeButton
             closeOnMove={false}
             // Default Mapbox Popup auto-closes on any map click, which
@@ -939,6 +984,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
                 props.onPhotoReject?.(popupId)
                 setActivePhotoMarkerId(null)
               }}
+              onPreview={props.onPhotoPreview ? () => props.onPhotoPreview?.(marker.photoId!) : undefined}
             />
           </Popup>
         )

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -21,6 +21,7 @@ import {
   LIVE_GROUND_MARKER_ICON_PX,
   LIVE_MARKER_DOT_BORDER_RADIUS_PX,
   LIVE_MARKER_DOT_PX,
+  LIVE_MARKER_HIT_PX,
 } from '../utils/markerSizes'
 
 type Overlay = {
@@ -310,10 +311,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         }))
 
       const printMarkers = (props.markers || []).map(m => ({
-        lng: m.lng,
-        lat: m.lat,
-        label: m.label,
-      }))
+          lng: m.lng,
+          lat: m.lat,
+          label: m.label,
+        }))
 
       const printGroundMarkers = (props.groundMarkerProps?.groundMarkers || []).map(gm => ({
         lng: gm.lng,
@@ -699,10 +700,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         // marker color so a user scanning the map sees one consistent
         // visual for "this is going on the score sheet" regardless of
         // origin. Unlabelled photos colour by flag.
+        // Unflagged ("neutral") photos use a high-contrast amber instead of the
+        // old grey (#616161), which was nearly invisible on both street and
+        // satellite basemaps — feedback 2026-05-30 ("brown dots, invisible").
         const ringColor = m.label ? '#facc15'
           : m.flag === 'pick' ? '#1976d2'
           : m.flag === 'reject' ? '#d32f2f'
-          : '#616161'
+          : '#fb8c00'
         const bg = moved ? ringColor : '#ffffff'
         // Phase 13 — the active photo (popup open / selected in the side
         // panel) gets a glow + scale-up and is lifted above its neighbours.
@@ -764,11 +768,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             }}
           >
             <div style={{
-              width: 14,
-              height: 14,
+              width: LIVE_MARKER_DOT_PX,
+              height: LIVE_MARKER_DOT_PX,
               borderRadius: '50%',
               background: bg,
               border: `2px solid ${ringColor}`,
+              position: 'relative',
               // Active marker: white halo + blue glow so it reads on any
               // basemap; otherwise the subtle drop shadow for moved photos.
               boxShadow: isActive
@@ -777,7 +782,23 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               transform: isActive ? 'scale(1.3)' : undefined,
               transition: 'transform 120ms ease, box-shadow 120ms ease',
               cursor: 'pointer',
-            }} />
+            }}>
+              {/* Transparent click/tap halo — enlarges the hit target a few px
+                  beyond the visible dot so markers are easier to grab without
+                  making the dot itself huge (feedback 2026-05-30). Centered on
+                  the dot; does not affect layout or the label offset. */}
+              <div style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                width: LIVE_MARKER_HIT_PX,
+                height: LIVE_MARKER_HIT_PX,
+                transform: 'translate(-50%, -50%)',
+                borderRadius: '50%',
+                background: 'transparent',
+                cursor: 'pointer',
+              }} />
+            </div>
             {m.label && (
               <div style={{
                 position: 'absolute',

--- a/frontend/map-corridors/src/map/photoLayers/markerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerFan.ts
@@ -1,0 +1,151 @@
+// Pure geometry for the "auto-fan overlapping markers" feature.
+//
+// When several photo markers project to nearly the same screen pixel (e.g.
+// a stack of photos shot at one rally turning point), they collapse into an
+// unclickable blob. This module clusters markers by SCREEN-PIXEL proximity
+// and fans each cluster out into a tight circle around the group centroid,
+// returning a per-marker pixel offset plus the leader-line segments
+// (centroid → fanned dot) that visually tie the cluster back to its place.
+//
+// Kept free of any map/React dependency so the clustering + layout maths can
+// be unit-tested with plain numbers. The hook (`useMarkerFan`) supplies the
+// screen-projected points and turns the screen-space leader segments back
+// into lng/lat for the GL line layer.
+
+/** A marker projected to screen-pixel space. */
+export interface ScreenPoint {
+  id: string
+  x: number
+  y: number
+}
+
+/** A leader line in screen space: centroid (`from`) → fanned dot (`to`). */
+export interface LeaderSegment {
+  id: string
+  from: [number, number]
+  to: [number, number]
+}
+
+export interface MarkerFanResult {
+  /** markerId → [dx, dy] pixel offset. Only members of a fanned group appear. */
+  offsets: Map<string, [number, number]>
+  /** One per fanned marker. Empty when nothing overlaps. */
+  leaders: LeaderSegment[]
+}
+
+export interface MarkerFanOptions {
+  /** Two markers within this pixel distance are considered overlapping. */
+  thresholdPx?: number
+  /** Base fan radius for a 2-member group (px). */
+  baseRadiusPx?: number
+  /** Extra radius per member beyond 2 (px). */
+  radiusStepPx?: number
+  /** Lower/upper clamp on the fan radius (px). */
+  minRadiusPx?: number
+  maxRadiusPx?: number
+}
+
+const DEFAULTS = {
+  thresholdPx: 20,
+  baseRadiusPx: 16,
+  radiusStepPx: 2,
+  minRadiusPx: 16,
+  maxRadiusPx: 40,
+} as const
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v))
+}
+
+/**
+ * Single-link spatial clustering: any two points within `threshold` px are
+ * placed in the same group (transitively). O(n²) — fine for the few dozen
+ * markers a competition produces. Returns groups as arrays of indices into
+ * `points`.
+ */
+export function clusterByProximity(
+  points: readonly ScreenPoint[],
+  threshold: number,
+): number[][] {
+  const n = points.length
+  const parent = Array.from({ length: n }, (_, i) => i)
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]
+      i = parent[i]
+    }
+    return i
+  }
+  const union = (a: number, b: number) => {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent[ra] = rb
+  }
+
+  const t2 = threshold * threshold
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const dx = points[i].x - points[j].x
+      const dy = points[i].y - points[j].y
+      if (dx * dx + dy * dy <= t2) union(i, j)
+    }
+  }
+
+  const groups = new Map<number, number[]>()
+  for (let i = 0; i < n; i++) {
+    const r = find(i)
+    const g = groups.get(r)
+    if (g) g.push(i)
+    else groups.set(r, [i])
+  }
+  return Array.from(groups.values())
+}
+
+/**
+ * Compute pixel offsets + leader segments that fan every overlapping group
+ * out into a circle around its centroid. Solitary markers get no offset.
+ *
+ * Members are laid out at evenly-spaced angles starting from straight up
+ * (-π/2), sorted by id so a given marker keeps a stable slot across
+ * recomputes (no angular jitter on pan/zoom).
+ */
+export function computeMarkerFan(
+  points: readonly ScreenPoint[],
+  options: MarkerFanOptions = {},
+): MarkerFanResult {
+  const opt = { ...DEFAULTS, ...options }
+  const offsets = new Map<string, [number, number]>()
+  const leaders: LeaderSegment[] = []
+
+  const groups = clusterByProximity(points, opt.thresholdPx)
+  for (const group of groups) {
+    if (group.length < 2) continue
+
+    const members = group
+      .map(i => points[i])
+      .slice()
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+
+    const cx = members.reduce((s, p) => s + p.x, 0) / members.length
+    const cy = members.reduce((s, p) => s + p.y, 0) / members.length
+    const n = members.length
+    const radius = clamp(
+      opt.baseRadiusPx + opt.radiusStepPx * (n - 2),
+      opt.minRadiusPx,
+      opt.maxRadiusPx,
+    )
+
+    for (let k = 0; k < n; k++) {
+      const p = members[k]
+      const theta = -Math.PI / 2 + (2 * Math.PI * k) / n
+      const tx = cx + radius * Math.cos(theta)
+      const ty = cy + radius * Math.sin(theta)
+      // Anchor stays at the marker's own projected point, so the offset must
+      // carry it from there to the target slot on the fan circle.
+      offsets.set(p.id, [tx - p.x, ty - p.y])
+      leaders.push({ id: p.id, from: [cx, cy], to: [tx, ty] })
+    }
+  }
+
+  return { offsets, leaders }
+}

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -1,0 +1,99 @@
+// React hook that drives the auto-fan of overlapping photo markers.
+//
+// It projects each visible marker to screen pixels, hands the points to the
+// pure `computeMarkerFan` clusterer, and exposes:
+//   • `offsets`  — markerId → [dx,dy] pixel offset, applied via the
+//                  react-map-gl `<Marker offset>` prop (anchor stays at the
+//                  true lng/lat, so drag still reports the real coords).
+//   • `leaders`  — a GeoJSON LineString FeatureCollection (centroid → fanned
+//                  dot) for a thin GL line layer that ties each cluster to its
+//                  place. Endpoints are unprojected back to lng/lat so the GL
+//                  layer tracks the map natively between recomputes.
+//
+// Overlap depends on zoom, so the fan recomputes on `moveend`/`zoomend` (the
+// settle events — not `move`/`zoom`, which fire every frame). It also
+// recomputes when the marker set changes or when a marker enters/leaves drag
+// (the dragged marker is excluded so its dot snaps cleanly to the cursor).
+
+import { useEffect, useMemo, useState } from 'react'
+import type { RefObject } from 'react'
+import type { MapRef } from 'react-map-gl/mapbox'
+import type { FeatureCollection, LineString } from 'geojson'
+import type { PhotoMarker } from '../../types/markers'
+import { isPhotoMarkerVisible } from './markerVisibility'
+import { computeMarkerFan, type ScreenPoint } from './markerFan'
+
+export interface UseMarkerFanResult {
+  offsets: Map<string, [number, number]>
+  leaders: FeatureCollection<LineString>
+}
+
+const EMPTY: UseMarkerFanResult = {
+  offsets: new Map(),
+  leaders: { type: 'FeatureCollection', features: [] },
+}
+
+export function useMarkerFan(params: {
+  mapRef: RefObject<MapRef | null>
+  isMapLoaded: boolean
+  markers: readonly PhotoMarker[] | undefined
+  /** Marker currently being dragged — excluded from fanning so it tracks the cursor. */
+  draggingMarkerId: string | null
+  thresholdPx?: number
+}): UseMarkerFanResult {
+  const { mapRef, isMapLoaded, markers, draggingMarkerId, thresholdPx } = params
+
+  // Bumped on every map settle so the memo below re-projects against the new
+  // viewport. A counter (not the camera state) keeps the dependency cheap.
+  const [settleTick, setSettleTick] = useState(0)
+  useEffect(() => {
+    if (!isMapLoaded || !mapRef.current) return
+    const map = mapRef.current.getMap()
+    const bump = () => setSettleTick(t => t + 1)
+    map.on('moveend', bump)
+    map.on('zoomend', bump)
+    // Initial compute once the map is ready (no settle event fires on load).
+    bump()
+    return () => {
+      map.off('moveend', bump)
+      map.off('zoomend', bump)
+    }
+  }, [isMapLoaded, mapRef])
+
+  return useMemo<UseMarkerFanResult>(() => {
+    if (!isMapLoaded || !mapRef.current || !markers) return EMPTY
+    const visible = markers.filter(m => isPhotoMarkerVisible(m) && m.id !== draggingMarkerId)
+    if (visible.length < 2) return EMPTY
+
+    const map = mapRef.current.getMap()
+    const points: ScreenPoint[] = visible.map(m => {
+      const p = map.project([m.lng, m.lat])
+      return { id: m.id, x: p.x, y: p.y }
+    })
+
+    const fan = computeMarkerFan(points, thresholdPx ? { thresholdPx } : undefined)
+    if (fan.offsets.size === 0) return EMPTY
+
+    const features: FeatureCollection<LineString>['features'] = fan.leaders.map(l => {
+      const from = map.unproject(l.from)
+      const to = map.unproject(l.to)
+      return {
+        type: 'Feature',
+        id: l.id,
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [from.lng, from.lat],
+            [to.lng, to.lat],
+          ],
+        },
+        properties: {},
+      }
+    })
+
+    return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+    // settleTick intentionally in deps: it's the signal that the viewport
+    // moved and projections must be recomputed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMapLoaded, mapRef, markers, draggingMarkerId, thresholdPx, settleTick])
+}

--- a/frontend/map-corridors/src/utils/markerSizes.ts
+++ b/frontend/map-corridors/src/utils/markerSizes.ts
@@ -13,9 +13,16 @@
  *  Previous values are left as a // comment so the +50% history is
  *  visible without a git blame round-trip.
  * ────────────────────────────────────────────────────────────────────── */
-export const LIVE_MARKER_DOT_PX = 12             // was 8
-export const LIVE_MARKER_DOT_BORDER_RADIUS_PX = 6 // was 4
+export const LIVE_MARKER_DOT_PX = 18             // was 12 (orig 8) — bumped for tap-ability (feedback 2026-05-30)
+export const LIVE_MARKER_DOT_BORDER_RADIUS_PX = 9 // was 6 (orig 4)
 export const LIVE_GROUND_MARKER_ICON_PX = 24     // was 16
+
+// Transparent circular click halo rendered as an absolutely-positioned child
+// of each live marker dot. It enlarges the clickable / tappable target a few
+// pixels beyond the visible dot WITHOUT affecting marker layout or the label
+// offsets (which are measured from the dot in normal flow). Markers were
+// "extremely small, hard to click / very sensitive" — feedback 2026-05-30.
+export const LIVE_MARKER_HIT_PX = 38
 
 /* ──────────────────────────────────────────────────────────────────────
  *  Printed / PNG map capture (mapCapture.ts)

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -448,6 +448,41 @@ function AppApi() {
     await promoteCandidateToSlot(photoId, setKey, slotIndex);
   };
 
+  // "Send to TP photos": route a tray candidate into the turning-point set.
+  // There is no always-on TP container — turning-point photos ARE set1/set2
+  // while the editor is in turning-point mode. So: if already in TP mode, place
+  // directly; otherwise switch mode first and let the effect below finish the
+  // placement once `session.mode` has actually flipped (updateSessionMode is
+  // async and persistAndSet-based, so promoteCandidateToSlot can't be chained
+  // synchronously without a stale-session closure). Reuses the existing tested
+  // promote path — no new session-mutation logic.
+  const [pendingTPSend, setPendingTPSend] = useState<string | null>(null);
+
+  const handleSendCandidateToTP = async (photoId: string) => {
+    if (!session) return;
+    if (session.mode === 'turningpoint') {
+      await handleSendCandidateToSet(photoId, 'set1');
+      return;
+    }
+    setPendingTPSend(photoId);
+    if (updateSessionMode) await updateSessionMode('turningpoint');
+  };
+
+  useEffect(() => {
+    if (!pendingTPSend) return;
+    if (session?.mode !== 'turningpoint') return;
+    const photoId = pendingTPSend;
+    setPendingTPSend(null);
+    // Only place if the candidate is still in the pool (it may have been moved
+    // or deleted between the mode switch and this effect firing).
+    if (session.candidates?.photos?.some(p => p.id === photoId)) {
+      void handleSendCandidateToSet(photoId, 'set1');
+    }
+  // handleSendCandidateToSet closes over the fresh post-switch session; keying
+  // on session.mode + pendingTPSend is the intended trigger.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.mode, pendingTPSend]);
+
   const handlePhotoUpdate = (setKey: 'set1' | 'set2' | 'candidates', photoId: string, canvasState: Partial<ApiPhoto['canvasState']>) => {
     // Dispatch to the right backend method — slot photos go through
     // updatePhotoState, candidates through updateCandidatePhotoState. The

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Container,
   Typography,
@@ -8,12 +8,9 @@ import {
   Alert,
   Button,
   IconButton,
-  Divider,
   Modal,
   Backdrop,
   Fade,
-  Card,
-  CardContent,
   useMediaQuery,
   useTheme,
   Link,
@@ -34,6 +31,8 @@ import {
   Warning,
   Home,
   Map,
+  ChevronLeft,
+  ChevronRight,
 } from '@mui/icons-material';
 import { useCompetitionSystem } from './hooks/useCompetitionSystem';
 import { useClipboardPaste } from './hooks/useClipboardPaste';
@@ -367,7 +366,7 @@ function AppApi() {
 
   const handlePhotoClick = (photo: ApiPhoto, setKey: 'set1' | 'set2') => {
     const setPhotos = session?.sets[setKey].photos || [];
-    const photoIndex = setPhotos.findIndex(p => p.id === photo.id);
+    const photoIndex = setPhotos.findIndex((p: ApiPhoto) => p.id === photo.id);
     setSelectedPhoto({ photo, setKey, label: computeLabelForSlot(setKey, photoIndex) });
   };
 
@@ -393,7 +392,7 @@ function AppApi() {
       const list = prev.setKey === 'candidates'
         ? (session?.candidates?.photos || [])
         : (session?.sets[prev.setKey]?.photos || []);
-      const idx = list.findIndex(p => p.id === prev.photo.id);
+      const idx = list.findIndex((p: ApiPhoto) => p.id === prev.photo.id);
       if (idx === -1) return prev;
       const nextIdx = idx + dir;
       if (nextIdx < 0 || nextIdx >= list.length) return prev;
@@ -406,7 +405,7 @@ function AppApi() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session, isPrecision, generateLabel]);
 
-  const modalIndex = selectedPhoto ? modalPhotoList.findIndex(p => p.id === selectedPhoto.photo.id) : -1;
+  const modalIndex = selectedPhoto ? modalPhotoList.findIndex((p: ApiPhoto) => p.id === selectedPhoto.photo.id) : -1;
   const canPrev = modalIndex > 0;
   const canNext = modalIndex >= 0 && modalIndex < modalPhotoList.length - 1;
 
@@ -475,7 +474,7 @@ function AppApi() {
     setPendingTPSend(null);
     // Only place if the candidate is still in the pool (it may have been moved
     // or deleted between the mode switch and this effect firing).
-    if (session.candidates?.photos?.some(p => p.id === photoId)) {
+    if (session.candidates?.photos?.some((p: ApiPhoto) => p.id === photoId)) {
       void handleSendCandidateToSet(photoId, 'set1');
     }
   // handleSendCandidateToSet closes over the fresh post-switch session; keying
@@ -957,6 +956,10 @@ function AppApi() {
             onSetFlag={(photoId, flag) => { if (setCandidateFlag) void setCandidateFlag(photoId, flag); }}
             onDelete={(photoId) => { if (removeCandidate) void removeCandidate(photoId); }}
             onSendToSet={handleSendCandidateToSet}
+            // Track mode only — in turning-point mode set1/set2 ARE the TP photos,
+            // so the extra button would be redundant (CandidateTray hides it when
+            // onSendToTP is undefined).
+            onSendToTP={session?.mode === 'turningpoint' ? undefined : handleSendCandidateToTP}
             onSlotDroppedIn={handleSlotDroppedToTray}
             hideSet2={isPrecision && session?.mode === 'track'}
           />
@@ -1333,6 +1336,34 @@ function AppApi() {
                         >
                           {selectedPhoto.photo.filename}
                         </Typography>
+                      )}
+                      {/* Prev/next navigation within the same set/pool. Mirrors
+                          the ArrowLeft/ArrowRight keyboard shortcuts; hidden when
+                          the set has a single photo. Clamps at both ends. */}
+                      {modalPhotoList.length > 1 && (
+                        <Box sx={{ mt: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <IconButton
+                            size="small"
+                            onClick={() => navigateModalPhoto(-1)}
+                            disabled={!canPrev}
+                            aria-label={t('modal.prevPhoto')}
+                            title={t('modal.prevPhoto')}
+                          >
+                            <ChevronLeft />
+                          </IconButton>
+                          <Typography variant="caption" color="text.secondary" sx={{ minWidth: 48, textAlign: 'center' }}>
+                            {modalIndex + 1} / {modalPhotoList.length}
+                          </Typography>
+                          <IconButton
+                            size="small"
+                            onClick={() => navigateModalPhoto(1)}
+                            disabled={!canNext}
+                            aria-label={t('modal.nextPhoto')}
+                            title={t('modal.nextPhoto')}
+                          >
+                            <ChevronRight />
+                          </IconButton>
+                        </Box>
                       )}
                     </Box>
 

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -630,7 +630,7 @@ function AppApi() {
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', pb: 4 }}>
-      <Container maxWidth={false} sx={{ pt: 4, px: { xs: 2, sm: 3, md: 4, lg: 5 }, maxWidth: { xl: '75%' }, mx: { xl: 'auto' } }}>
+      <Container maxWidth={false} sx={{ pt: 4, px: { xs: 2, sm: 3, md: 4, lg: 5 } }}>
         {/* Unified Header and Controls */}
         <Paper elevation={2} sx={{ mb: 3, borderRadius: 2, overflow: 'hidden' }}>
           {/* Blue Header Section */}
@@ -652,6 +652,21 @@ function AppApi() {
                   <Home />
                 </IconButton>
               )}
+              {isDesktopManaged && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  onClick={() => {
+                    const params = new URLSearchParams(window.location.search);
+                    const compId = params.get('competitionId');
+                    (window as any).electronAPI?.navigateToApp('map-corridors', compId);
+                  }}
+                  startIcon={<Map sx={{ fontSize: 18 }} />}
+                  sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)', textTransform: 'none', mr: 1.5, '&:hover': { borderColor: 'white', bgcolor: 'rgba(255,255,255,0.1)' } }}
+                >
+                  {t('app.switchToPlacement')}
+                </Button>
+              )}
               <FlightTakeoff sx={{ fontSize: 32, color: 'white', mr: 1.5 }} />
               <Typography variant="h5" component="h1" sx={{ color: 'white', fontWeight: 600 }}>
                 {t('app.title')}
@@ -660,20 +675,6 @@ function AppApi() {
                 <Chip label={currentCompetition.name} size="small" sx={{ ml: 2, bgcolor: 'rgba(255,255,255,0.2)', color: 'white' }} />
               )}
             </Box>
-            {isDesktopManaged && (
-              <IconButton
-                size="small"
-                onClick={() => {
-                  const params = new URLSearchParams(window.location.search);
-                  const compId = params.get('competitionId');
-                  (window as any).electronAPI?.navigateToApp('map-corridors', compId);
-                }}
-                sx={{ color: 'white' }}
-                title={t('app.switchToPlacement') || 'Photo Placement'}
-              >
-                <Map />
-              </IconButton>
-            )}
           </Box>
 
           {/* White Content Section */}
@@ -1158,7 +1159,7 @@ function AppApi() {
 
       {/* Footer */}
       <Box component="footer" sx={{ py: 2, mt: 4, bgcolor: 'background.default' }}>
-        <Container maxWidth={false} sx={{ px: { xs: 2, sm: 3, md: 4, lg: 5 }, maxWidth: { xl: '75%' }, mx: { xl: 'auto' } }}>
+        <Container maxWidth={false} sx={{ px: { xs: 2, sm: 3, md: 4, lg: 5 } }}>
           <Box sx={{ p: 2, borderRadius: 2, bgcolor: '#1565C0' }}>
             <Typography variant="body2" align="center" sx={{ color: 'common.white' }}>
               {t('footer.copy', { year: new Date().getFullYear(), name: 'Lukáš Běhounek' })} {' '}

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -344,12 +344,10 @@ function AppApi() {
   // just grid columns within landscape — but can be re-evaluated if it also
   // feels confusing.)
 
-  const handlePhotoClick = (photo: ApiPhoto, setKey: 'set1' | 'set2') => {
-    const setPhotos = session?.sets[setKey].photos || [];
-    const photoIndex = setPhotos.findIndex(p => p.id === photo.id);
-
-    // Calculate label based on mode
-    let label: string;
+  // Label for a slotted photo at a given index in set1/set2, mirroring the grid
+  // labels (mode-aware). Extracted so photo-click AND modal prev/next nav share
+  // one source of truth. Candidate (tray) photos have no slot index → ''.
+  const computeLabelForSlot = (setKey: 'set1' | 'set2', photoIndex: number): string => {
     if (session?.mode === 'turningpoint') {
       // Turning point mode: SP, TP1, TP2, ..., FP
       const set1Count = session.sets.set1.photos.length;
@@ -357,27 +355,20 @@ function AppApi() {
       // (keeps SP/TP/FP sequence anchored to the single visible grid).
       const set2Count = isPrecision ? 0 : session.sets.set2.photos.length;
       const turningPointLabels = generateTurningPointLabels(set1Count, set2Count, session.layoutMode || 'landscape');
-      
-      if (setKey === 'set1') {
-        label = turningPointLabels.set1[photoIndex] || 'X';
-      } else {
-        label = turningPointLabels.set2[photoIndex] || 'X';
-      }
-    } else {
-      // Track mode: use labeling context (letters or numbers) with offset
-      if (setKey === 'set1') {
-        label = generateLabel(photoIndex);
-      } else {
-        const set1Count = session?.sets.set1?.photos?.length || 0;
-        label = generateLabel(photoIndex, set1Count); // Continue sequence from Set 1
-      }
+      return (setKey === 'set1' ? turningPointLabels.set1[photoIndex] : turningPointLabels.set2[photoIndex]) || 'X';
     }
+    // Track mode: use labeling context (letters or numbers) with offset
+    if (setKey === 'set1') {
+      return generateLabel(photoIndex);
+    }
+    const set1Count = session?.sets.set1?.photos?.length || 0;
+    return generateLabel(photoIndex, set1Count); // Continue sequence from Set 1
+  };
 
-    setSelectedPhoto({
-      photo,
-      setKey,
-      label
-    });
+  const handlePhotoClick = (photo: ApiPhoto, setKey: 'set1' | 'set2') => {
+    const setPhotos = session?.sets[setKey].photos || [];
+    const photoIndex = setPhotos.findIndex(p => p.id === photo.id);
+    setSelectedPhoto({ photo, setKey, label: computeLabelForSlot(setKey, photoIndex) });
   };
 
   // Click handler for tray thumbs — opens the same editor modal, label is
@@ -385,6 +376,50 @@ function AppApi() {
   const handleCandidateClick = (photo: ApiPhoto) => {
     setSelectedPhoto({ photo, setKey: 'candidates', label: '' });
   };
+
+  // The ordered photo list the modal navigates within — the set/pool the
+  // currently-open photo came from. Used by prev/next arrows + arrow keys.
+  const modalPhotoList: ApiPhoto[] = selectedPhoto
+    ? (selectedPhoto.setKey === 'candidates'
+        ? (session?.candidates?.photos || [])
+        : (session?.sets[selectedPhoto.setKey]?.photos || []))
+    : [];
+
+  // Step to the previous/next photo within the same set/pool. Clamps at the
+  // ends (no wrap), regenerating the label for slotted photos.
+  const navigateModalPhoto = useCallback((dir: -1 | 1) => {
+    setSelectedPhoto(prev => {
+      if (!prev) return prev;
+      const list = prev.setKey === 'candidates'
+        ? (session?.candidates?.photos || [])
+        : (session?.sets[prev.setKey]?.photos || []);
+      const idx = list.findIndex(p => p.id === prev.photo.id);
+      if (idx === -1) return prev;
+      const nextIdx = idx + dir;
+      if (nextIdx < 0 || nextIdx >= list.length) return prev;
+      const nextPhoto = list[nextIdx];
+      const label = prev.setKey === 'candidates' ? '' : computeLabelForSlot(prev.setKey, nextIdx);
+      return { photo: nextPhoto, setKey: prev.setKey, label };
+    });
+  // computeLabelForSlot closes over session/isPrecision/generateLabel; session
+  // is the meaningful dependency for the list + label recompute.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session, isPrecision, generateLabel]);
+
+  const modalIndex = selectedPhoto ? modalPhotoList.findIndex(p => p.id === selectedPhoto.photo.id) : -1;
+  const canPrev = modalIndex > 0;
+  const canNext = modalIndex >= 0 && modalIndex < modalPhotoList.length - 1;
+
+  // Arrow-key navigation while the modal is open.
+  useEffect(() => {
+    if (!selectedPhoto) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); navigateModalPhoto(-1); }
+      else if (e.key === 'ArrowRight') { e.preventDefault(); navigateModalPhoto(1); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectedPhoto, navigateModalPhoto]);
 
   // Tray → slot promotion. The hook handles swap-on-occupied semantics and the
   // capacity clamp for out-of-range indices (PR #62 review C1). Errors are

--- a/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
+++ b/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
@@ -172,15 +172,13 @@ describe('CandidateTray — populated state', () => {
     expect(screen.getByTestId('mock-editor-c')).toBeInTheDocument();
   });
 
-  it('toggling Hide Rejected removes rejected photos from the DOM', () => {
+  // The "Hide rejects" toggle is part of the pick/reject workflow now hidden
+  // from the candidate tray (SHOW_CANDIDATE_FLAG_UI = false, feedback
+  // 2026-05-30). The filtering logic is retained and unit-tested in
+  // candidateFilter; here we assert the toggle UI is gone.
+  it('does not render the "Hide rejects" toggle', () => {
     renderTray({ photos: [p('a', 'pick'), p('b', 'reject'), p('c')] });
-    // Find the toggle switch — the FormControlLabel wraps a label with the
-    // i18n string. Clicking the visible label flips the control.
-    const toggleLabel = screen.getByText('candidates.hideRejects');
-    fireEvent.click(toggleLabel);
-    expect(screen.getByTestId('mock-editor-a')).toBeInTheDocument();
-    expect(screen.queryByTestId('mock-editor-b')).not.toBeInTheDocument();
-    expect(screen.getByTestId('mock-editor-c')).toBeInTheDocument();
+    expect(screen.queryByText('candidates.hideRejects')).not.toBeInTheDocument();
   });
 
   it('fires onSendToSet when a "Send to Set 1" toolbar button is clicked', () => {
@@ -192,20 +190,18 @@ describe('CandidateTray — populated state', () => {
     expect(onSendToSet).toHaveBeenCalledWith('photo-X', 'set1');
   });
 
-  it('fires onSetFlag with "pick" when star button is clicked on a neutral photo', () => {
-    const onSetFlag = vi.fn();
-    renderTray({ photos: [p('photo-X')], onSetFlag });
-    const pickButtons = screen.getAllByLabelText('candidates.flag.pick');
-    fireEvent.click(pickButtons[pickButtons.length - 1]);
-    expect(onSetFlag).toHaveBeenCalledWith('photo-X', 'pick');
+  // Per-thumb star (pick) / block (reject) buttons are intentionally hidden
+  // (SHOW_CANDIDATE_FLAG_UI = false) — that selection workflow moved to the Map
+  // Corridors app (feedback 2026-05-30). onSetFlag remains on the props so the
+  // capability can be re-enabled; these assert the buttons are not rendered.
+  it('does not render the star (pick) flag button', () => {
+    renderTray({ photos: [p('photo-X')] });
+    expect(screen.queryByLabelText('candidates.flag.pick')).not.toBeInTheDocument();
   });
 
-  it('fires onSetFlag with "neutral" when star button is clicked on an already-picked photo', () => {
-    const onSetFlag = vi.fn();
-    renderTray({ photos: [p('photo-X', 'pick')], onSetFlag });
-    const pickButtons = screen.getAllByLabelText('candidates.flag.pick');
-    fireEvent.click(pickButtons[pickButtons.length - 1]);
-    expect(onSetFlag).toHaveBeenCalledWith('photo-X', 'neutral');
+  it('does not render the block (reject) flag button', () => {
+    renderTray({ photos: [p('photo-X')] });
+    expect(screen.queryByLabelText('candidates.flag.reject')).not.toBeInTheDocument();
   });
 
   it('fires onDelete when delete button is clicked', () => {

--- a/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
+++ b/frontend/photo-helper/src/__tests__/CandidateTray.test.tsx
@@ -190,6 +190,21 @@ describe('CandidateTray — populated state', () => {
     expect(onSendToSet).toHaveBeenCalledWith('photo-X', 'set1');
   });
 
+  // "Send to TP photos" — only rendered when onSendToTP is provided (AppApi
+  // passes it in track mode; in turning-point mode set1/set2 are already TP).
+  it('does not render the "Send to TP" button when onSendToTP is absent', () => {
+    renderTray({ photos: [p('photo-X')] });
+    expect(screen.queryByLabelText('candidates.sendToTP')).not.toBeInTheDocument();
+  });
+
+  it('fires onSendToTP when the "Send to TP" toolbar button is clicked', () => {
+    const onSendToTP = vi.fn();
+    renderTray({ photos: [p('photo-X')], onSendToTP });
+    const tpButtons = screen.getAllByLabelText('candidates.sendToTP');
+    fireEvent.click(tpButtons[tpButtons.length - 1]);
+    expect(onSendToTP).toHaveBeenCalledWith('photo-X');
+  });
+
   // Per-thumb star (pick) / block (reject) buttons are intentionally hidden
   // (SHOW_CANDIDATE_FLAG_UI = false) — that selection workflow moved to the Map
   // Corridors app (feedback 2026-05-30). onSetFlag remains on the props so the

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -52,6 +52,14 @@ export interface CandidateTrayProps {
   onDelete: (photoId: string) => void;
   onSendToSet: (photoId: string, setKey: 'set1' | 'set2') => void;
   /**
+   * Send a candidate to the turning-point ("TP photos") set. When provided, a
+   * dedicated TP button shows on each thumb. AppApi switches the editor to
+   * turning-point mode and places the photo there. Omitted (undefined) when
+   * already in turning-point mode — set1/set2 are the TP photos then, so the
+   * extra button would be redundant.
+   */
+  onSendToTP?: (photoId: string) => void;
+  /**
    * Called when a slot photo is dropped into the tray. Receives the parsed
    * dataTransfer payload. If the payload is a slot drop, AppApi demotes it.
    */
@@ -70,6 +78,7 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
   onSetFlag,
   onDelete,
   onSendToSet,
+  onSendToTP,
   onSlotDroppedIn,
   hideSet2,
 }) => {
@@ -311,6 +320,7 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
               onSetFlag={(flag) => onSetFlag(photo.id, flag)}
               onDelete={() => onDelete(photo.id)}
               onSendToSet={(setKey) => onSendToSet(photo.id, setKey)}
+              onSendToTP={onSendToTP ? () => onSendToTP(photo.id) : undefined}
             />
           ))}
           {visiblePhotos.length === 0 && (
@@ -359,6 +369,7 @@ interface CandidateThumbProps {
   onSetFlag: (flag: CandidateFlag) => void;
   onDelete: () => void;
   onSendToSet: (setKey: 'set1' | 'set2') => void;
+  onSendToTP?: () => void;
 }
 const CandidateThumb: React.FC<CandidateThumbProps> = ({
   photo,
@@ -368,6 +379,7 @@ const CandidateThumb: React.FC<CandidateThumbProps> = ({
   onSetFlag,
   onDelete,
   onSendToSet,
+  onSendToTP,
 }) => {
   const theme = useTheme();
   const { t } = useI18n();
@@ -518,6 +530,15 @@ const CandidateThumb: React.FC<CandidateThumbProps> = ({
               <KeyboardDoubleArrowRight sx={{ fontSize: 14 }} />2
             </Box>,
             () => onSendToSet('set2'),
+          )}
+          {onSendToTP && tbBtn(
+            t('candidates.sendToTP'),
+            false,
+            'primary',
+            <Box sx={{ display: 'flex', alignItems: 'center', fontSize: 11, fontWeight: 700 }}>
+              <KeyboardDoubleArrowRight sx={{ fontSize: 14 }} />TP
+            </Box>,
+            () => onSendToTP(),
           )}
           {tbBtn(
             t('common.delete'),

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -37,6 +37,13 @@ import { filterCandidates, countByFlag } from '../utils/candidateFilter';
 import { parseDragPayload, serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
 import type { ApiPhoto, CandidateFlag } from '../types/api';
 
+// Pick (star) / reject (block) flagging in the candidate tray is intentionally
+// hidden: that selection workflow now lives in the Map Corridors app, and
+// surfacing it here too confused users (feedback 2026-05-30). The code paths
+// (onSetFlag, flag state, candidateFilter) are kept intact — flip this to
+// re-enable the per-thumb star/block toolbar buttons.
+const SHOW_CANDIDATE_FLAG_UI = false;
+
 export interface CandidateTrayProps {
   photos: ApiPhoto[];
   onAddFiles: (files: File[]) => void;
@@ -215,23 +222,29 @@ export const CandidateTray: React.FC<CandidateTrayProps> = ({
         <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
           {t('candidates.title', { count: counts.total })}
         </Typography>
-        <Box sx={{ display: 'flex', gap: 1, ml: 1, flexWrap: 'wrap' }}>
-          <CountChip icon={<Star sx={{ fontSize: 14 }} />} count={counts.pick} color="warning" />
-          <CountChip count={counts.neutral} color="default" />
-          <CountChip icon={<Block sx={{ fontSize: 14 }} />} count={counts.reject} color="error" />
-        </Box>
+        {/* Pick/reject count chips + "Hide rejects" toggle are hidden together
+            with the per-thumb star/block buttons (see SHOW_CANDIDATE_FLAG_UI). */}
+        {SHOW_CANDIDATE_FLAG_UI && (
+          <Box sx={{ display: 'flex', gap: 1, ml: 1, flexWrap: 'wrap' }}>
+            <CountChip icon={<Star sx={{ fontSize: 14 }} />} count={counts.pick} color="warning" />
+            <CountChip count={counts.neutral} color="default" />
+            <CountChip icon={<Block sx={{ fontSize: 14 }} />} count={counts.reject} color="error" />
+          </Box>
+        )}
         <Box sx={{ flex: 1 }} />
-        <FormControlLabel
-          control={
-            <Switch
-              size="small"
-              checked={hideRejects}
-              onChange={(_, v) => setHideRejects(v)}
-            />
-          }
-          label={<Typography variant="caption">{t('candidates.hideRejects')}</Typography>}
-          sx={{ mr: 1 }}
-        />
+        {SHOW_CANDIDATE_FLAG_UI && (
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={hideRejects}
+                onChange={(_, v) => setHideRejects(v)}
+              />
+            }
+            label={<Typography variant="caption">{t('candidates.hideRejects')}</Typography>}
+            sx={{ mr: 1 }}
+          />
+        )}
         <Tooltip title={t('candidates.addMore')}>
           <span>
             <Button
@@ -465,23 +478,26 @@ const CandidateThumb: React.FC<CandidateThumbProps> = ({
           bgcolor: alpha(theme.palette.background.default, 0.6),
         }}
       >
-        {/* Flag toggles */}
-        <Box sx={{ display: 'flex', gap: 0.25 }}>
-          {tbBtn(
-            t('candidates.flag.pick'),
-            isPick,
-            'warning',
-            isPick ? <Star sx={{ fontSize: 16 }} /> : <StarBorder sx={{ fontSize: 16 }} />,
-            () => onSetFlag(isPick ? 'neutral' : 'pick'),
-          )}
-          {tbBtn(
-            t('candidates.flag.reject'),
-            isReject,
-            'error',
-            <Block sx={{ fontSize: 16 }} />,
-            () => onSetFlag(isReject ? 'neutral' : 'reject'),
-          )}
-        </Box>
+        {/* Flag toggles — hidden (see SHOW_CANDIDATE_FLAG_UI). Empty span keeps
+            the space-between layout so "Send to set" stays right-aligned. */}
+        {SHOW_CANDIDATE_FLAG_UI ? (
+          <Box sx={{ display: 'flex', gap: 0.25 }}>
+            {tbBtn(
+              t('candidates.flag.pick'),
+              isPick,
+              'warning',
+              isPick ? <Star sx={{ fontSize: 16 }} /> : <StarBorder sx={{ fontSize: 16 }} />,
+              () => onSetFlag(isPick ? 'neutral' : 'pick'),
+            )}
+            {tbBtn(
+              t('candidates.flag.reject'),
+              isReject,
+              'error',
+              <Block sx={{ fontSize: 16 }} />,
+              () => onSetFlag(isReject ? 'neutral' : 'reject'),
+            )}
+          </Box>
+        ) : <Box />}
 
         {/* Send to set */}
         <Box sx={{ display: 'flex', gap: 0.25 }}>

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -21,7 +21,7 @@
         "description": "Standardní"
       },
       "4:3": {
-        "name": "4:3", 
+        "name": "4:3",
         "description": "Klasický"
       },
       "16:9": {
@@ -39,7 +39,7 @@
       "tooltip": "Rozložení na šířku s 9 fotkami na stránku"
     },
     "portrait": {
-      "name": "Na výšku", 
+      "name": "Na výšku",
       "short": "2×5",
       "description": "10 fotek (mřížka 2×5)",
       "tooltip": "Rozložení na výšku s 10 fotkami na stránku"
@@ -60,7 +60,7 @@
         "description": "A, B, C..."
       },
       "numbers": {
-        "name": "Čísla", 
+        "name": "Čísla",
         "description": "1, 2, 3..."
       }
     }
@@ -72,7 +72,7 @@
       "description": "Standardní fotky navigačního letu s možností náhodného pořadí"
     },
     "turningpoint": {
-      "name": "Fotky otočných bodů", 
+      "name": "Fotky otočných bodů",
       "description": "Sekvenční fotky otočných bodů (SP, TP1-TPx, FP)"
     }
   },
@@ -105,8 +105,7 @@
       "message": "Opravdu chcete smazat \"{{name}}\"?",
       "warning": "Tuto akci nelze vrátit zpět. Všechny fotografie a nastavení budou trvale smazány.",
       "confirm": "Smazat soutěž"
-    }
-    ,
+    },
     "helper": {
       "leaveEmptyForDefault": "Ponechte prázdné pro výchozí pojmenování"
     },
@@ -125,7 +124,7 @@
   },
   "sets": {
     "set1": "Sada 1",
-    "set2": "Sada 2", 
+    "set2": "Sada 2",
     "title": {
       "placeholder": "Zadejte název pro {{setName}}..."
     }
@@ -172,7 +171,7 @@
   "controls": {
     "imageAdjustments": "Úpravy obrázku",
     "brightness": "Jas",
-    "contrast": "Kontrast", 
+    "contrast": "Kontrast",
     "sharpness": "Ostrost",
     "whiteBalance": "Vyvážení bílé",
     "temperature": "Modrá ↔ Žlutá",
@@ -184,7 +183,7 @@
     "resetAll": "Obnovit vše",
     "preview": "Náhled",
     "resetBrightness": "Obnovit jas",
-    "resetContrast": "Obnovit kontrast", 
+    "resetContrast": "Obnovit kontrast",
     "resetSharpness": "Obnovit ostrost",
     "zoom": "Přiblížení",
     "basicColor": "Základní barvy",
@@ -239,8 +238,7 @@
   },
   "storage": {
     "warning": "Volné místo: {{percent}}% · Využito {{used}} / Kvóta {{quota}}",
-    "recheck": "Znovu zkontrolovat"
-    ,
+    "recheck": "Znovu zkontrolovat",
     "status": {
       "critical": "Kritické využití úložiště: {{percent}}%. Zvažte vyčištění starých soutěží.",
       "high": "Vysoké využití úložiště: {{percent}}%. Zvažte brzké vyčištění starých soutěží.",
@@ -311,6 +309,7 @@
     },
     "sendToSet1": "Přesunout do sady 1",
     "sendToSet2": "Přesunout do sady 2",
+    "sendToTP": "Poslat do TP fotek",
     "cleanup": {
       "title": "Smazat nepoužité kandidáty?",
       "message": "Máte {{count}} kandidátských fotografií, které nejsou v žádné sadě. Smazat je a uvolnit přibližně {{size}} MB úložiště?",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -2,7 +2,8 @@
   "app": {
     "title": "Foto editor",
     "subtitle": "Organizujte fotografie z navigačního letu do standardizovaných PDF rozvržení",
-    "backToMenu": "Zpět do hlavního menu"
+    "backToMenu": "Zpět do hlavního menu",
+    "switchToPlacement": "Umístění fotek"
   },
   "navigation": {
     "overview": "Přehled",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -5,6 +5,10 @@
     "backToMenu": "Zpět do hlavního menu",
     "switchToPlacement": "Umístění fotek"
   },
+  "modal": {
+    "prevPhoto": "Předchozí fotka",
+    "nextPhoto": "Další fotka"
+  },
   "navigation": {
     "overview": "Přehled",
     "statistics": "Statistiky"

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -21,7 +21,7 @@
         "description": "Standard"
       },
       "4:3": {
-        "name": "4:3", 
+        "name": "4:3",
         "description": "Classic"
       },
       "16:9": {
@@ -39,7 +39,7 @@
       "tooltip": "Landscape layout with 9 photos per page"
     },
     "portrait": {
-      "name": "Portrait", 
+      "name": "Portrait",
       "short": "2×5",
       "description": "10 photos (2×5 grid)",
       "tooltip": "Portrait layout with 10 photos per page"
@@ -60,7 +60,7 @@
         "description": "A, B, C..."
       },
       "numbers": {
-        "name": "Numbers", 
+        "name": "Numbers",
         "description": "1, 2, 3..."
       }
     }
@@ -72,7 +72,7 @@
       "description": "Standard navigation flight photos with randomizable order"
     },
     "turningpoint": {
-      "name": "Turning Point Photos", 
+      "name": "Turning Point Photos",
       "description": "Sequential turning point photos (SP, TP1-TPx, FP)"
     }
   },
@@ -105,8 +105,7 @@
       "message": "Are you sure you want to delete \"{{name}}\"?",
       "warning": "This action cannot be undone. All photos and settings will be permanently deleted.",
       "confirm": "Delete Competition"
-    }
-    ,
+    },
     "helper": {
       "leaveEmptyForDefault": "Leave empty to use default naming"
     },
@@ -132,7 +131,7 @@
   },
   "upload": {
     "dragDrop": "Drag & drop photos here",
-    "browse": "or click to browse files", 
+    "browse": "or click to browse files",
     "supported": "Supported: JPEG, PNG (max {{maxSize}}MB each)",
     "clickOrDrop": "Click, drop, or paste (Ctrl+V) images",
     "dropImages": "Drop images here",
@@ -172,7 +171,7 @@
   "controls": {
     "imageAdjustments": "Image Adjustments",
     "brightness": "Brightness",
-    "contrast": "Contrast", 
+    "contrast": "Contrast",
     "sharpness": "Sharpness",
     "whiteBalance": "White Balance",
     "temperature": "Blue ↔ Yellow",
@@ -184,7 +183,7 @@
     "resetAll": "Reset All",
     "preview": "Preview",
     "resetBrightness": "Reset brightness",
-    "resetContrast": "Reset contrast", 
+    "resetContrast": "Reset contrast",
     "resetSharpness": "Reset sharpness",
     "zoom": "Zoom",
     "basicColor": "Basic Color",
@@ -206,7 +205,7 @@
       "radius": "Radius",
       "color": "Color",
       "white": "White",
-      "red": "Red", 
+      "red": "Red",
       "yellow": "Yellow",
       "removeCircle": "Remove Circle"
     }
@@ -240,8 +239,7 @@
   },
   "storage": {
     "warning": "Storage free: {{percent}}% · Used {{used}} / Quota {{quota}}",
-    "recheck": "Recheck"
-    ,
+    "recheck": "Recheck",
     "status": {
       "critical": "Critical storage usage: {{percent}}%. Consider cleaning up old competitions.",
       "high": "High storage usage: {{percent}}%. You may want to clean up old competitions soon.",
@@ -312,6 +310,7 @@
     },
     "sendToSet1": "Send to Set 1",
     "sendToSet2": "Send to Set 2",
+    "sendToTP": "Send to TP photos",
     "cleanup": {
       "title": "Delete unused candidates?",
       "message": "You have {{count}} candidate photos that aren't in the final set. Delete them to free ~{{size}} MB of storage?",

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -5,6 +5,10 @@
     "backToMenu": "Back to main menu",
     "switchToPlacement": "Photo Placement"
   },
+  "modal": {
+    "prevPhoto": "Previous photo",
+    "nextPhoto": "Next photo"
+  },
   "navigation": {
     "overview": "Overview",
     "statistics": "Statistics"

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -2,7 +2,8 @@
   "app": {
     "title": "Photo Editor",
     "subtitle": "Organize your navigation flight photos into standardized PDF layouts",
-    "backToMenu": "Back to main menu"
+    "backToMenu": "Back to main menu",
+    "switchToPlacement": "Photo Placement"
   },
   "navigation": {
     "overview": "Overview",


### PR DESCRIPTION
## Summary

UX-pass across both apps + the desktop launcher (feedback 2026-05-30). Five commits on top of the `feat/map-ux-maximize-preview-autofan` work (`d61524a`, included as the branch base).

**Map Corridors**
- Unselected/neutral photo dots now high-contrast **amber** (`#fb8c00`) instead of near-invisible grey.
- **Bigger markers** (12→18px) + a transparent ~38px click/tap halo so they're easier to grab.
- App-switch button moved to the **top-left** as a labelled button ("Editor fotek" / "Photo Editor"); decorative Place pin removed.

**Photo Editor**
- App-switch button moved **top-left** with text ("Umístění fotek" / "Photo Placement").
- Layout **expands full-width** on wide screens (removed the xl 75% cap).
- Candidate-tray **star/deny flagging UI hidden** (`SHOW_CANDIDATE_FLAG_UI`, code retained) — that workflow lives in Map Corridors.
- Photo modal: **prev/next arrows + ArrowLeft/ArrowRight** keyboard nav within the current set/pool.
- New **"Send to TP photos"** candidate-tray button — switches to turning-point mode and places the photo.

**Desktop launcher**
- **Rename an existing competition** (new `competition-rename` IPC + preload bridge + inline form, cs/en i18n).

**Docs**
- `docs/photo-map-culling/track-turning-categorization-plan.md` — hand-off plan for the deferred A3 work (split `pick` → `pick-track`/`pick-turning` + handoff auto-route).

## Not in this PR
- **A3** (track/turning pick categorization) — planned only; see the doc. Highest-risk cross-app change, deferred to a focused session.
- **C3** (rally/precision mode persistence) and **B1** (candidate drag-drop) — verified correct by inspection; the originally-reported symptoms traced to a concurrent branch contamination (since cleaned). Need an interactive build to confirm before any code change.

## Test plan
- [x] map-corridors: `tsc -b` clean · vitest 616 pass + 2 todo
- [x] photo-helper: `tsc --noEmit` clean · vitest 434 pass
- [x] desktop: vitest 63 pass
- [ ] Manual (desktop build): app-switch buttons top-left with labels; marker color/size/click-area on street + satellite; editor full-width on a wide monitor; candidate tray has no star/deny, has "Send to TP photos"; modal prev/next + arrow keys; launcher competition rename round-trips (dropdown label + session.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)