### PR TITLE
test(map-corridors): cover PhotoMarkerPopup track/turning wiring

### DIFF
--- a/frontend/map-corridors/package.json
+++ b/frontend/map-corridors/package.json
@@ -32,6 +32,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@testing-library/jest-dom": "6.6.3",
+    "@testing-library/react": "16.1.0",
     "@types/geojson": "^7946.0.14",
     "@types/node": "^25.0.3",
     "@types/react": "^19.1.10",

--- a/frontend/map-corridors/src/__tests__/PhotoMarkerPopup.test.tsx
+++ b/frontend/map-corridors/src/__tests__/PhotoMarkerPopup.test.tsx
@@ -1,0 +1,111 @@
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { PhotoMarkerPopup, type PhotoMarkerPopupProps } from '../components/PhotoMarkerPopup'
+import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
+
+// A3 (2026-05-30) split the single "Include" button into two category
+// buttons — Track (blue/primary) and Turning-point (purple/secondary) —
+// each wired to its own handler. The wiring is pure UI (which button calls
+// which callback, which one is highlighted for the marker's current flag)
+// and had no test, so a swapped handler or a wrong-button highlight would
+// ship green. These pin the button → handler mapping and the active-state
+// highlight in both directions.
+
+// Stub useI18n so we don't spin up I18nContext. Echo the key back, so a
+// button's accessible name is its translation key (e.g. 'photo.popup.pickTrack').
+vi.mock('../contexts/I18nContext', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+// Stub the thumbnail hook — rendering the real one pulls in storage I/O and
+// blob URLs. We only care about the action buttons here.
+vi.mock('../components/usePhotoThumbUrl', () => ({
+  usePhotoThumbUrl: () => ({ url: null, state: 'missing' as const }),
+}))
+
+afterEach(cleanup)
+
+function renderPopup(overrides: Partial<PhotoMarkerPopupProps> = {}) {
+  const onIncludeTrack = vi.fn()
+  const onIncludeTurning = vi.fn()
+  const onSkip = vi.fn()
+  const onReject = vi.fn()
+  const props: PhotoMarkerPopupProps = {
+    photoId: 'pm-1',
+    filename: 'DSC_0001.JPG',
+    storage: {} as StorageInterface,
+    photosDir: {} as DirectoryHandle,
+    onIncludeTrack,
+    onIncludeTurning,
+    onSkip,
+    onReject,
+    ...overrides,
+  }
+  render(<PhotoMarkerPopup {...props} />)
+  const trackBtn = screen.getByRole('button', { name: 'photo.popup.pickTrack' })
+  const turningBtn = screen.getByRole('button', { name: 'photo.popup.pickTurning' })
+  return { props, onIncludeTrack, onIncludeTurning, onSkip, onReject, trackBtn, turningBtn }
+}
+
+describe('PhotoMarkerPopup — track/turning button wiring', () => {
+  it('renders both category buttons plus skip and reject', () => {
+    renderPopup()
+    expect(screen.getByRole('button', { name: 'photo.popup.pickTrack' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'photo.popup.pickTurning' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'photo.popup.skip' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'photo.popup.reject' })).toBeInTheDocument()
+  })
+
+  it('Track button fires onIncludeTrack ONLY (handlers not crossed)', () => {
+    const { trackBtn, onIncludeTrack, onIncludeTurning, onSkip, onReject } = renderPopup()
+    fireEvent.click(trackBtn)
+    expect(onIncludeTrack).toHaveBeenCalledTimes(1)
+    expect(onIncludeTurning).not.toHaveBeenCalled()
+    expect(onSkip).not.toHaveBeenCalled()
+    expect(onReject).not.toHaveBeenCalled()
+  })
+
+  it('Turning button fires onIncludeTurning ONLY (handlers not crossed)', () => {
+    const { turningBtn, onIncludeTrack, onIncludeTurning } = renderPopup()
+    fireEvent.click(turningBtn)
+    expect(onIncludeTurning).toHaveBeenCalledTimes(1)
+    expect(onIncludeTrack).not.toHaveBeenCalled()
+  })
+
+  it('skip / reject buttons fire their own handlers', () => {
+    const { onSkip, onReject, onIncludeTrack, onIncludeTurning } = renderPopup()
+    fireEvent.click(screen.getByRole('button', { name: 'photo.popup.skip' }))
+    fireEvent.click(screen.getByRole('button', { name: 'photo.popup.reject' }))
+    expect(onSkip).toHaveBeenCalledTimes(1)
+    expect(onReject).toHaveBeenCalledTimes(1)
+    expect(onIncludeTrack).not.toHaveBeenCalled()
+    expect(onIncludeTurning).not.toHaveBeenCalled()
+  })
+
+  it('flag="pick-track" highlights Track (contained) and leaves Turning outlined', () => {
+    const { trackBtn, turningBtn } = renderPopup({ flag: 'pick-track' })
+    expect(trackBtn).toHaveClass('MuiButton-contained')
+    expect(turningBtn).toHaveClass('MuiButton-outlined')
+  })
+
+  it('flag="pick-turning" highlights Turning (contained) and leaves Track outlined', () => {
+    const { trackBtn, turningBtn } = renderPopup({ flag: 'pick-turning' })
+    expect(turningBtn).toHaveClass('MuiButton-contained')
+    expect(trackBtn).toHaveClass('MuiButton-outlined')
+  })
+
+  it('no flag (un-categorized) leaves BOTH category buttons outlined', () => {
+    const { trackBtn, turningBtn } = renderPopup()
+    expect(trackBtn).toHaveClass('MuiButton-outlined')
+    expect(turningBtn).toHaveClass('MuiButton-outlined')
+    expect(trackBtn).not.toHaveClass('MuiButton-contained')
+    expect(turningBtn).not.toHaveClass('MuiButton-contained')
+  })
+
+  it('flag="reject" does not highlight either category button', () => {
+    const { trackBtn, turningBtn } = renderPopup({ flag: 'reject' })
+    expect(trackBtn).toHaveClass('MuiButton-outlined')
+    expect(turningBtn).toHaveClass('MuiButton-outlined')
+  })
+})

--- a/frontend/map-corridors/vitest.config.ts
+++ b/frontend/map-corridors/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
   },
 })

--- a/frontend/map-corridors/vitest.setup.ts
+++ b/frontend/map-corridors/vitest.setup.ts
@@ -1,0 +1,4 @@
+// Global vitest setup — runs once before any test file. Loads jest-dom's
+// custom matchers (toBeInTheDocument, toHaveClass, …) so RTL-based tests
+// can use them without per-file imports. Mirrors photo-helper's setup.
+import '@testing-library/jest-dom/vitest';

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.39.3
+      '@testing-library/jest-dom':
+        specifier: 6.6.3
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 16.1.0
+        version: 16.1.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/geojson':
         specifier: ^7946.0.14
         version: 7946.0.16


### PR DESCRIPTION
## Summary
Closes the test gap from the PR #87 review (Gap 3): the A3 track/turning split added two category buttons to `PhotoMarkerPopup` with no test guarding the button → handler wiring or the active-state highlight.

- Adds `@testing-library/react@16.1.0` + `@testing-library/jest-dom@6.6.3` to map-corridors (first `.tsx` render test in this package) with a `vitest.setup.ts` mirroring photo-helper, and `setupFiles` wired in `vitest.config.ts`.
- New `PhotoMarkerPopup.test.tsx` (8 cases) pins:
  - both category buttons + skip/reject render
  - Track click fires `onIncludeTrack` only; Turning click fires `onIncludeTurning` only (handlers not crossed)
  - skip/reject fire their own handlers in isolation
  - active-highlight: `pick-track` → Track contained, `pick-turning` → Turning contained, no-flag / `reject` → both outlined

## Test plan
- [x] `tsc -b` (map-corridors) clean
- [x] vitest map-corridors — 652 passed (+8), 40 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)