### PR TITLE
docs(changelog): add 2.20.0 (track vs turning-point categorization)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.20.0] - 2026-05-30
+
+### Added
+- **Map Corridors:** picked photos can now be categorised as **track** or
+  **turning-point** photos. The marker popup's single *Vybrané* button is
+  replaced by two pick buttons — *Fotka trati* / *Fotka otočného bodu*
+  (English *Track photo* / *Turning-point photo*). The chosen category shows in
+  the marker's ring colour — blue for track, purple for turning-point — and is
+  highlighted in the popup. The category travels with the photo across the
+  handoff into Photo Helper, so the editor knows which print set each photo
+  belongs to. Picking does not auto-place the photo; the existing "Send to set"
+  / "Send to TP photos" controls still do that. Sessions saved before this
+  release load their existing picks as track photos (no picks are lost).
+
 ## [2.19.0] - 2026-05-30
 
 ### Added

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",


### PR DESCRIPTION
## Summary
Adds the **2.20.0** changelog entry for the track vs turning-point pick categorization feature (merged in PR #87). The `desktop-v2.20.0` tag was already auto-created from the `#minor` flag, but the feature PR missed two things this PR fixes:

- **CHANGELOG.md:** new `## [2.20.0] - 2026-05-30` entry, user-facing description in the established voice (quotes the cs/en popup labels, notes the blue/purple ring colours, the handoff, and lossless legacy load).
- **frontend/desktop/package.json:** bumped `2.19.0 → 2.20.0` to match the existing tag (the version bump normally rides the feature commit).

No code/behaviour change → no test run needed. Test-only PR #88 is intentionally omitted from the changelog (no user impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)