### PR TITLE
fix(deps): patch tmp path-traversal CVE-2026-44705

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.6: ^5.0.6
   protocol-buffers-schema@<3.6.1: 3.6.1
   ip-address@<10.1.1: ^10.1.1
+  tmp@<0.2.6: ^0.2.6
 
 importers:
 
@@ -3911,8 +3912,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   topojson-client@3.1.0:
@@ -8862,9 +8863,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.6
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   topojson-client@3.1.0:
     dependencies:

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -54,3 +54,11 @@ overrides:
   # spanAll/parseMessage), so real-world exposure here is zero — the
   # override is defense-in-depth + cleans the Dependabot alert.
   'ip-address@<10.1.1': '^10.1.1'
+  # CVE-2026-44705 / GHSA-ph9p-34f9-6g65 — path traversal in `tmp` via
+  # unsanitized prefix/postfix/dir options (directory escape). Patched in
+  # 0.2.6. Pulled in transitively (dev only) via electron-builder →
+  # app-builder-lib → @malept/flatpak-bundler → tmp-promise; it runs at
+  # package-build time with internal static values, never user input, so
+  # real-world exposure is nil — the override is defense-in-depth + clears
+  # the Dependabot alert.
+  'tmp@<0.2.6': '^0.2.6'


### PR DESCRIPTION
## Summary

Closes Dependabot alert #149 (high): **GHSA-ph9p-34f9-6g65 / CVE-2026-44705** — path traversal in the `tmp` npm package (< 0.2.6) via unsanitized `prefix`/`postfix`/`dir` options (directory escape).

## Assessment

- `tmp@0.2.5` is a **transitive devDependency only**: `electron-builder → app-builder-lib → @malept/flatpak-bundler → tmp-promise → tmp`.
- It runs at **desktop package-build time** with electron-builder's internal static values — never user input, never in the shipped app.
- **Real-world exposure: nil.** Patching as defense-in-depth and to clear the alert.

## Change

- Adds a conditional override `'tmp@<0.2.6': '^0.2.6'` to `frontend/pnpm-workspace.yaml`, matching the existing security-override convention (caret pin, self-removing once upstream moves on).
- `frontend/pnpm-lock.yaml` now resolves `tmp@0.2.6`.

## Verification

- `pnpm install --frozen-lockfile` passes (lockfile CI-valid).
- `pnpm why tmp` → `tmp@0.2.6`.
- All 12 pre-existing security overrides preserved; diff is `tmp`-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)