### PR TITLE
feat: categorize map picks as track vs turning-point photos #minor

### DIFF
--- a/docs/photo-map-culling/track-turning-categorization-plan.md
+++ b/docs/photo-map-culling/track-turning-categorization-plan.md
@@ -1,6 +1,8 @@
 # Plan: Categorize map picks as Track vs Turning-Point photos
 
-**Status:** NOT STARTED — ready to implement in a fresh session.
+**Status:** IMPLEMENTED (2026-05-30, branch `feat/track-turning-categorization`).
+Green gate: `tsc -b` (map-corridors) + `tsc --noEmit` (photo-helper) clean;
+vitest map-corridors 633 ✓ / photo-helper 436 ✓ / desktop 63 ✓.
 **Owner feedback (2026-05-30):** "it would be good in corridors app, to be able to
 distinguish between track and TP photos by categorizing them to track
 photos/turning photos category, once they are selected" + auto-route those into

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -33,7 +33,7 @@ import { extractStartName, extractEndName } from './corridors/extractStartName'
 import { buildRouteWaypoints } from './corridors/buildRouteWaypoints'
 import { useI18n } from './contexts/I18nContext'
 import { useCorridorSessionOPFS } from './hooks/useCorridorSessionOPFS'
-import type { PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
+import type { PhotoFlag, PhotoLabel, GroundMarker, GroundMarkerType } from './types/markers'
 import { DEFAULT_GROUND_MARKER_TYPE, getLabelsForDiscipline, buildPhotoMarkerKmlName, noGpsPhotoDisplayName, photoMarkerDisplayName } from './types/markers'
 import { importPhotosToStorage } from './photoImport/importPhotosToStorage'
 import type { ImportFailureReason, ImportFailure } from './photoImport/types'
@@ -700,7 +700,7 @@ function App() {
   // Phase 5 photo-popup action handlers. `flag` lives on PhotoMarker as
   // an intermediate until Phase 8 moves the source of truth to
   // map-picks.json — see PhotoMarker type docstring.
-  const setPhotoFlag = useCallback(async (markerId: string, flag: 'pick' | 'reject' | null) => {
+  const setPhotoFlag = useCallback(async (markerId: string, flag: PhotoFlag | null) => {
     await persistMarkers((prev) =>
       prev.map(m => {
         if (m.id !== markerId) return m
@@ -713,8 +713,12 @@ function App() {
     )
   }, [persistMarkers])
 
-  const handlePhotoInclude = useCallback((markerId: string) => {
-    void setPhotoFlag(markerId, 'pick')
+  const handlePhotoIncludeTrack = useCallback((markerId: string) => {
+    void setPhotoFlag(markerId, 'pick-track')
+  }, [setPhotoFlag])
+
+  const handlePhotoIncludeTurning = useCallback((markerId: string) => {
+    void setPhotoFlag(markerId, 'pick-turning')
   }, [setPhotoFlag])
 
   const handlePhotoSkip = useCallback((markerId: string) => {
@@ -790,7 +794,7 @@ function App() {
 
   // Phase 14 — drag-to-recategorize: a row dropped on another group sets its
   // flag. Reuses the same setter the popup buttons use.
-  const handlePhotoSetFlag = useCallback((markerId: string, flag: 'pick' | 'reject' | null) => {
+  const handlePhotoSetFlag = useCallback((markerId: string, flag: PhotoFlag | null) => {
     void setPhotoFlag(markerId, flag)
   }, [setPhotoFlag])
 
@@ -829,7 +833,7 @@ function App() {
   // Commit the provisional placement at the dragged location with the chosen
   // category. Atomic via placeNoGpsPhoto (single persist write); on success the
   // photo leaves "Bez GPS" and becomes a marker.
-  const handleProvisionalCommit = useCallback(async (flag: 'pick' | 'reject' | null) => {
+  const handleProvisionalCommit = useCallback(async (flag: PhotoFlag | null) => {
     const p = provisionalPlacement
     if (!p) return
     setProvisionalPlacement(null)
@@ -1341,7 +1345,8 @@ function App() {
             }}
             photoStorage={storage}
             photoDir={photosDir}
-            onPhotoInclude={handlePhotoInclude}
+            onPhotoIncludeTrack={handlePhotoIncludeTrack}
+            onPhotoIncludeTurning={handlePhotoIncludeTurning}
             onPhotoSkip={handlePhotoSkip}
             onPhotoReject={handlePhotoReject}
             onNoGpsPhotoPlaced={handleNoGpsPhotoPlaced}

--- a/frontend/map-corridors/src/__tests__/activePhoto.test.ts
+++ b/frontend/map-corridors/src/__tests__/activePhoto.test.ts
@@ -13,7 +13,7 @@ function pm(over: Partial<PhotoMarker>): PhotoMarker {
   return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
 }
 
-const pick = pm({ id: 'a', photoId: 'pa', flag: 'pick' })
+const pick = pm({ id: 'a', photoId: 'pa', flag: 'pick-track' })
 const neutral = pm({ id: 'b', photoId: 'pb' })
 const rejected = pm({ id: 'c', photoId: 'pc', flag: 'reject' })
 const kml = pm({ id: 'k', photoId: undefined }) // KML marker, no photoId

--- a/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
@@ -13,7 +13,7 @@ function pm(over: Partial<PhotoMarker>): PhotoMarker {
 }
 
 const markers: PhotoMarker[] = [
-  pm({ id: 'a', photoId: 'a', name: 'a.jpg', flag: 'pick' }),
+  pm({ id: 'a', photoId: 'a', name: 'a.jpg', flag: 'pick-track' }),
   pm({ id: 'b', photoId: 'b', name: 'b.jpg' }), // neutral (no flag)
   pm({ id: 'c', photoId: 'c', name: 'c.jpg', flag: 'reject' }),
 ]

--- a/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
@@ -20,14 +20,17 @@ describe('groupPhotosByFlag', () => {
     expect(g.total).toBe(0)
   })
 
-  it('puts photos in their flag groups', () => {
+  it('puts photos in their flag groups — BOTH pick categories land in picks', () => {
     const markers: PhotoMarker[] = [
-      pm({ id: 'a', photoId: 'pid-a' }),                // neutral
-      pm({ id: 'b', photoId: 'pid-b', flag: 'pick' }),  // pick
-      pm({ id: 'c', photoId: 'pid-c', flag: 'reject' }),// reject
+      pm({ id: 'a', photoId: 'pid-a' }),                        // neutral
+      pm({ id: 'b', photoId: 'pid-b', flag: 'pick-track' }),    // pick (track)
+      pm({ id: 'd', photoId: 'pid-d', flag: 'pick-turning' }),  // pick (turning)
+      pm({ id: 'c', photoId: 'pid-c', flag: 'reject' }),        // reject
     ]
     const g = groupPhotosByFlag(markers, [])
-    expect(g.picks.map(m => m.id)).toEqual(['b'])
+    // Track + turning-point picks both count as "picks"; the category only
+    // matters for the editor handoff, not the 4-group panel.
+    expect(g.picks.map(m => m.id)).toEqual(['b', 'd'])
     expect(g.neutral.map(m => m.id)).toEqual(['a'])
     expect(g.rejects.map(m => m.id)).toEqual(['c'])
   })
@@ -35,7 +38,7 @@ describe('groupPhotosByFlag', () => {
   it('excludes KML/click-placed markers (no photoId) from all groups', () => {
     const markers: PhotoMarker[] = [
       pm({ id: 'kml', photoId: undefined }),
-      pm({ id: 'photo', photoId: 'pid-1', flag: 'pick' }),
+      pm({ id: 'photo', photoId: 'pid-1', flag: 'pick-track' }),
     ]
     const g = groupPhotosByFlag(markers, [])
     expect(g.picks.map(m => m.id)).toEqual(['photo'])
@@ -62,9 +65,9 @@ describe('groupPhotosByFlag', () => {
 
   it('orders each flag group by original filename, numeric-aware', () => {
     const markers: PhotoMarker[] = [
-      pm({ id: 'p10', photoId: 'a', flag: 'pick', name: 'DSC_0010.JPG' }),
-      pm({ id: 'p9', photoId: 'b', flag: 'pick', name: 'DSC_0009.JPG' }),
-      pm({ id: 'p100', photoId: 'c', flag: 'pick', name: 'DSC_0100.JPG' }),
+      pm({ id: 'p10', photoId: 'a', flag: 'pick-track', name: 'DSC_0010.JPG' }),
+      pm({ id: 'p9', photoId: 'b', flag: 'pick-track', name: 'DSC_0009.JPG' }),
+      pm({ id: 'p100', photoId: 'c', flag: 'pick-track', name: 'DSC_0100.JPG' }),
     ]
     const g = groupPhotosByFlag(markers, [])
     expect(g.picks.map(m => m.name)).toEqual(['DSC_0009.JPG', 'DSC_0010.JPG', 'DSC_0100.JPG'])
@@ -72,8 +75,8 @@ describe('groupPhotosByFlag', () => {
 
   it('orders by original filename, NOT by a custom displayName', () => {
     const markers: PhotoMarker[] = [
-      pm({ id: 'z', photoId: 'a', flag: 'pick', name: 'DSC_0002.JPG', displayName: 'AAA' }),
-      pm({ id: 'a', photoId: 'b', flag: 'pick', name: 'DSC_0001.JPG', displayName: 'ZZZ' }),
+      pm({ id: 'z', photoId: 'a', flag: 'pick-track', name: 'DSC_0002.JPG', displayName: 'AAA' }),
+      pm({ id: 'a', photoId: 'b', flag: 'pick-turning', name: 'DSC_0001.JPG', displayName: 'ZZZ' }),
     ]
     const g = groupPhotosByFlag(markers, [])
     // 0001 before 0002 (filename order) — a rename to ZZZ/AAA must not reorder.
@@ -83,7 +86,7 @@ describe('groupPhotosByFlag', () => {
   it('total is the sum across all four groups', () => {
     const g = groupPhotosByFlag(
       [
-        pm({ id: 'p', photoId: 'pid-p', flag: 'pick' }),
+        pm({ id: 'p', photoId: 'pid-p', flag: 'pick-track' }),
         pm({ id: 'n1', photoId: 'pid-n1' }),
         pm({ id: 'n2', photoId: 'pid-n2' }),
         pm({ id: 'r', photoId: 'pid-r', flag: 'reject' }),

--- a/frontend/map-corridors/src/__tests__/handoffRoundTrip.test.ts
+++ b/frontend/map-corridors/src/__tests__/handoffRoundTrip.test.ts
@@ -83,14 +83,15 @@ describe('cross-app round-trip — map writes, editor reads, editor writes back,
   it('map writes a pick → editor side can read it from map-picks.json', async () => {
     const storage = makeStorage()
     const markers: PhotoMarker[] = [
-      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', capturedAt: { lng: 14, lat: 50 } }),
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick-track', capturedAt: { lng: 14, lat: 50 } }),
     ]
     scheduleWriteMapPicks(storage, compDir, buildMapPicks(markers))
     await flushPendingMapPicks()
     const file = storage._files.get('/competitions/comp-1::map-picks.json') as { picks: Array<{ photoId: string; flag: string }> }
     expect(file).toBeTruthy()
     expect(file.picks).toHaveLength(1)
-    expect(file.picks[0]).toMatchObject({ photoId: 'pm-1', flag: 'pick' })
+    // The pick category rides through the handoff as-is (track vs turning).
+    expect(file.picks[0]).toMatchObject({ photoId: 'pm-1', flag: 'pick-track' })
   })
 
   it('editor writes a label → map applies it via syncEditorPicksOnce (newer-wins)', async () => {
@@ -102,7 +103,7 @@ describe('cross-app round-trip — map writes, editor reads, editor writes back,
       picks: [{ photoId: 'pm-1', label: 'B', labelUpdatedAt: '2025-02-01T00:00:00Z' }],
     })
     const markers: PhotoMarker[] = [
-      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick-track', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
     ]
     let updated: PhotoMarker[] = markers
     const setMarkers = async (updater: (prev: readonly PhotoMarker[]) => readonly PhotoMarker[]) => {
@@ -122,7 +123,7 @@ describe('cross-app round-trip — map writes, editor reads, editor writes back,
       picks: [{ photoId: 'pm-1', label: 'remote', labelUpdatedAt: t }],
     })
     const markers: PhotoMarker[] = [
-      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'local' as never, labelUpdatedAt: t }),
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick-track', label: 'local' as never, labelUpdatedAt: t }),
     ]
     let updated: PhotoMarker[] = markers
     const result = await syncEditorPicksOnce(
@@ -141,7 +142,7 @@ describe('cross-app round-trip — map writes, editor reads, editor writes back,
       picks: [{ photoId: 'pm-1', label: '', labelUpdatedAt: '2025-02-01T00:00:00Z' }],
     })
     const markers: PhotoMarker[] = [
-      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick-track', label: 'A' as never, labelUpdatedAt: '2025-01-01T00:00:00Z' }),
     ]
     let updated: PhotoMarker[] = markers
     await syncEditorPicksOnce(storage, compDir, async u => { updated = [...u(updated)] })
@@ -158,7 +159,7 @@ describe('cross-app round-trip — map writes, editor reads, editor writes back,
       ],
     })
     const markers: PhotoMarker[] = [
-      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick' }),
+      pm({ id: 'pm-1', photoId: 'pm-1', flag: 'pick-track' }),
     ]
     let updated: PhotoMarker[] = markers
     const result = await syncEditorPicksOnce(storage, compDir, async u => { updated = [...u(updated)] })

--- a/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
+++ b/frontend/map-corridors/src/__tests__/mapPicksWriter.test.ts
@@ -25,8 +25,9 @@ describe('buildMapPickEntry', () => {
     expect(e.flag).toBe('neutral')
   })
 
-  it('preserves explicit pick/reject', () => {
-    expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'pick' }))!.flag).toBe('pick')
+  it('preserves explicit pick categories + reject (category rides the wire)', () => {
+    expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'pick-track' }))!.flag).toBe('pick-track')
+    expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'pick-turning' }))!.flag).toBe('pick-turning')
     expect(buildMapPickEntry(pm({ photoId: 'pid', flag: 'reject' }))!.flag).toBe('reject')
   })
 
@@ -83,7 +84,7 @@ describe('buildMapPickEntry', () => {
     const e = buildMapPickEntry(pm({
       photoId: 'pid',
       lng: 14, lat: 50,
-      flag: 'pick',
+      flag: 'pick-track',
       // no capturedAt
     }))!
     expect(e.gps?.subjectAt).toEqual({ lng: 14, lat: 50 })
@@ -109,10 +110,10 @@ describe('buildMapPicks', () => {
     // is still tracked on PhotoMarker.flag.
     const result = buildMapPicks([
       pm({ id: 'kml', photoId: undefined }),
-      pm({ id: 'p1', photoId: 'pid-1', flag: 'pick' }),
+      pm({ id: 'p1', photoId: 'pid-1', flag: 'pick-track' }),
       pm({ id: 'p2', photoId: 'pid-2' }), // no flag → neutral → excluded
       pm({ id: 'p3', photoId: 'pid-3', flag: 'reject' }), // excluded
-      pm({ id: 'p4', photoId: 'pid-4', flag: 'pick' }),
+      pm({ id: 'p4', photoId: 'pid-4', flag: 'pick-turning' }), // turning still crosses
     ])
     expect(result.map(e => e.photoId)).toEqual(['pid-1', 'pid-4'])
   })

--- a/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerSanitize.test.ts
@@ -216,8 +216,14 @@ describe('isPhotoMarker — photoId', () => {
 describe('isPhotoMarker — flag', () => {
   const base = { id: 'pm-1', lng: 14, lat: 50, name: 'Test' }
 
-  it.each(['pick', 'reject'])('accepts flag = %s', (flag) => {
+  it.each(['pick-track', 'pick-turning', 'reject'])('accepts flag = %s', (flag) => {
     expect(isPhotoMarker({ ...base, flag })).toBe(true)
+  })
+
+  it('rejects a legacy bare "pick" flag (must be migrated to pick-track BEFORE the guard)', () => {
+    // migrateLegacyPhotoFlag runs first in sanitizePhotoMarkers; the raw guard
+    // itself no longer accepts the pre-split value.
+    expect(isPhotoMarker({ ...base, flag: 'pick' })).toBe(false)
   })
 
   it('accepts absent flag (neutral state)', () => {

--- a/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
@@ -15,8 +15,9 @@ describe('isPhotoMarkerVisible', () => {
     expect(isPhotoMarkerVisible(pm({}))).toBe(true)
   })
 
-  it('shows a picked photo', () => {
-    expect(isPhotoMarkerVisible(pm({ flag: 'pick' }))).toBe(true)
+  it('shows a picked photo (both track and turning categories)', () => {
+    expect(isPhotoMarkerVisible(pm({ flag: 'pick-track' }))).toBe(true)
+    expect(isPhotoMarkerVisible(pm({ flag: 'pick-turning' }))).toBe(true)
   })
 
   it('hides a rejected photo (disappears from the map)', () => {

--- a/frontend/map-corridors/src/__tests__/migrateLegacyPhotoFlag.test.ts
+++ b/frontend/map-corridors/src/__tests__/migrateLegacyPhotoFlag.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { migrateLegacyPhotoFlag, isPhotoMarker, sanitizePhotoMarkers } from '../types/markers'
+
+// A3 (2026-05-30) split the single `pick` flag into `pick-track` / `pick-turning`.
+// A v1 session persisted `flag: 'pick'`; that value is no longer in the guard's
+// accepted set, so the migration MUST run before isPhotoMarker or a previously-
+// picked photo is silently dropped on load. These pin both halves of that trap.
+
+describe('migrateLegacyPhotoFlag', () => {
+  it('rewrites a legacy bare `pick` to `pick-track`', () => {
+    const out = migrateLegacyPhotoFlag({ id: 'pm-1', flag: 'pick' }) as { flag: string }
+    expect(out.flag).toBe('pick-track')
+  })
+
+  it('does not mutate the input object (returns a fresh copy)', () => {
+    const input = { id: 'pm-1', flag: 'pick' as const }
+    const out = migrateLegacyPhotoFlag(input)
+    expect(out).not.toBe(input)
+    expect(input.flag).toBe('pick') // original untouched
+  })
+
+  it.each(['pick-track', 'pick-turning', 'reject'])('leaves a current flag (%s) untouched', (flag) => {
+    const input = { id: 'pm-1', flag }
+    expect(migrateLegacyPhotoFlag(input)).toBe(input) // same reference — no copy
+  })
+
+  it('leaves a marker with no flag (neutral) untouched', () => {
+    const input = { id: 'pm-1' }
+    expect(migrateLegacyPhotoFlag(input)).toBe(input)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['string', 'pick'],
+    ['number', 42],
+  ])('passes non-objects (%s) straight through', (_label, value) => {
+    expect(migrateLegacyPhotoFlag(value)).toBe(value)
+  })
+
+  it('migrated marker passes the isPhotoMarker guard (no data loss on load)', () => {
+    const legacy = { id: 'pm-1', lng: 14, lat: 50, name: 'DSC_0001.JPG', flag: 'pick' }
+    // Pre-migration the legacy value fails the guard…
+    expect(isPhotoMarker(legacy)).toBe(false)
+    // …and migrating first rescues it.
+    const migrated = migrateLegacyPhotoFlag(legacy)
+    expect(isPhotoMarker(migrated)).toBe(true)
+  })
+
+  it('sanitizePhotoMarkers migrates-then-keeps a legacy pick (end-to-end load path)', () => {
+    const out = sanitizePhotoMarkers([
+      { id: 'pm-1', lng: 14, lat: 50, name: 'DSC_0001.JPG', flag: 'pick' },
+    ])
+    expect(out).toHaveLength(1) // not dropped
+    expect(out[0].flag).toBe('pick-track')
+  })
+})

--- a/frontend/map-corridors/src/__tests__/recategorize.test.ts
+++ b/frontend/map-corridors/src/__tests__/recategorize.test.ts
@@ -6,7 +6,7 @@ import { flagForGroup, canRecategorize } from '../recategorize/recategorize'
 // rejected so the drop handler can no-op cleanly.
 
 describe('flagForGroup', () => {
-  it('picks → pick', () => expect(flagForGroup('picks')).toBe('pick'))
+  it('picks → pick-track (default category; re-categorize to turning via popup)', () => expect(flagForGroup('picks')).toBe('pick-track'))
   it('rejects → reject', () => expect(flagForGroup('rejects')).toBe('reject'))
   it('neutral → null (flag cleared)', () => expect(flagForGroup('neutral')).toBeNull())
   it('noGps → undefined (not a recategorize target)', () => expect(flagForGroup('noGps')).toBeUndefined())

--- a/frontend/map-corridors/src/__tests__/resolveVariantFlags.test.ts
+++ b/frontend/map-corridors/src/__tests__/resolveVariantFlags.test.ts
@@ -14,20 +14,30 @@ function pm(over: Partial<PhotoMarker>): PhotoMarker {
 }
 
 describe('resolveVariantFlags', () => {
-  it('promotes the winner to pick and demotes losers to reject', () => {
+  it('promotes a previously-uncategorized winner to pick-track and demotes losers to reject', () => {
     const markers = [
       pm({ id: 'a', photoId: 'a' }),
       pm({ id: 'b', photoId: 'b' }),
       pm({ id: 'c', photoId: 'c' }),
     ]
     const out = resolveVariantFlags(markers, 'b', ['a', 'c'])
-    expect(out.find(m => m.id === 'b')!.flag).toBe('pick')
+    expect(out.find(m => m.id === 'b')!.flag).toBe('pick-track')
     expect(out.find(m => m.id === 'a')!.flag).toBe('reject')
     expect(out.find(m => m.id === 'c')!.flag).toBe('reject')
   })
 
+  it('preserves the winner\'s existing pick-turning category instead of forcing track', () => {
+    const markers = [
+      pm({ id: 'a', photoId: 'a', flag: 'pick-turning' }),
+      pm({ id: 'b', photoId: 'b' }),
+    ]
+    const out = resolveVariantFlags(markers, 'a', ['b'])
+    expect(out.find(m => m.id === 'a')!.flag).toBe('pick-turning')
+    expect(out.find(m => m.id === 'b')!.flag).toBe('reject')
+  })
+
   it('leaves markers outside the variant set untouched (same reference)', () => {
-    const bystander = pm({ id: 'z', photoId: 'z', flag: 'pick', label: 'A' as never })
+    const bystander = pm({ id: 'z', photoId: 'z', flag: 'pick-track', label: 'A' as never })
     const markers = [pm({ id: 'a', photoId: 'a' }), pm({ id: 'b', photoId: 'b' }), bystander]
     const out = resolveVariantFlags(markers, 'a', ['b'])
     // Identity-preserved: a bystander marker is returned by reference, not cloned.
@@ -50,6 +60,6 @@ describe('resolveVariantFlags', () => {
 
   it('handles the 2-variant case (one winner, one loser)', () => {
     const out = resolveVariantFlags([pm({ id: 'a', photoId: 'a' }), pm({ id: 'b', photoId: 'b' })], 'a', ['b'])
-    expect(out.map(m => m.flag)).toEqual(['pick', 'reject'])
+    expect(out.map(m => m.flag)).toEqual(['pick-track', 'reject'])
   })
 })

--- a/frontend/map-corridors/src/__tests__/sharedHandoffGuards.test.ts
+++ b/frontend/map-corridors/src/__tests__/sharedHandoffGuards.test.ts
@@ -10,6 +10,7 @@ import {
   isMapPickEntry,
   isMapPicksFile,
   isWireFlag,
+  isPickFlag,
   MAP_PICKS_FILENAME,
   EDITOR_PICKS_FILENAME,
   PM_PHOTO_ID_PREFIX,
@@ -42,6 +43,27 @@ describe('isWireFlag', () => {
     ['object', { kind: 'pick' }],
   ])('rejects %s', (_label, v) => {
     expect(isWireFlag(v)).toBe(false)
+  })
+})
+
+describe('isPickFlag', () => {
+  // Single source of truth for "is this a pick" across both apps — guards
+  // against stale `flag === 'pick'` comparisons surviving the A3 split.
+  it.each(['pick', 'pick-track', 'pick-turning'])('accepts pick category %s', (f) => {
+    expect(isPickFlag(f)).toBe(true)
+  })
+
+  it.each([
+    ['neutral', 'neutral'],
+    ['reject', 'reject'],
+    ['empty string', ''],
+    ['unknown string', 'archived'],
+    ['number', 1],
+    ['null', null],
+    ['undefined', undefined],
+    ['object', { kind: 'pick' }],
+  ])('rejects %s', (_label, v) => {
+    expect(isPickFlag(v)).toBe(false)
   })
 })
 

--- a/frontend/map-corridors/src/__tests__/sharedHandoffGuards.test.ts
+++ b/frontend/map-corridors/src/__tests__/sharedHandoffGuards.test.ts
@@ -27,7 +27,9 @@ describe('constants — wire contract', () => {
 })
 
 describe('isWireFlag', () => {
-  it.each(['pick', 'neutral', 'reject'])('accepts %s', (f) => {
+  // Bare `pick` retained for back-compat with legacy map-picks.json (pre-split);
+  // `pick-track`/`pick-turning` are the categorized values new writes emit.
+  it.each(['pick', 'pick-track', 'pick-turning', 'neutral', 'reject'])('accepts %s', (f) => {
     expect(isWireFlag(f)).toBe(true)
   })
 

--- a/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
+++ b/frontend/map-corridors/src/components/PhotoMarkerPopup.tsx
@@ -4,10 +4,12 @@
 // MapProviderView ignorant of storage.
 
 import { Box, Button, CircularProgress, Stack, Typography } from '@mui/material'
+import CheckIcon from '@mui/icons-material/Check'
+import FlagIcon from '@mui/icons-material/Flag'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
-import type { PhotoLabel } from '../types/markers'
+import type { PhotoFlag, PhotoLabel } from '../types/markers'
 import { ALL_PHOTO_LABELS } from '../types/markers'
 
 export interface PhotoMarkerPopupProps {
@@ -33,7 +35,16 @@ export interface PhotoMarkerPopupProps {
   usedLabels?: readonly string[]
   onLabelChange?: (label: PhotoLabel) => void
   onLabelClear?: () => void
-  onInclude: () => void
+  /**
+   * Current pick category of the marker, used to highlight the active
+   * Track / Turning-point button. Absent for an un-categorized photo (e.g. a
+   * provisional no-GPS placement that hasn't been committed yet).
+   */
+  flag?: PhotoFlag
+  /** Pick as a TRACK photo (blue). Routes to the editor's track print set. */
+  onIncludeTrack: () => void
+  /** Pick as a TURNING-POINT photo (purple). Routes to the editor's TP set. */
+  onIncludeTurning: () => void
   onSkip: () => void
   onReject: () => void
   /**
@@ -78,6 +89,8 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
   const { t } = useI18n()
   const { photoId, filename, originalFilename, timestamp, storage, photosDir } = props
   const { url: thumbUrl, state: loadState } = usePhotoThumbUrl(storage, photosDir, photoId)
+  const isPickTrack = props.flag === 'pick-track'
+  const isPickTurning = props.flag === 'pick-turning'
 
   return (
     <Box sx={{ minWidth: THUMB_WIDTH_PX + 16 }}>
@@ -124,11 +137,26 @@ export function PhotoMarkerPopup(props: PhotoMarkerPopupProps) {
           {timestamp}
         </Typography>
       )}
-      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-        <Button size="small" variant="contained" onClick={props.onInclude}>
-          {t('photo.popup.include')}
+      <Stack direction="row" spacing={1} sx={{ mt: 1, flexWrap: 'wrap', gap: 1 }}>
+        <Button
+          size="small"
+          variant={isPickTrack ? 'contained' : 'outlined'}
+          color={isPickTrack ? 'primary' : 'inherit'}
+          startIcon={<CheckIcon />}
+          onClick={props.onIncludeTrack}
+        >
+          {t('photo.popup.pickTrack')}
         </Button>
-        <Button size="small" variant="outlined" onClick={props.onSkip}>
+        <Button
+          size="small"
+          variant={isPickTurning ? 'contained' : 'outlined'}
+          color={isPickTurning ? 'secondary' : 'inherit'}
+          startIcon={<FlagIcon />}
+          onClick={props.onIncludeTurning}
+        >
+          {t('photo.popup.pickTurning')}
+        </Button>
+        <Button size="small" variant="outlined" color="inherit" onClick={props.onSkip}>
           {t('photo.popup.skip')}
         </Button>
         <Button size="small" variant="outlined" color="error" onClick={props.onReject}>

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -2,6 +2,7 @@
 // Pure function so the component itself stays thin and the grouping logic
 // is testable without mounting React.
 
+import { isPickFlag } from '@airq/shared-handoff'
 import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { compareFilenames, compareNoGpsPhotos } from '../types/markers'
 
@@ -34,7 +35,7 @@ export function groupPhotosByFlag(
     if (!m.photoId) continue // KML markers don't belong in the photo list
     // Both pick categories (track + turning-point) count as "picks" — the
     // 4-group panel stays; the category only matters for the editor handoff.
-    if (m.flag === 'pick-track' || m.flag === 'pick-turning') picks.push(m)
+    if (isPickFlag(m.flag)) picks.push(m)
     else if (m.flag === 'reject') rejects.push(m)
     else neutral.push(m)
   }

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -6,7 +6,7 @@ import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { compareFilenames, compareNoGpsPhotos } from '../types/markers'
 
 export interface GroupedPhotos {
-  /** Photo markers with `flag === 'pick'`. Includes label-less picks. */
+  /** Photo markers picked as track OR turning-point. Includes label-less picks. */
   picks: readonly PhotoMarker[]
   /** Photo markers with no flag and no label. */
   neutral: readonly PhotoMarker[]
@@ -32,7 +32,9 @@ export function groupPhotosByFlag(
   const rejects: PhotoMarker[] = []
   for (const m of markers) {
     if (!m.photoId) continue // KML markers don't belong in the photo list
-    if (m.flag === 'pick') picks.push(m)
+    // Both pick categories (track + turning-point) count as "picks" — the
+    // 4-group panel stays; the category only matters for the editor handoff.
+    if (m.flag === 'pick-track' || m.flag === 'pick-turning') picks.push(m)
     else if (m.flag === 'reject') rejects.push(m)
     else neutral.push(m)
   }

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -16,6 +16,7 @@
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import {
   MAP_PICKS_FILENAME,
+  isPickFlag,
   type MapPickEntry,
   type MapPicksFile,
 } from '@airq/shared-handoff'
@@ -94,7 +95,7 @@ export function buildMapPicks(markers: readonly PhotoMarker[]): MapPickEntry[] {
     // Both pick categories cross the handoff; the category (`pick-track` /
     // `pick-turning`) rides through as-is on `entry.flag` so the editor can
     // route the photo into the right print set.
-    if (m.flag !== 'pick-track' && m.flag !== 'pick-turning') continue
+    if (!isPickFlag(m.flag)) continue
     const entry = buildMapPickEntry(m)
     if (entry) out.push(entry)
   }

--- a/frontend/map-corridors/src/handoff/mapPicksWriter.ts
+++ b/frontend/map-corridors/src/handoff/mapPicksWriter.ts
@@ -91,7 +91,10 @@ export function buildMapPickEntry(marker: PhotoMarker): MapPickEntry | null {
 export function buildMapPicks(markers: readonly PhotoMarker[]): MapPickEntry[] {
   const out: MapPickEntry[] = []
   for (const m of markers) {
-    if (m.flag !== 'pick') continue
+    // Both pick categories cross the handoff; the category (`pick-track` /
+    // `pick-turning`) rides through as-is on `entry.flag` so the editor can
+    // route the photo into the right print set.
+    if (m.flag !== 'pick-track' && m.flag !== 'pick-turning') continue
     const entry = buildMapPickEntry(m)
     if (entry) out.push(entry)
   }

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -104,7 +104,7 @@ export type CorridorsSession = {
   // Photos imported without EXIF GPS (Phase 6 of photo-map-culling,
   // ADR-012). Live here as candidate-pool entries until the user drags
   // one onto the map; on drop, an entry is removed and a PhotoMarker
-  // is appended to `markers` with `flag: 'pick'` at the drop coord.
+  // is appended to `markers` with `flag: 'pick-track'` at the drop coord.
   noGpsPhotos: readonly NoGpsPhoto[]
   // Persisted UI state for the no-GPS photo tray (ADR-012). `true` = open,
   // `false` = collapsed. Defaults open on first run + after migration.
@@ -391,7 +391,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
   // Replaces the previous two-await sequence which could leave the photo
   // duplicated in both lists if the second write failed (quota, transient
   // I/O). Returns true on success, false when the entry isn't found.
-  const placeNoGpsPhoto = useCallback(async (photoId: string, lng: number, lat: number, flag: PhotoFlag | null = 'pick'): Promise<boolean> => {
+  const placeNoGpsPhoto = useCallback(async (photoId: string, lng: number, lat: number, flag: PhotoFlag | null = 'pick-track'): Promise<boolean> => {
     const current = sessionRef.current
     if (!current) return false
     const entry = (current.noGpsPhotos || []).find(p => p.photoId === photoId)
@@ -407,7 +407,7 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
       ...(entry.displayName ? { displayName: entry.displayName } : {}),
       // Phase 14 — caller may commit straight to a chosen category (provisional
       // placement). `null` = neutral, so omit the flag field. Tray drag-drop
-      // keeps the historical default of 'pick'.
+      // defaults to 'pick-track' (the common case; re-categorize via the popup).
       ...(flag ? { flag } : {}),
     }
     await persistSession({

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -38,6 +38,8 @@
     },
     "popup": {
       "include": "Vybrané",
+      "pickTrack": "Fotka trati",
+      "pickTurning": "Fotka otočného bodu",
       "skip": "Neutrální",
       "reject": "Odmítnuté",
       "thumbMissing": "Náhled není k dispozici",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -38,6 +38,8 @@
     },
     "popup": {
       "include": "Picked",
+      "pickTrack": "Track photo",
+      "pickTurning": "Turning-point photo",
       "skip": "Neutral",
       "reject": "Rejected",
       "thumbMissing": "Thumbnail unavailable",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -16,6 +16,7 @@ import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+import { isPickFlag } from '@airq/shared-handoff'
 import { GROUND_MARKER_ICON } from '../components/GroundMarkerIcons'
 import {
   LIVE_GROUND_MARKER_ICON_PX,
@@ -343,7 +344,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       // coords. Both use lng/lat or capturedAt.lng/lat — subject is
       // initialised to capturedAt on import (ADR-007), so for unmoved
       // markers either works. Picks may have been dragged.
-      const center: [number, number] = (marker.flag === 'pick-track' || marker.flag === 'pick-turning')
+      const center: [number, number] = isPickFlag(marker.flag)
         ? [marker.lng, marker.lat]
         : [marker.capturedAt?.lng ?? marker.lng, marker.capturedAt?.lat ?? marker.lat]
       map.flyTo({ center, zoom: Math.max(map.getZoom(), 14), duration: 700 })

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -9,7 +9,7 @@ import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
 import { isPhotoMarkerVisible } from './photoLayers/markerVisibility'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
-import type { PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
+import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { useMarkerFan } from './photoLayers/useMarkerFan'
@@ -94,7 +94,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // have to touch them; absence simply means no photo popup is shown.
   photoStorage?: StorageInterface | null
   photoDir?: DirectoryHandle | null
-  onPhotoInclude?: (markerId: string) => void
+  // Two pick categories — track vs turning-point — so the cross-app handoff
+  // can route the photo into the editor's matching print set (A3, 2026-05-30).
+  onPhotoIncludeTrack?: (markerId: string) => void
+  onPhotoIncludeTurning?: (markerId: string) => void
   onPhotoSkip?: (markerId: string) => void
   onPhotoReject?: (markerId: string) => void
   // Phase 6 — fires when a no-GPS thumbnail from NoGpsTray is dropped
@@ -114,7 +117,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // no placement in progress.
   provisionalPlacement?: { photoId: string; filename: string; lng: number; lat: number } | null
   onProvisionalDrag?: (lng: number, lat: number) => void
-  onProvisionalCommit?: (flag: 'pick' | 'reject' | null) => void
+  onProvisionalCommit?: (flag: PhotoFlag | null) => void
   onProvisionalCancel?: () => void
 }>(function MapProviderView(props, ref) {
   const { mapStyle, mapboxAccessToken, geojsonOverlays } = props
@@ -340,7 +343,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       // coords. Both use lng/lat or capturedAt.lng/lat — subject is
       // initialised to capturedAt on import (ADR-007), so for unmoved
       // markers either works. Picks may have been dragged.
-      const center: [number, number] = marker.flag === 'pick'
+      const center: [number, number] = (marker.flag === 'pick-track' || marker.flag === 'pick-turning')
         ? [marker.lng, marker.lat]
         : [marker.capturedAt?.lng ?? marker.lng, marker.capturedAt?.lat ?? marker.lat]
       map.flyTo({ center, zoom: Math.max(map.getZoom(), 14), duration: 700 })
@@ -704,7 +707,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         // old grey (#616161), which was nearly invisible on both street and
         // satellite basemaps — feedback 2026-05-30 ("brown dots, invisible").
         const ringColor = m.label ? '#facc15'
-          : m.flag === 'pick' ? '#1976d2'
+          : m.flag === 'pick-track' ? '#1976d2'
+          : m.flag === 'pick-turning' ? '#7b1fa2'
           : m.flag === 'reject' ? '#d32f2f'
           : '#fb8c00'
         const bg = moved ? ringColor : '#ffffff'
@@ -955,7 +959,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       {(() => {
         if (!activePhotoMarkerId) return null
         if (!props.photoStorage || !props.photoDir) return null
-        if (!props.onPhotoInclude || !props.onPhotoSkip || !props.onPhotoReject) return null
+        if (!props.onPhotoIncludeTrack || !props.onPhotoIncludeTurning || !props.onPhotoSkip || !props.onPhotoReject) return null
         const marker = props.markers?.find(m => m.id === activePhotoMarkerId)
         if (!marker || !marker.capturedAt || !marker.photoId) return null
         const popupId = activePhotoMarkerId
@@ -985,6 +989,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               filename={marker.displayName ?? marker.name}
               originalFilename={marker.displayName ? marker.name : undefined}
               timestamp={marker.capturedAt.timestamp}
+              flag={marker.flag}
               storage={props.photoStorage}
               photosDir={props.photoDir}
               label={marker.label}
@@ -992,10 +997,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               usedLabels={props.usedLabels}
               onLabelChange={(L) => props.onMarkerLabelChange?.(popupId, L)}
               onLabelClear={() => props.onMarkerLabelClear?.(popupId)}
-              onInclude={() => {
-                props.onPhotoInclude?.(popupId)
-                // Keep the popup open after Include — user often wants
-                // to assign a label right after picking. Was: closed.
+              onIncludeTrack={() => {
+                props.onPhotoIncludeTrack?.(popupId)
+                // Keep the popup open after picking — user often wants
+                // to assign a label right after. Was: closed.
+              }}
+              onIncludeTurning={() => {
+                props.onPhotoIncludeTurning?.(popupId)
               }}
               onSkip={() => {
                 props.onPhotoSkip?.(popupId)
@@ -1053,7 +1061,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
                 filename={prov.filename}
                 storage={props.photoStorage}
                 photosDir={props.photoDir}
-                onInclude={() => props.onProvisionalCommit?.('pick')}
+                onIncludeTrack={() => props.onProvisionalCommit?.('pick-track')}
+                onIncludeTurning={() => props.onProvisionalCommit?.('pick-turning')}
                 onSkip={() => props.onProvisionalCommit?.(null)}
                 onReject={() => props.onProvisionalCommit?.('reject')}
               />

--- a/frontend/map-corridors/src/photoVariants/resolveVariantFlags.ts
+++ b/frontend/map-corridors/src/photoVariants/resolveVariantFlags.ts
@@ -14,7 +14,7 @@
 // flag-only `setPhotoFlag` handler, which likewise leaves `labelUpdatedAt`
 // alone.
 
-import type { PhotoMarker } from '../types/markers'
+import type { PhotoFlag, PhotoMarker } from '../types/markers'
 
 export function resolveVariantFlags(
   markers: readonly PhotoMarker[],
@@ -23,7 +23,12 @@ export function resolveVariantFlags(
 ): readonly PhotoMarker[] {
   const loserSet = new Set(loserIds)
   return markers.map(m => {
-    if (m.id === winnerId) return { ...m, flag: 'pick' as const }
+    if (m.id === winnerId) {
+      // Preserve the winner's existing pick category if it already had one;
+      // otherwise default to track (the user re-categorizes via the popup).
+      const winnerFlag: PhotoFlag = m.flag === 'pick-turning' ? 'pick-turning' : 'pick-track'
+      return { ...m, flag: winnerFlag }
+    }
     if (loserSet.has(m.id)) return { ...m, flag: 'reject' as const }
     return m
   })

--- a/frontend/map-corridors/src/recategorize/recategorize.ts
+++ b/frontend/map-corridors/src/recategorize/recategorize.ts
@@ -14,7 +14,9 @@ export type PanelGroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
  */
 export function flagForGroup(key: PanelGroupKey): PhotoFlag | null | undefined {
   switch (key) {
-    case 'picks': return 'pick'
+    // Dropping into the picks section defaults to track; the user re-categorizes
+    // to turning-point via the marker popup. (A neutral pick category isn't a thing.)
+    case 'picks': return 'pick-track'
     case 'neutral': return null
     case 'rejects': return 'reject'
     default: return undefined // noGps — not a recategorize target

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -18,7 +18,11 @@ export type { PhotoLabel } from '@airq/shared-discipline'
 // `flag` is a Phase-5 intermediate — until Phase 8 (map-picks.json), the
 // flag persists on the marker. Phase 8 makes map-picks.json the source
 // of truth and the marker.flag becomes a render-time projection.
-export type PhotoFlag = 'pick' | 'reject'
+// `pick` was split into two categories so the cross-app handoff can route a
+// photo into the editor's track vs turning-point print sets (A3, 2026-05-30).
+// A legacy persisted `flag: 'pick'` migrates to `pick-track` — see
+// `migrateLegacyPhotoFlag`.
+export type PhotoFlag = 'pick-track' | 'pick-turning' | 'reject'
 export type PhotoMarker = Readonly<{
   id: string
   lng: number
@@ -120,7 +124,7 @@ function isValidCapturedAt(value: unknown): boolean {
   return true
 }
 
-const PHOTO_FLAG_SET: ReadonlySet<string> = new Set<string>(['pick', 'reject'])
+const PHOTO_FLAG_SET: ReadonlySet<string> = new Set<string>(['pick-track', 'pick-turning', 'reject'])
 
 export function isPhotoMarker(value: unknown): value is PhotoMarker {
   if (!value || typeof value !== 'object') return false
@@ -145,9 +149,12 @@ export function sanitizeGroundMarkers(input: unknown): GroundMarker[] {
 
 export function sanitizePhotoMarkers(input: unknown): PhotoMarker[] {
   if (!Array.isArray(input)) return []
+  // Migrate legacy `flag: 'pick'` → `pick-track` BEFORE the guard runs:
+  // `pick` is no longer in PHOTO_FLAG_SET, so an un-migrated marker would
+  // fail isPhotoMarker and a v1 session's picks would be silently dropped.
   // Keep the photo even if its label is illegal — just strip the bad
   // displayName rather than .filter()-evicting the whole marker.
-  return input.filter(isPhotoMarker).map(m => {
+  return input.map(migrateLegacyPhotoFlag).filter(isPhotoMarker).map(m => {
     const displayName = normalizeDisplayName(m.displayName, m.name)
     return displayName === m.displayName ? m : { ...m, displayName }
   })
@@ -286,4 +293,14 @@ export function sanitizeNoGpsPhotos(input: unknown): NoGpsPhoto[] {
     const displayName = normalizeDisplayName(p.displayName, p.filename)
     return displayName === p.displayName ? p : { ...p, displayName }
   })
+}
+
+/** v1 stored a bare `flag: 'pick'`; the flag was split into pick-track /
+ *  pick-turning. A legacy `pick` becomes `pick-track`. MUST run BEFORE the
+ *  isPhotoMarker guard on load or previously-picked photos get dropped. */
+export function migrateLegacyPhotoFlag(m: unknown): unknown {
+  if (m && typeof m === 'object' && (m as { flag?: unknown }).flag === 'pick') {
+    return { ...(m as object), flag: 'pick-track' }
+  }
+  return m
 }

--- a/frontend/photo-helper/src/__tests__/candidateFilter.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateFilter.test.ts
@@ -73,4 +73,18 @@ describe('countByFlag', () => {
   it('zeros all counts on an empty pool', () => {
     expect(countByFlag([])).toEqual({ pick: 0, neutral: 0, reject: 0, total: 0 });
   });
+
+  // A3 (2026-05-30) split `pick` into `pick-track`/`pick-turning`; a map-
+  // originated candidate now carries a category, never bare `pick`. All pick
+  // categories must still tally as picks or the header chip reads 0.
+  it('counts pick-track and pick-turning as picks (not neutral)', () => {
+    const photos = [
+      makePhoto('a', 'pick'),
+      makePhoto('b', 'pick-track'),
+      makePhoto('c', 'pick-turning'),
+      makePhoto('d'),
+      makePhoto('e', 'reject'),
+    ];
+    expect(countByFlag(photos)).toEqual({ pick: 3, neutral: 1, reject: 1, total: 5 });
+  });
 });

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -73,7 +73,7 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   }
 }
 
-function pmEntry(id: string, flag: 'pick' | 'neutral' | 'reject' = 'pick') {
+function pmEntry(id: string, flag: 'pick-track' | 'neutral' | 'reject' = 'pick-track') {
   return { photoId: id, filename: `${id}.jpg`, flag }
 }
 
@@ -116,7 +116,7 @@ describe('syncMapPicksOnce — file absence', () => {
   it('does NOT delete pool entries when the file is missing (absence ≠ empty)', async () => {
     const storage = fakeStorage()
     storage.readJSON.mockResolvedValue(null)
-    const session = fakeSession([existing('pm-abc', 'pick')])
+    const session = fakeSession([existing('pm-abc', 'pick-track')])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.removeCandidate).not.toHaveBeenCalled()
   })
@@ -136,7 +136,7 @@ describe('syncMapPicksOnce — insert path', () => {
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [pmEntry('pm-new', 'pick')],
+      picks: [pmEntry('pm-new', 'pick-track')],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(32)], { type: 'image/jpeg' }))
     const session = fakeSession([])
@@ -146,7 +146,7 @@ describe('syncMapPicksOnce — insert path', () => {
     const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
     expect(inserted.id).toBe('pm-new')
     expect(inserted.filename).toBe('pm-new.jpg')
-    expect(inserted.flag).toBe('pick')
+    expect(inserted.flag).toBe('pick-track')
     expect(inserted.canvasState.scale).toBe(1) // matches createDefaultCanvasState
   })
 
@@ -192,7 +192,7 @@ describe('syncMapPicksOnce — insert path', () => {
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [{ photoId: 'photo-from-helper', filename: 'a.jpg', flag: 'pick' as const }],
+      picks: [{ photoId: 'photo-from-helper', filename: 'a.jpg', flag: 'pick-track' as const }],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([]))
     const session = fakeSession([])
@@ -202,18 +202,47 @@ describe('syncMapPicksOnce — insert path', () => {
   })
 })
 
+describe('syncMapPicksOnce — legacy flag normalization (bare `pick` → `pick-track`)', () => {
+  it('normalizes a legacy bare `pick` on INSERT so the candidate carries an explicit category', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      // A pre-split map-picks.json wrote bare `pick`.
+      picks: [{ photoId: 'pm-legacy', filename: 'pm-legacy.jpg', flag: 'pick' }],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
+    const session = fakeSession([])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
+    expect(inserted.flag).toBe('pick-track')
+  })
+
+  it('normalizes a legacy bare `pick` on UPDATE (reconciles an existing candidate to pick-track)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [{ photoId: 'pm-abc', filename: 'pm-abc.jpg', flag: 'pick' }],
+    })
+    const session = fakeSession([existing('pm-abc', 'neutral')])
+    await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick-track')
+  })
+})
+
 describe('syncMapPicksOnce — update path', () => {
   it('updates flag on a pm- entry already in the pool', async () => {
     const storage = fakeStorage()
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [pmEntry('pm-abc', 'pick')],
+      picks: [pmEntry('pm-abc', 'pick-track')],
     })
     const session = fakeSession([existing('pm-abc', 'neutral')])
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.updates).toBe(1)
-    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick')
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick-track')
   })
 
   it('does NOT call setCandidateFlag when flag is unchanged', async () => {
@@ -221,9 +250,9 @@ describe('syncMapPicksOnce — update path', () => {
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [pmEntry('pm-abc', 'pick')],
+      picks: [pmEntry('pm-abc', 'pick-track')],
     })
-    const session = fakeSession([existing('pm-abc', 'pick')])
+    const session = fakeSession([existing('pm-abc', 'pick-track')])
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.updates).toBe(0)
     expect(session.setCandidateFlag).not.toHaveBeenCalled()
@@ -238,7 +267,7 @@ describe('syncMapPicksOnce — update path', () => {
       updatedAt: 'x',
       picks: [pmEntry('pm-abc', 'reject')],
     })
-    const session = fakeSession([existing('pm-abc', 'pick')])
+    const session = fakeSession([existing('pm-abc', 'pick-track')])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.addCandidate).not.toHaveBeenCalled()
   })
@@ -251,7 +280,7 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-new', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-new', filename: 'a.jpg', flag: 'pick-track',
         label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
       }],
     })
@@ -270,11 +299,11 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick-track',
         label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z',
       }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', 'B')
@@ -286,11 +315,11 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick-track',
         label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
       }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z' }
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track'), label: 'B', labelUpdatedAt: '2024-02-01T00:00:00Z' }
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).not.toHaveBeenCalled()
@@ -302,11 +331,11 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick-track',
         label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z',
       }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'B', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track'), label: 'B', labelUpdatedAt: '2024-01-01T00:00:00Z' }
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).not.toHaveBeenCalled()
@@ -318,11 +347,11 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick-track',
         label: 'C', labelUpdatedAt: '2024-01-01T00:00:00Z',
       }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A' }
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track'), label: 'A' }
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', 'C')
@@ -334,11 +363,11 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [{
-        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick',
+        photoId: 'pm-abc', filename: 'a.jpg', flag: 'pick-track',
         label: '', labelUpdatedAt: '2024-02-01T00:00:00Z',
       }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track'), label: 'A', labelUpdatedAt: '2024-01-01T00:00:00Z' }
     const session = fakeSession([local])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(session.setCandidateLabel).toHaveBeenCalledWith('pm-abc', '')
@@ -358,9 +387,9 @@ describe('syncMapPicksOnce — filename one-way sync (rename of existing pm- can
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [{ photoId: 'pm-abc', filename: 'TP1', flag: 'pick' }],
+      picks: [{ photoId: 'pm-abc', filename: 'TP1', flag: 'pick-track' }],
     })
-    const local: ApiPhoto = { ...existing('pm-abc', 'pick') } // filename = 'pm-abc.jpg' from existing()
+    const local: ApiPhoto = { ...existing('pm-abc', 'pick-track') } // filename = 'pm-abc.jpg' from existing()
     const session = fakeSession([local])
     const result = await syncMapPicksOnce(
       storage as unknown as StorageInterface, competitionDir, photosDir, session,
@@ -374,9 +403,9 @@ describe('syncMapPicksOnce — filename one-way sync (rename of existing pm- can
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [{ photoId: 'pm-abc', filename: 'pm-abc.jpg', flag: 'pick' }],
+      picks: [{ photoId: 'pm-abc', filename: 'pm-abc.jpg', flag: 'pick-track' }],
     })
-    const session = fakeSession([existing('pm-abc', 'pick')])
+    const session = fakeSession([existing('pm-abc', 'pick-track')])
     await syncMapPicksOnce(
       storage as unknown as StorageInterface, competitionDir, photosDir, session,
     )
@@ -388,13 +417,13 @@ describe('syncMapPicksOnce — filename one-way sync (rename of existing pm- can
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [{ photoId: 'pm-abc', filename: 'TP2', flag: 'pick' }],
+      picks: [{ photoId: 'pm-abc', filename: 'TP2', flag: 'pick-track' }],
     })
     const session = fakeSession([existing('pm-abc', 'neutral')])
     const result = await syncMapPicksOnce(
       storage as unknown as StorageInterface, competitionDir, photosDir, session,
     )
-    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick')
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-abc', 'pick-track')
     expect(session.setCandidateFilename).toHaveBeenCalledWith('pm-abc', 'TP2')
     // Both writes count toward a single "touched" tally (one update event).
     expect(result.updates).toBe(1)
@@ -410,7 +439,7 @@ describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [pmEntry('pm-dup', 'pick'), pmEntry('pm-dup', 'pick')],
+      picks: [pmEntry('pm-dup', 'pick-track'), pmEntry('pm-dup', 'pick-track')],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
     let createUrlCount = 0
@@ -435,7 +464,7 @@ describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs
     storage.readJSON.mockResolvedValue({
       version: 1,
       updatedAt: 'x',
-      picks: [pmEntry('pm-new', 'pick')],
+      picks: [pmEntry('pm-new', 'pick-track')],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
     // session.candidates frozen at [] — addCandidate does NOT append to it.
@@ -494,13 +523,13 @@ describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [
-        { photoId: 'pm-bad', filename: 42, flag: 'pick' }, // filename wrong type → drop
-        pmEntry('pm-good', 'pick'),
+        { photoId: 'pm-bad', filename: 42, flag: 'pick-track' }, // filename wrong type → drop
+        pmEntry('pm-good', 'pick-track'),
       ],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
     const session = fakeSession([
-      existing('pm-bad', 'pick'),  // pre-existing local copy of the now-dropped id
+      existing('pm-bad', 'pick-track'),  // pre-existing local copy of the now-dropped id
       existing('pm-good', 'neutral'),
     ])
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -510,7 +539,7 @@ describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
     )
     expect(result.deletes).toBe(1)
     expect(session.removeCandidate).toHaveBeenCalledWith('pm-bad')
-    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-good', 'pick')
+    expect(session.setCandidateFlag).toHaveBeenCalledWith('pm-good', 'pick-track')
     expect(warn).toHaveBeenCalled() // dropped row was logged
     warn.mockRestore()
   })
@@ -521,10 +550,10 @@ describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [
-        pmEntry('pm-1', 'pick'),
+        pmEntry('pm-1', 'pick-track'),
         { photoId: 'pm-2', filename: 'b.jpg', flag: 'archived' }, // bad flag → drop
-        pmEntry('pm-3', 'pick'),
-        { photoId: 'pm-4', flag: 'pick' },                         // missing filename → drop
+        pmEntry('pm-3', 'pick-track'),
+        { photoId: 'pm-4', flag: 'pick-track' },                         // missing filename → drop
       ],
     })
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
@@ -548,7 +577,7 @@ describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
       version: 1,
       updatedAt: 'x',
       picks: [
-        pmEntry('pm-new', 'pick'),
+        pmEntry('pm-new', 'pick-track'),
         pmEntry('pm-existing', 'reject'), // currently neutral
         // 'pm-going-away' is in the pool but not here
       ],

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -34,6 +34,7 @@ import { PhotoEditorApi } from './PhotoEditorApi';
 import { useI18n } from '../contexts/I18nContext';
 import { isValidImageFile } from '../utils/imageProcessing';
 import { filterCandidates, countByFlag } from '../utils/candidateFilter';
+import { isPickFlag } from '@airq/shared-handoff';
 import { parseDragPayload, serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
 import type { ApiPhoto, CandidateFlag } from '../types/api';
 
@@ -384,7 +385,10 @@ const CandidateThumb: React.FC<CandidateThumbProps> = ({
   const theme = useTheme();
   const { t } = useI18n();
   const flag: CandidateFlag = (photo.flag as CandidateFlag | undefined) ?? 'neutral';
-  const isPick = flag === 'pick';
+  // Any pick category counts as picked for the status border/toggle. A
+  // map-originated candidate now carries `pick-track`/`pick-turning`, not bare
+  // `pick`, so a literal `=== 'pick'` would drop its picked highlight (A3 split).
+  const isPick = isPickFlag(flag);
   const isReject = flag === 'reject';
 
   // Status border colour communicates flag at a glance.

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -65,6 +65,16 @@ export interface MapPicksSyncSessionApi {
 const PM_PREFIX = PM_PHOTO_ID_PREFIX;
 
 /**
+ * Normalize a wire flag into the candidate's flag. A legacy bare `pick`
+ * (written by map-corridors before the pick/track split, A3 2026-05-30)
+ * becomes `pick-track` so a candidate always carries an explicit category
+ * after crossing the handoff. Every other value passes through unchanged.
+ */
+function normalizeCandidateFlag(flag: MapPickEntry['flag']): CandidateFlag {
+  return flag === 'pick' ? 'pick-track' : flag;
+}
+
+/**
  * Reusable side-effect: read map-picks.json, project entries into the
  * candidate pool. Exported (not just the hook) so tests + a future
  * one-shot integration can call it without React. Returns the number
@@ -110,6 +120,7 @@ export async function syncMapPicksOnce(
     }
     if (!entry.photoId.startsWith(PM_PREFIX)) continue;
     remoteIds.add(entry.photoId);
+    const entryFlag = normalizeCandidateFlag(entry.flag);
     const existing = localById.get(entry.photoId);
     if (!existing) {
       // Narrow the swallow to NotFoundError — other storage errors
@@ -135,7 +146,7 @@ export async function syncMapPicksOnce(
         filename: entry.filename,
         canvasState: createDefaultCanvasState(),
         label: entry.label ?? '',
-        flag: entry.flag,
+        flag: entryFlag,
         ...(entry.labelUpdatedAt ? { labelUpdatedAt: entry.labelUpdatedAt } : {}),
       };
       await session.addCandidate(photo);
@@ -143,8 +154,8 @@ export async function syncMapPicksOnce(
       inserts++;
     } else {
       let touched = false;
-      if (existing.flag !== entry.flag) {
-        await session.setCandidateFlag(entry.photoId, entry.flag);
+      if (existing.flag !== entryFlag) {
+        await session.setCandidateFlag(entry.photoId, entryFlag);
         touched = true;
       }
       // Bidirectional label sync — newer wins. Equal timestamps → local

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -4,7 +4,11 @@
 
 import type { Photo } from './index';
 
-export type CandidateFlag = 'pick' | 'neutral' | 'reject';
+// `pick` retained for back-compat with candidates created before the
+// pick/track split (A3, 2026-05-30); useMapPicksSync normalizes an incoming
+// legacy `pick` to `pick-track` so a candidate always carries an explicit
+// category after crossing the handoff.
+export type CandidateFlag = 'pick' | 'pick-track' | 'pick-turning' | 'neutral' | 'reject';
 
 /**
  * Result of a photo-add operation (`addPhotosToSet`, `addPhotosToTurningPoint`).

--- a/frontend/photo-helper/src/utils/candidateFilter.ts
+++ b/frontend/photo-helper/src/utils/candidateFilter.ts
@@ -4,6 +4,7 @@
  * `hideRejects` toggle; future pill filters (Picks / Neutral / Rejects)
  * will add cases to this helper rather than re-implementing the predicates.
  */
+import { isPickFlag } from '@airq/shared-handoff';
 import type { ApiPhoto } from '../types/api';
 
 export type CandidateFilter = { hideRejects: boolean };
@@ -35,7 +36,9 @@ export function countByFlag(photos: ApiPhoto[]): {
   let neutral = 0;
   let reject = 0;
   for (const p of photos) {
-    if (p.flag === 'pick') pick++;
+    // Any pick category (legacy `pick`, `pick-track`, `pick-turning`) tallies
+    // as a pick — see shared isPickFlag (A3 split, 2026-05-30).
+    if (isPickFlag(p.flag)) pick++;
     else if (p.flag === 'reject') reject++;
     else neutral++;
   }

--- a/frontend/shared-handoff/src/guards.ts
+++ b/frontend/shared-handoff/src/guards.ts
@@ -20,7 +20,8 @@ export const EDITOR_PICKS_FILENAME = 'photo-helper-picks.json' as const;
 /** Prefix that marks a photo as map-originated. Readers gate inclusion on this. */
 export const PM_PHOTO_ID_PREFIX = 'pm-' as const;
 
-const WIRE_FLAGS: ReadonlySet<string> = new Set(['pick', 'neutral', 'reject']);
+// Bare `pick` kept for back-compat with legacy map-picks.json (pre-split).
+const WIRE_FLAGS: ReadonlySet<string> = new Set(['pick', 'pick-track', 'pick-turning', 'neutral', 'reject']);
 
 export function isWireFlag(x: unknown): x is WireFlag {
   return typeof x === 'string' && WIRE_FLAGS.has(x);

--- a/frontend/shared-handoff/src/guards.ts
+++ b/frontend/shared-handoff/src/guards.ts
@@ -27,6 +27,19 @@ export function isWireFlag(x: unknown): x is WireFlag {
   return typeof x === 'string' && WIRE_FLAGS.has(x);
 }
 
+// The three values that all mean "this photo is a pick". Single source of
+// truth so the pick/track split (A3, 2026-05-30) doesn't leave stale
+// `flag === 'pick'` comparisons scattered across both apps. Includes the
+// legacy bare `pick` so a candidate that hasn't been normalized yet still
+// reads as a pick. Accepts `unknown` (and undefined) so callers can pass a
+// possibly-absent marker/candidate flag without a pre-check.
+const PICK_FLAGS: ReadonlySet<string> = new Set(['pick', 'pick-track', 'pick-turning']);
+
+/** True for any pick category — bare `pick` (legacy), `pick-track`, or `pick-turning`. */
+export function isPickFlag(x: unknown): boolean {
+  return typeof x === 'string' && PICK_FLAGS.has(x);
+}
+
 function isObject(x: unknown): x is Record<string, unknown> {
   return typeof x === 'object' && x !== null && !Array.isArray(x);
 }

--- a/frontend/shared-handoff/src/index.ts
+++ b/frontend/shared-handoff/src/index.ts
@@ -25,6 +25,7 @@ export {
   EDITOR_PICKS_FILENAME,
   PM_PHOTO_ID_PREFIX,
   isWireFlag,
+  isPickFlag,
   isMapPickEntry,
   isMapPicksFile,
   isEditorPickEntry,

--- a/frontend/shared-handoff/src/types.ts
+++ b/frontend/shared-handoff/src/types.ts
@@ -11,8 +11,15 @@
 //   - `flag` is a closed `WireFlag` union — the cross-app vocabulary
 //     must agree, so a typo in one app must compile-fail in the other.
 
-/** Closed enum of valid flag values on the wire. */
-export type WireFlag = 'pick' | 'neutral' | 'reject';
+/**
+ * Closed enum of valid flag values on the wire.
+ *
+ * Bare `pick` is RETAINED for backward compatibility with `map-picks.json`
+ * files written before the pick/track split — a v1 file's `flag: 'pick'`
+ * must still validate. New writes emit the categorized `pick-track` /
+ * `pick-turning`; the reader normalizes a legacy bare `pick` to `pick-track`.
+ */
+export type WireFlag = 'pick' | 'pick-track' | 'pick-turning' | 'neutral' | 'reject';
 
 /**
  * One row in `map-picks.json` — photo-map-culling's outgoing handoff


### PR DESCRIPTION
## Summary
- Split the single `pick` flag into **`pick-track`** and **`pick-turning`** so a photo's category rides the cross-app handoff and the editor knows which print set (track vs turning-point) it belongs to. Picks are **not** auto-promoted — the existing tray "Send to Set" / "Send to TP photos" controls still do the placement.
- Lossless legacy migration: a v1 `flag: 'pick'` becomes `pick-track`, applied in `sanitizePhotoMarkers` **before** the marker guard so previously-picked photos aren't silently dropped on load.
- Visual language: marker ring blue `#1976d2` (track), purple `#7b1fa2` (turning); popup gains two include buttons (Track / Turning-point) with primary/secondary highlight from the marker's current category.
- Handoff contract: `WireFlag` + photo-helper `CandidateFlag` gain both categories while **keeping bare `pick`** for back-compat with old `map-picks.json`; `useMapPicksSync` normalizes a legacy `pick` → `pick-track` on read so a candidate always carries an explicit category.
- i18n: `photo.popup.pickTrack` / `pickTurning` (en + cs with diacritics).
- Tests: updated every flag-assertion suite; added a `migrateLegacyPhotoFlag` suite, a both-categories grouping case, a guard-rejects-legacy-`pick` case, and legacy-normalization cases in `useMapPicksSync`.

## Test plan
- [x] `tsc -b` (map-corridors) clean
- [x] `tsc --noEmit` (photo-helper) clean
- [x] vitest map-corridors — 633 passed
- [x] vitest photo-helper — 436 passed
- [x] vitest desktop — 63 passed
- [ ] Manual: pick a photo as Track (blue) and as Turning (purple), confirm ring color + popup highlight
- [ ] Manual: send to editor, confirm category survives the handoff into the candidate tray
- [ ] Manual: load a pre-split session and confirm old picks appear as Track (no data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)