### PR TITLE
feat(map-corridors): auto-pan map when dragging a marker past the viewport edge #minor

### DIFF
--- a/frontend/map-corridors/src/__tests__/edgePanVelocity.test.ts
+++ b/frontend/map-corridors/src/__tests__/edgePanVelocity.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { edgeVelocity, EDGE_ZONE_PX, MAX_PAN_PX_PER_FRAME } from '../map/useEdgePanDrag'
+
+// Pure screen-space ramp that drives auto-pan when a dragged marker's cursor
+// nears a viewport edge. `px` is the cursor offset along one axis; `size` is
+// that axis' viewport length. Sign: negative = pan toward the low edge
+// (left/top), positive = high edge (right/bottom).
+
+const SIZE = 1000
+
+describe('edgeVelocity', () => {
+  it('is zero in the dead zone away from both edges', () => {
+    expect(edgeVelocity(SIZE / 2, SIZE)).toBe(0)
+    expect(edgeVelocity(EDGE_ZONE_PX, SIZE)).toBe(0) // exactly at the zone boundary
+    expect(edgeVelocity(SIZE - EDGE_ZONE_PX, SIZE)).toBe(0)
+  })
+
+  it('pans toward the low edge (negative) inside the leading zone', () => {
+    expect(edgeVelocity(EDGE_ZONE_PX - 1, SIZE)).toBeLessThan(0)
+    expect(edgeVelocity(0, SIZE)).toBe(-MAX_PAN_PX_PER_FRAME) // at the very edge → full speed
+  })
+
+  it('pans toward the high edge (positive) inside the trailing zone', () => {
+    expect(edgeVelocity(SIZE - EDGE_ZONE_PX + 1, SIZE)).toBeGreaterThan(0)
+    expect(edgeVelocity(SIZE, SIZE)).toBe(MAX_PAN_PX_PER_FRAME)
+  })
+
+  it('clamps to full speed past the edge (cursor dragged off-screen)', () => {
+    expect(edgeVelocity(-200, SIZE)).toBe(-MAX_PAN_PX_PER_FRAME)
+    expect(edgeVelocity(SIZE + 200, SIZE)).toBe(MAX_PAN_PX_PER_FRAME)
+  })
+
+  it('eases quadratically — slower just inside the zone than near the edge', () => {
+    const justInside = Math.abs(edgeVelocity(EDGE_ZONE_PX - 4, SIZE))
+    const nearEdge = Math.abs(edgeVelocity(4, SIZE))
+    expect(justInside).toBeLessThan(nearEdge)
+    // Quadratic ease: halfway into the zone yields a quarter of max speed.
+    expect(Math.abs(edgeVelocity(EDGE_ZONE_PX / 2, SIZE))).toBeCloseTo(MAX_PAN_PX_PER_FRAME * 0.25, 5)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/useEdgePanDrag.controller.test.ts
+++ b/frontend/map-corridors/src/__tests__/useEdgePanDrag.controller.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import type { MapRef } from 'react-map-gl/mapbox'
+import { createEdgePanController, type DragHandleConfig } from '../map/useEdgePanDrag'
+
+// Behavioral tests for the drag state machine inside createEdgePanController —
+// the part that decides what coordinates get written to a competition marker
+// (commit) vs. treated as a tap (click), and that cancel paths NEVER commit.
+// The pure ramp (edgeVelocity) is covered separately in edgePanVelocity.test.ts.
+//
+// The controller consumes only a structural slice of a mapbox map, so a tiny
+// fake drives it deterministically. World/screen model: world = screenPx + pan.
+//   project([lng,lat]) → { x: lng - pan.x, y: lat - pan.y }
+//   unproject([x,y])   → { lng: x + pan.x, lat: y + pan.y }
+//   panBy([dx,dy])     → pan += [dx,dy]
+// Canvas is a fixed 1000×1000 at viewport origin (0,0), so screen px == world
+// coords while pan is zero.
+
+function makeFakeMap() {
+  const pan = { x: 0, y: 0 }
+  const calls = { panBy: 0 }
+  const map = {
+    getCanvas: () => ({
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 1000 }),
+    }),
+    project: ([lng, lat]: [number, number]) => ({ x: lng - pan.x, y: lat - pan.y }),
+    unproject: ([x, y]: [number, number]) => ({ lng: x + pan.x, lat: y + pan.y }),
+    panBy: ([dx, dy]: [number, number]) => { pan.x += dx; pan.y += dy; calls.panBy++ },
+  }
+  return { map, pan, calls }
+}
+
+// Manual requestAnimationFrame pump: tick() re-schedules itself, so each
+// flush() drains the queued callbacks captured so far (the new one a tick
+// schedules runs on the next flush).
+let rafQueue: Array<FrameRequestCallback>
+function flush(n = 1) {
+  for (let i = 0; i < n; i++) {
+    const batch = rafQueue
+    rafQueue = []
+    batch.forEach(cb => cb(0))
+  }
+}
+
+function pointerEvent(over: Record<string, unknown>) {
+  return { pointerId: 1, button: 0, isPrimary: true, clientX: 0, clientY: 0, ...over } as unknown as PointerEvent
+}
+
+function dispatch(type: string, props: Record<string, unknown> = {}) {
+  const e = new Event(type)
+  Object.assign(e, props)
+  window.dispatchEvent(e)
+}
+
+beforeEach(() => {
+  rafQueue = []
+  let id = 0
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { rafQueue.push(cb); return ++id })
+  vi.stubGlobal('cancelAnimationFrame', () => {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+type Harness = {
+  controller: ReturnType<typeof createEdgePanController>
+  active: Array<{ id: string; lng: number; lat: number } | null>
+  onCommit: Mock<(lng: number, lat: number) => void>
+  onClick: Mock<() => void>
+  fake: ReturnType<typeof makeFakeMap>
+  startAt: (cx: number, cy: number, anchor?: { lng: number; lat: number }) => void
+}
+
+function setup(extraCfg: Partial<DragHandleConfig> = {}): Harness {
+  const fake = makeFakeMap()
+  const mapRef = { current: { getMap: () => fake.map } } as unknown as React.RefObject<MapRef | null>
+  const active: Harness['active'] = []
+  const controller = createEdgePanController(mapRef, d => active.push(d))
+  // Typed mocks so they satisfy DragHandleConfig's onCommit/onClick under tsc.
+  const onCommit = vi.fn<(lng: number, lat: number) => void>()
+  const onClick = vi.fn<() => void>()
+  const startAt: Harness['startAt'] = (cx, cy, anchor = { lng: cx, lat: cy }) => {
+    controller.startDrag(pointerEvent({ clientX: cx, clientY: cy }), {
+      id: 'm1', lng: anchor.lng, lat: anchor.lat, onCommit, onClick, ...extraCfg,
+    })
+  }
+  return { controller, active, onCommit, onClick, fake, startAt }
+}
+
+const lastActive = (h: Harness) => h.active[h.active.length - 1]
+
+describe('createEdgePanController — commit vs click', () => {
+  it('treats a sub-threshold gesture as a click: onClick fires, onCommit does not', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 503, clientY: 502 }) // ~3.6px < 8
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onClick).toHaveBeenCalledTimes(1)
+    expect(h.onCommit).not.toHaveBeenCalled()
+    expect(lastActive(h)).toBeNull() // override dropped on end
+  })
+
+  it('does NOT move the dot during a sub-threshold tap', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    const beforeMove = h.active.length // only the start publish so far
+    dispatch('pointermove', { pointerId: 1, clientX: 504, clientY: 500 }) // 4px < 8
+    // No new override published while still below the click threshold.
+    expect(h.active.length).toBe(beforeMove)
+  })
+
+  it('treats a supra-threshold gesture as a drag and commits the cursor-derived coords', () => {
+    const h = setup()
+    h.startAt(500, 500) // anchor at 500,500; grab offset 0
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 540 }) // 100px > 8
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onClick).not.toHaveBeenCalled()
+    expect(h.onCommit).toHaveBeenCalledTimes(1)
+    expect(h.onCommit).toHaveBeenCalledWith(600, 540) // pan still zero → screen==world
+    expect(lastActive(h)).toBeNull()
+  })
+
+  it('respects the grab offset so the grab point stays under the cursor', () => {
+    const h = setup()
+    // Grab 20px to the right / 10px below the marker's true anchor (485,490).
+    h.startAt(505, 500, { lng: 485, lat: 490 })
+    dispatch('pointermove', { pointerId: 1, clientX: 605, clientY: 600 })
+    dispatch('pointerup', { pointerId: 1 })
+    // Cursor moved by (+100,+100); the anchor should move by the same delta:
+    // 485+100=585, 490+100=590 — NOT the raw cursor position (605,600).
+    expect(h.onCommit).toHaveBeenCalledWith(585, 590)
+  })
+})
+
+describe('createEdgePanController — cancel paths never commit', () => {
+  it('Escape mid-drag cancels: no commit, no click, override dropped', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 }) // real move
+    dispatch('keydown', { key: 'Escape' })
+    expect(h.onCommit).not.toHaveBeenCalled()
+    expect(h.onClick).not.toHaveBeenCalled()
+    expect(lastActive(h)).toBeNull()
+    // A subsequent pointerup must be a no-op (drag already torn down).
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onCommit).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-Escape keys', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 })
+    dispatch('keydown', { key: 'a' })
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onCommit).toHaveBeenCalledTimes(1) // drag survived the keypress
+  })
+
+  it('window blur cancels without committing', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 })
+    dispatch('blur')
+    expect(h.onCommit).not.toHaveBeenCalled()
+    expect(lastActive(h)).toBeNull()
+  })
+
+  it('pointercancel cancels without committing', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 })
+    dispatch('pointercancel', { pointerId: 1 })
+    expect(h.onCommit).not.toHaveBeenCalled()
+    expect(lastActive(h)).toBeNull()
+  })
+})
+
+describe('createEdgePanController — multi-pointer guard', () => {
+  it('ignores moves/ups from a different pointerId', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 }) // real move on primary
+    dispatch('pointerup', { pointerId: 2 }) // secondary finger lifts — must be ignored
+    expect(h.onCommit).not.toHaveBeenCalled()
+    dispatch('pointerup', { pointerId: 1 }) // primary lifts — now commit
+    expect(h.onCommit).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createEdgePanController — edge auto-pan', () => {
+  it('pans every frame while held in an edge zone and keeps committing past the cursor', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    // Drag the cursor into the left edge zone (x=10 < EDGE_ZONE_PX=64) and hold.
+    dispatch('pointermove', { pointerId: 1, clientX: 10, clientY: 500 })
+    expect(h.fake.calls.panBy).toBe(0) // pan happens in the RAF loop, not on move
+    flush(3) // three animation frames
+    expect(h.fake.calls.panBy).toBe(3)
+    // Each frame pans toward the low edge (negative vx) and re-derives lng from
+    // the stationary cursor, so the committed lng drifts west of the cursor's
+    // at-rest unprojection (10).
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onCommit).toHaveBeenCalledTimes(1)
+    const [lng] = h.onCommit.mock.calls[0]
+    expect(lng).toBeLessThan(10)
+    expect(h.onClick).not.toHaveBeenCalled()
+  })
+
+  it('does NOT auto-pan on a sub-threshold grab inside the edge zone (still a tap)', () => {
+    const h = setup()
+    h.startAt(30, 500) // grab already inside the left edge zone (x < 64)
+    dispatch('pointermove', { pointerId: 1, clientX: 28, clientY: 500 }) // 2px < 8
+    flush(2)
+    // Being near the edge is not enough — the gesture must first qualify as a
+    // drag (cross the 8px threshold) before the auto-pan loop is armed.
+    expect(h.fake.calls.panBy).toBe(0)
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onClick).toHaveBeenCalledTimes(1)
+    expect(h.onCommit).not.toHaveBeenCalled()
+  })
+
+  it('stops the loop when the cursor leaves the edge zone and restarts on re-entry', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 10, clientY: 500 }) // into edge
+    flush(1)
+    const afterEntry = h.fake.calls.panBy
+    expect(afterEntry).toBeGreaterThan(0)
+    dispatch('pointermove', { pointerId: 1, clientX: 500, clientY: 500 }) // back to center → velocity 0
+    flush(2) // the in-flight frame idles out; no new frames scheduled
+    const afterLeave = h.fake.calls.panBy
+    dispatch('pointermove', { pointerId: 1, clientX: 990, clientY: 500 }) // into right edge
+    flush(1)
+    expect(h.fake.calls.panBy).toBeGreaterThan(afterLeave) // restarted
+    dispatch('pointerup', { pointerId: 1 })
+  })
+})
+
+describe('createEdgePanController — re-entrant startDrag', () => {
+  it('a second startDrag cancels the first without committing it', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 500 }) // first drag moved
+    // New grab before the first lifted (e.g. a stray second pointerdown).
+    h.controller.startDrag(pointerEvent({ clientX: 200, clientY: 200, pointerId: 9 }), {
+      id: 'm2', lng: 200, lat: 200, onCommit: h.onCommit, onClick: h.onClick,
+    })
+    // First drag must NOT have committed.
+    expect(h.onCommit).not.toHaveBeenCalled()
+    // The old pointerId no longer controls anything; only the new one does.
+    dispatch('pointerup', { pointerId: 1 })
+    expect(h.onCommit).not.toHaveBeenCalled() // stale pointer ignored
+    dispatch('pointermove', { pointerId: 9, clientX: 300, clientY: 300 })
+    dispatch('pointerup', { pointerId: 9 })
+    expect(h.onCommit).toHaveBeenCalledTimes(1)
+    expect(h.onCommit).toHaveBeenCalledWith(300, 300)
+  })
+})

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import MapGL, { Layer, Source, Marker, Popup } from 'react-map-gl/mapbox'
-import type { MapRef, MarkerDragEvent, MarkerEvent } from 'react-map-gl/mapbox'
+import type { MapRef } from 'react-map-gl/mapbox'
 import type { GeoJSON, Geometry, Position } from 'geojson'
 import type { LngLatBoundsLike, LngLatLike, StyleSpecification } from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
@@ -13,6 +13,8 @@ import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { useMarkerFan } from './photoLayers/useMarkerFan'
+import { useEdgePanDrag } from './useEdgePanDrag'
+import { MarkerDragHandle } from './MarkerDragHandle'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
@@ -148,17 +150,25 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     (id: string | null) => { onActivePhotoMarkerChange?.(id) },
     [onActivePhotoMarkerChange],
   )
-  const dragStartLngLatRef = useRef<Map<string, { lng: number, lat: number }>>(new Map())
-  const dragMovedPxRef = useRef<Map<string, number>>(new Map())
-  // Auto-fan: which photo marker is mid-drag (excluded from fanning so its
-  // dot snaps to the cursor instead of sitting at its fan offset). `null` =
-  // none dragging. State (not a ref) so dropping its offset re-renders.
-  const [draggingPhotoMarkerId, setDraggingPhotoMarkerId] = useState<string | null>(null)
+  // Custom marker drag with auto-pan when the cursor nears a viewport edge
+  // (replaces react-map-gl's built-in `draggable`, which can't scroll the map
+  // mid-drag without the dot sliding off the cursor — see useEdgePanDrag).
+  // `activeDrag` is the live override position of whichever marker is mid-drag.
+  const { activeDrag, controller: dragController } = useEdgePanDrag(mapRef)
+  // Position a marker at its live drag override (if it's the one being dragged)
+  // or its committed prop position otherwise.
+  const liveDragPos = useCallback(
+    (id: string, lng: number, lat: number) =>
+      activeDrag && activeDrag.id === id ? { lng: activeDrag.lng, lat: activeDrag.lat } : { lng, lat },
+    [activeDrag],
+  )
   const photoFan = useMarkerFan({
     mapRef,
     isMapLoaded,
     markers: props.markers,
-    draggingMarkerId: draggingPhotoMarkerId,
+    // Auto-fan excludes the dragging marker so its dot snaps to the cursor
+    // instead of sitting at its fan offset.
+    draggingMarkerId: activeDrag?.id ?? null,
   })
   // `N` resets the map to north (Google-Earth style). Suppressed while typing
   // in a field (marker-name inputs live in popups) and for modifier combos
@@ -517,75 +527,49 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           markers (m.photoId !== undefined) are handled in the photo-
           pin block below to keep the click + popup semantics distinct
           (photo popup vs KML label picker). */}
-      {props.markers?.filter(m => !m.photoId).map(m => (
+      {props.markers?.filter(m => !m.photoId).map(m => {
+        const pos = liveDragPos(m.id, m.lng, m.lat)
+        return (
         <React.Fragment key={m.id}>
           <Marker
-            longitude={m.lng}
-            latitude={m.lat}
-            draggable
-            onClick={(ev: MarkerEvent<MouseEvent>) => {
-              const moved = dragMovedPxRef.current.get(m.id) || 0
-              if (moved < 8) {
-                ev.originalEvent?.stopPropagation?.()
-                props.onMarkerClick?.(m.id)
-              }
-              dragStartLngLatRef.current.delete(m.id)
-              dragMovedPxRef.current.delete(m.id)
-            }}
-            onDragStart={(ev: MarkerDragEvent) => {
-              const ll = ev.lngLat
-              dragStartLngLatRef.current.set(m.id, { lng: ll.lng, lat: ll.lat })
-              dragMovedPxRef.current.set(m.id, 0)
-            }}
-            onDrag={(ev: MarkerDragEvent) => {
-              const start = dragStartLngLatRef.current.get(m.id)
-              if (!start || !mapRef.current) return
-              const map = mapRef.current.getMap()
-              const p0 = map.project([start.lng, start.lat])
-              const p1 = map.project([ev.lngLat.lng, ev.lngLat.lat])
-              const dx = p1.x - p0.x
-              const dy = p1.y - p0.y
-              const dist = Math.sqrt(dx*dx + dy*dy)
-              dragMovedPxRef.current.set(m.id, dist)
-            }}
-            onDragEnd={(ev: MarkerDragEvent) => {
-              const moved = dragMovedPxRef.current.get(m.id) || 0
-              dragStartLngLatRef.current.delete(m.id)
-              dragMovedPxRef.current.delete(m.id)
-              if (moved < 8) {
-                // Treat as click: do not update position, just open popup
-                props.onMarkerClick?.(m.id)
-              } else {
-                const ll = ev.lngLat
-                props.onMarkerDragEnd?.(m.id, ll.lng, ll.lat)
-                props.onMarkerClick?.(m.id)
-              }
-            }}
+            longitude={pos.lng}
+            latitude={pos.lat}
           >
-            <div style={{
-              width: LIVE_MARKER_DOT_PX,
-              height: LIVE_MARKER_DOT_PX,
-              borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
-              background: '#FFFF00',
-              border: '1px solid #333333',
-              cursor: 'pointer',
-              position: 'relative'
-            }} />
-            {/* Letter label near the marker */}
-            {m.label && (
+            <MarkerDragHandle
+              controller={dragController}
+              id={m.id}
+              lng={m.lng}
+              lat={m.lat}
+              // Drag: update position then open the popup (parity with the old
+              // native onDragEnd). Tap: just open the popup.
+              onCommit={(lng, lat) => { props.onMarkerDragEnd?.(m.id, lng, lat); props.onMarkerClick?.(m.id) }}
+              onClick={() => props.onMarkerClick?.(m.id)}
+            >
               <div style={{
-                position: 'absolute',
-                transform: 'translate(10px, -6px)',
-                background: 'rgba(255,255,255,0.85)',
-                borderRadius: 4,
-                padding: '1px 4px',
-                fontSize: 14,
-                lineHeight: '18px',
-                fontWeight: 600,
-                color: '#111',
-                border: '1px solid #e5e7eb'
-              }}>{m.label}</div>
-            )}
+                width: LIVE_MARKER_DOT_PX,
+                height: LIVE_MARKER_DOT_PX,
+                borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
+                background: '#FFFF00',
+                border: '1px solid #333333',
+                cursor: 'pointer',
+                position: 'relative'
+              }} />
+              {/* Letter label near the marker */}
+              {m.label && (
+                <div style={{
+                  position: 'absolute',
+                  transform: 'translate(10px, -6px)',
+                  background: 'rgba(255,255,255,0.85)',
+                  borderRadius: 4,
+                  padding: '1px 4px',
+                  fontSize: 14,
+                  lineHeight: '18px',
+                  fontWeight: 600,
+                  color: '#111',
+                  border: '1px solid #e5e7eb'
+                }}>{m.label}</div>
+              )}
+            </MarkerDragHandle>
           </Marker>
           {props.activeMarkerId === m.id && (
             <Popup longitude={m.lng} latitude={m.lat} anchor="top" closeButton={true} closeOnMove={false}
@@ -721,7 +705,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             </Popup>
           )}
         </React.Fragment>
-      ))}
+        )
+      })}
       {/* Photo markers — every photo is draggable. Pin position is the
           subject (m.lng/lat); fill is solid when the user has moved the
           marker away from its EXIF capture spot (= processed), hollow
@@ -750,62 +735,29 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         // Phase 13 — the active photo (popup open / selected in the side
         // panel) gets a glow + scale-up and is lifted above its neighbours.
         const isActive = activePhotoMarkerId === m.id
+        const pos = liveDragPos(m.id, m.lng, m.lat)
         return (
           <Marker
             key={m.id}
-            longitude={m.lng}
-            latitude={m.lat}
-            draggable
+            longitude={pos.lng}
+            latitude={pos.lat}
             // Auto-fan: nudge overlapping markers apart by a pixel offset
             // (anchor stays at the true lng/lat). Suppressed while THIS marker
             // is being dragged so its dot tracks the cursor without a jump.
-            offset={draggingPhotoMarkerId === m.id ? undefined : photoFan.offsets.get(m.id)}
+            offset={activeDrag?.id === m.id ? undefined : photoFan.offsets.get(m.id)}
             style={isActive ? { zIndex: 2 } : undefined}
-            onClick={(ev: MarkerEvent<MouseEvent>) => {
-              const movedPx = dragMovedPxRef.current.get(m.id) || 0
-              dragStartLngLatRef.current.delete(m.id)
-              dragMovedPxRef.current.delete(m.id)
-              if (movedPx < 8) {
-                ev.originalEvent?.stopPropagation?.()
-                setActivePhotoMarkerId(m.id)
-              }
-            }}
-            onDragStart={(ev: MarkerDragEvent) => {
-              const ll = ev.lngLat
-              dragStartLngLatRef.current.set(m.id, { lng: ll.lng, lat: ll.lat })
-              dragMovedPxRef.current.set(m.id, 0)
-              setDraggingPhotoMarkerId(m.id)
-            }}
-            onDrag={(ev: MarkerDragEvent) => {
-              const start = dragStartLngLatRef.current.get(m.id)
-              if (!start || !mapRef.current) return
-              const map = mapRef.current.getMap()
-              const p0 = map.project([start.lng, start.lat])
-              const p1 = map.project([ev.lngLat.lng, ev.lngLat.lat])
-              const dx = p1.x - p0.x
-              const dy = p1.y - p0.y
-              dragMovedPxRef.current.set(m.id, Math.sqrt(dx * dx + dy * dy))
-            }}
-            onDragEnd={(ev: MarkerDragEvent) => {
-              const movedPx = dragMovedPxRef.current.get(m.id) || 0
-              dragStartLngLatRef.current.delete(m.id)
-              dragMovedPxRef.current.delete(m.id)
-              // Clear the drag exclusion; the fan recomputes for the new
-              // position (a marker drag fires no map `moveend`, so the hook's
-              // dependency on `draggingMarkerId` is what triggers the recompute).
-              setDraggingPhotoMarkerId(null)
-              if (movedPx < 8) {
-                // Treated as click — open photo popup without moving.
-                setActivePhotoMarkerId(m.id)
-              } else {
-                const ll = ev.lngLat
-                props.onMarkerDragEnd?.(m.id, ll.lng, ll.lat)
-                // Intentionally do NOT auto-open the photo popup after a
-                // real drag — the user has just placed the subject and
-                // doesn't need the popup interrupting their flow.
-              }
-            }}
           >
+            <MarkerDragHandle
+              controller={dragController}
+              id={m.id}
+              lng={m.lng}
+              lat={m.lat}
+              // Tap → open the photo popup. Real drag → commit the new subject
+              // coords; intentionally do NOT auto-open the popup afterwards, so
+              // it doesn't interrupt the user who has just placed the subject.
+              onCommit={(lng, lat) => props.onMarkerDragEnd?.(m.id, lng, lat)}
+              onClick={() => setActivePhotoMarkerId(m.id)}
+            >
             <div style={{
               width: LIVE_MARKER_DOT_PX,
               height: LIVE_MARKER_DOT_PX,
@@ -852,6 +804,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
                 border: '1px solid #e5e7eb',
               }}>{m.label}</div>
             )}
+            </MarkerDragHandle>
           </Marker>
         )
       })}
@@ -866,71 +819,46 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           console.error('[MapProviderView] Unknown ground marker type in session:', gm.type, gm.id)
           return null
         }
+        const pos = liveDragPos(gm.id, gm.lng, gm.lat)
         return (
           <React.Fragment key={`gm-${gm.id}`}>
             <Marker
-              longitude={gm.lng}
-              latitude={gm.lat}
-              draggable
-              onClick={(ev: MarkerEvent<MouseEvent>) => {
-                const moved = dragMovedPxRef.current.get(gm.id) || 0
-                if (moved < 8) {
-                  ev.originalEvent?.stopPropagation?.()
-                  gmp.onGroundMarkerClick(gm.id)
-                }
-                dragStartLngLatRef.current.delete(gm.id)
-                dragMovedPxRef.current.delete(gm.id)
-              }}
-              onDragStart={(ev: MarkerDragEvent) => {
-                const ll = ev.lngLat
-                dragStartLngLatRef.current.set(gm.id, { lng: ll.lng, lat: ll.lat })
-                dragMovedPxRef.current.set(gm.id, 0)
-              }}
-              onDrag={(ev: MarkerDragEvent) => {
-                const start = dragStartLngLatRef.current.get(gm.id)
-                if (!start || !mapRef.current) return
-                const map = mapRef.current.getMap()
-                const p0 = map.project([start.lng, start.lat])
-                const p1 = map.project([ev.lngLat.lng, ev.lngLat.lat])
-                const dx = p1.x - p0.x
-                const dy = p1.y - p0.y
-                dragMovedPxRef.current.set(gm.id, Math.sqrt(dx*dx + dy*dy))
-              }}
-              onDragEnd={(ev: MarkerDragEvent) => {
-                const moved = dragMovedPxRef.current.get(gm.id) || 0
-                dragStartLngLatRef.current.delete(gm.id)
-                dragMovedPxRef.current.delete(gm.id)
-                if (moved < 8) {
-                  gmp.onGroundMarkerClick(gm.id)
-                } else {
-                  const ll = ev.lngLat
-                  gmp.onGroundMarkerDragEnd(gm.id, ll.lng, ll.lat)
-                  gmp.onGroundMarkerClick(gm.id)
-                }
-              }}
+              longitude={pos.lng}
+              latitude={pos.lat}
             >
-              <div style={{
-                width: LIVE_MARKER_DOT_PX,
-                height: LIVE_MARKER_DOT_PX,
-                borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
-                background: '#FF9800',
-                border: '1px solid #333333',
-                cursor: 'pointer',
-                position: 'relative'
-              }} />
-              {/* Type icon label near the marker */}
-              <div style={{
-                position: 'absolute',
-                transform: 'translate(10px, -6px)',
-                background: 'rgba(255,255,255,0.9)',
-                borderRadius: 4,
-                padding: '2px',
-                border: '1px solid #e5e7eb',
-                display: 'flex',
-                alignItems: 'center',
-              }}>
-                <Icon size={LIVE_GROUND_MARKER_ICON_PX} />
-              </div>
+              <MarkerDragHandle
+                controller={dragController}
+                id={gm.id}
+                lng={gm.lng}
+                lat={gm.lat}
+                // Drag → move then open the type picker; tap → just open it
+                // (parity with the old native handlers).
+                onCommit={(lng, lat) => { gmp.onGroundMarkerDragEnd(gm.id, lng, lat); gmp.onGroundMarkerClick(gm.id) }}
+                onClick={() => gmp.onGroundMarkerClick(gm.id)}
+              >
+                <div style={{
+                  width: LIVE_MARKER_DOT_PX,
+                  height: LIVE_MARKER_DOT_PX,
+                  borderRadius: LIVE_MARKER_DOT_BORDER_RADIUS_PX,
+                  background: '#FF9800',
+                  border: '1px solid #333333',
+                  cursor: 'pointer',
+                  position: 'relative'
+                }} />
+                {/* Type icon label near the marker */}
+                <div style={{
+                  position: 'absolute',
+                  transform: 'translate(10px, -6px)',
+                  background: 'rgba(255,255,255,0.9)',
+                  borderRadius: 4,
+                  padding: '2px',
+                  border: '1px solid #e5e7eb',
+                  display: 'flex',
+                  alignItems: 'center',
+                }}>
+                  <Icon size={LIVE_GROUND_MARKER_ICON_PX} />
+                </div>
+              </MarkerDragHandle>
             </Marker>
             {gmp.activeGroundMarkerId === gm.id && (
               <Popup longitude={gm.lng} latitude={gm.lat} anchor="top" closeButton closeOnMove={false}
@@ -1061,29 +989,34 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const prov = props.provisionalPlacement
         if (!prov) return null
         if (!props.photoStorage || !props.photoDir) return null
+        const provPos = liveDragPos('provisional-placement', prov.lng, prov.lat)
         return (
           <React.Fragment key="provisional-placement">
             <Marker
-              longitude={prov.lng}
-              latitude={prov.lat}
-              draggable
-              onDragEnd={(ev: MarkerDragEvent) => {
-                props.onProvisionalDrag?.(ev.lngLat.lng, ev.lngLat.lat)
-              }}
+              longitude={provPos.lng}
+              latitude={provPos.lat}
             >
-              <div style={{
-                width: 16,
-                height: 16,
-                borderRadius: '50%',
-                background: 'rgba(25,118,210,0.25)',
-                border: '2px dashed #1976d2',
-                boxShadow: '0 0 0 3px rgba(255,255,255,0.9)',
-                cursor: 'grab',
-              }} />
+              <MarkerDragHandle
+                controller={dragController}
+                id="provisional-placement"
+                lng={prov.lng}
+                lat={prov.lat}
+                onCommit={(lng, lat) => props.onProvisionalDrag?.(lng, lat)}
+              >
+                <div style={{
+                  width: 16,
+                  height: 16,
+                  borderRadius: '50%',
+                  background: 'rgba(25,118,210,0.25)',
+                  border: '2px dashed #1976d2',
+                  boxShadow: '0 0 0 3px rgba(255,255,255,0.9)',
+                  cursor: 'grab',
+                }} />
+              </MarkerDragHandle>
             </Marker>
             <Popup
-              longitude={prov.lng}
-              latitude={prov.lat}
+              longitude={provPos.lng}
+              latitude={provPos.lat}
               anchor="top"
               closeButton
               closeOnMove={false}

--- a/frontend/map-corridors/src/map/MarkerDragHandle.tsx
+++ b/frontend/map-corridors/src/map/MarkerDragHandle.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from 'react'
+import type { EdgePanDragController } from './useEdgePanDrag'
+
+/**
+ * Wraps a marker's visual children and routes their pointer gestures through an
+ * {@link EdgePanDragController} (see useEdgePanDrag). Renders a `display: contents`
+ * element (no box, so it never affects the marker's layout or label offset) and
+ * attaches *native* listeners: `pointerdown` starts the custom drag;
+ * `mousedown`/`touchstart`/`click`/`dblclick`/`dragstart` are stopped so they
+ * never reach mapbox's canvas-container handlers (which would otherwise pan/zoom
+ * the map or fire a map click underneath the marker).
+ */
+export function MarkerDragHandle(props: {
+  controller: EdgePanDragController
+  id: string
+  lng: number
+  lat: number
+  onCommit: (lng: number, lat: number) => void
+  onClick?: () => void
+  clickThresholdPx?: number
+  children: React.ReactNode
+}): React.ReactElement {
+  const ref = useRef<HTMLDivElement | null>(null)
+  // Latest props for the once-attached native listener to read at fire time.
+  // Updated in an effect (not during render) so the ref is only written outside
+  // render. Safe: pointerdown can only fire after mount + commit.
+  const latest = useRef(props)
+  useEffect(() => { latest.current = props })
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const onPointerDown = (e: PointerEvent) => {
+      // Primary, left-button only; let secondary buttons/touches fall through.
+      if (!e.isPrimary || e.button !== 0) return
+      e.stopPropagation()
+      const p = latest.current
+      p.controller.startDrag(e, {
+        id: p.id,
+        lng: p.lng,
+        lat: p.lat,
+        onCommit: p.onCommit,
+        onClick: p.onClick,
+        clickThresholdPx: p.clickThresholdPx,
+      })
+    }
+    const block = (e: Event) => e.stopPropagation()
+    el.addEventListener('pointerdown', onPointerDown)
+    el.addEventListener('mousedown', block)
+    el.addEventListener('touchstart', block, { passive: true })
+    el.addEventListener('click', block)
+    el.addEventListener('dblclick', block)
+    el.addEventListener('dragstart', block)
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('mousedown', block)
+      el.removeEventListener('touchstart', block)
+      el.removeEventListener('click', block)
+      el.removeEventListener('dblclick', block)
+      el.removeEventListener('dragstart', block)
+    }
+  }, [])
+
+  return <div ref={ref} style={{ display: 'contents' }}>{props.children}</div>
+}

--- a/frontend/map-corridors/src/map/MarkerDragHandle.tsx
+++ b/frontend/map-corridors/src/map/MarkerDragHandle.tsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useRef } from 'react'
-import type { EdgePanDragController } from './useEdgePanDrag'
+import type { DragHandleConfig, EdgePanDragController } from './useEdgePanDrag'
+
+/**
+ * Props are the drag config the controller needs ({@link DragHandleConfig})
+ * plus the controller itself and the marker's visual children. Reusing
+ * `DragHandleConfig` keeps this in lock-step with the controller's input — a
+ * new config field flows here automatically instead of needing a hand-mirrored
+ * copy.
+ */
+export type MarkerDragHandleProps = DragHandleConfig & {
+  controller: EdgePanDragController
+  children: React.ReactNode
+}
 
 /**
  * Wraps a marker's visual children and routes their pointer gestures through an
@@ -10,16 +22,7 @@ import type { EdgePanDragController } from './useEdgePanDrag'
  * never reach mapbox's canvas-container handlers (which would otherwise pan/zoom
  * the map or fire a map click underneath the marker).
  */
-export function MarkerDragHandle(props: {
-  controller: EdgePanDragController
-  id: string
-  lng: number
-  lat: number
-  onCommit: (lng: number, lat: number) => void
-  onClick?: () => void
-  clickThresholdPx?: number
-  children: React.ReactNode
-}): React.ReactElement {
+export function MarkerDragHandle(props: MarkerDragHandleProps): React.ReactElement {
   const ref = useRef<HTMLDivElement | null>(null)
   // Latest props for the once-attached native listener to read at fire time.
   // Updated in an effect (not during render) so the ref is only written outside
@@ -34,15 +37,10 @@ export function MarkerDragHandle(props: {
       // Primary, left-button only; let secondary buttons/touches fall through.
       if (!e.isPrimary || e.button !== 0) return
       e.stopPropagation()
-      const p = latest.current
-      p.controller.startDrag(e, {
-        id: p.id,
-        lng: p.lng,
-        lat: p.lat,
-        onCommit: p.onCommit,
-        onClick: p.onClick,
-        clickThresholdPx: p.clickThresholdPx,
-      })
+      // Strip the wrapper-only props; the rest IS a DragHandleConfig.
+      const { controller, children, ...cfg } = latest.current
+      void children // rendered separately below, not part of the drag config
+      controller.startDrag(e, cfg)
     }
     const block = (e: Event) => e.stopPropagation()
     el.addEventListener('pointerdown', onPointerDown)

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -15,7 +15,7 @@
 // recomputes when the marker set changes or when a marker enters/leaves drag
 // (the dragged marker is excluded so its dot snaps cleanly to the cursor).
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 import type { MapRef } from 'react-map-gl/mapbox'
 import type { FeatureCollection, LineString } from 'geojson'
@@ -46,10 +46,21 @@ export function useMarkerFan(params: {
   // Bumped on every map settle so the memo below re-projects against the new
   // viewport. A counter (not the camera state) keeps the dependency cheap.
   const [settleTick, setSettleTick] = useState(0)
+
+  // Edge-pan marker drag calls `map.panBy({ duration: 0 })` every animation
+  // frame, and mapbox emits a `moveend` per call — so without this guard the
+  // fan would re-project every visible marker at ~60fps while a marker is held
+  // against a viewport edge (the exact per-frame work this `moveend`-vs-`move`
+  // choice was made to avoid). Skip the bump mid-drag; the memo recomputes once
+  // on drag end via its `draggingMarkerId` dependency. A ref (not a dep of the
+  // subscribe effect) so the listener isn't re-bound on every drag transition.
+  const draggingRef = useRef(draggingMarkerId)
+  useEffect(() => { draggingRef.current = draggingMarkerId }, [draggingMarkerId])
+
   useEffect(() => {
     if (!isMapLoaded || !mapRef.current) return
     const map = mapRef.current.getMap()
-    const bump = () => setSettleTick(t => t + 1)
+    const bump = () => { if (draggingRef.current == null) setSettleTick(t => t + 1) }
     map.on('moveend', bump)
     map.on('zoomend', bump)
     // Initial compute once the map is ready (no settle event fires on load).

--- a/frontend/map-corridors/src/map/useEdgePanDrag.ts
+++ b/frontend/map-corridors/src/map/useEdgePanDrag.ts
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { MapRef } from 'react-map-gl/mapbox'
+
+/**
+ * Edge-pan marker drag.
+ *
+ * react-map-gl's built-in `draggable` Marker is pointer-event driven: the
+ * marker's lng/lat is recomputed only on `pointermove`. That makes it
+ * impossible to auto-scroll the map while the user holds the cursor still near
+ * a viewport edge — mapbox would re-project the dot at its last *geographic*
+ * position and it would slide away from the cursor as the map moves.
+ *
+ * This hook replaces the native drag with a custom pointer drag that owns the
+ * animation loop: while the cursor is within `EDGE_ZONE_PX` of an edge, the map
+ * pans every frame and the marker's lng/lat is re-derived from the (stationary)
+ * cursor each frame, so the dot stays glued to the cursor while new map area
+ * scrolls into view. Lets the user drag a marker anywhere — including off the
+ * current screen — in one continuous motion.
+ *
+ * Used by all four draggable marker types in `MapProviderView` (KML/click,
+ * photo, ground, provisional) via the {@link MarkerDragHandle} wrapper.
+ */
+
+// How close (px) the cursor must get to an edge before auto-pan kicks in.
+export const EDGE_ZONE_PX = 64
+// Max pan speed at (or past) the very edge, in px per animation frame (~60fps).
+export const MAX_PAN_PX_PER_FRAME = 18
+// Below this many px of cursor travel a gesture is treated as a click, not a
+// drag — mirrors the 8px threshold the native handlers used.
+const DEFAULT_CLICK_THRESHOLD_PX = 8
+
+export type DragHandleConfig = {
+  id: string
+  /** Marker's true anchor at drag start (not a fan-offset/override position). */
+  lng: number
+  lat: number
+  /** Commit a real move (cursor travelled past the click threshold, or the map
+   *  auto-panned during the gesture). */
+  onCommit: (lng: number, lat: number) => void
+  /** A tap that never crossed the threshold — open a popup, select, etc. */
+  onClick?: () => void
+  clickThresholdPx?: number
+}
+
+export type EdgePanDragController = {
+  startDrag: (e: PointerEvent, cfg: DragHandleConfig) => void
+}
+
+type DragState = {
+  cfg: DragHandleConfig
+  pointerId: number
+  /** Cursor-to-anchor pixel offset captured at grab time (keeps the grab point
+   *  under the cursor as it moves). */
+  offsetX: number
+  offsetY: number
+  startCx: number
+  startCy: number
+  lastCx: number
+  lastCy: number
+  vx: number
+  vy: number
+  raf: number | null
+  /** A real move happened (threshold crossed or an auto-pan occurred). */
+  moved: boolean
+  curLng: number
+  curLat: number
+}
+
+// Eased 0→1 ramp inside the edge zone; clamps so a cursor *past* the edge
+// (negative px or beyond width/height) pins at full speed. Negative result =
+// pan toward the low edge (left/top), positive = high edge (right/bottom), 0 =
+// outside both zones. Exported for unit tests.
+export function edgeVelocity(px: number, size: number): number {
+  const ease = (d: number) => {
+    const x = Math.min(Math.max(d, 0), 1)
+    return x * x
+  }
+  if (px < EDGE_ZONE_PX) return -ease((EDGE_ZONE_PX - px) / EDGE_ZONE_PX) * MAX_PAN_PX_PER_FRAME
+  if (px > size - EDGE_ZONE_PX) return ease((px - (size - EDGE_ZONE_PX)) / EDGE_ZONE_PX) * MAX_PAN_PX_PER_FRAME
+  return 0
+}
+
+type ActiveDrag = { id: string; lng: number; lat: number } | null
+
+// Builds the stable drag controller once. Every handler closes over the same
+// `state` + `mapRef`, so add/removeEventListener stays symmetric. The mutable
+// drag state is a plain closure variable (not a React ref) so it's never read
+// during render.
+function createEdgePanController(
+  mapRef: React.RefObject<MapRef | null>,
+  setActiveDrag: (d: ActiveDrag) => void,
+): EdgePanDragController & { destroy: () => void } {
+    let state: DragState | null = null
+    const getMap = () => mapRef.current?.getMap() ?? null
+    type MapboxMap = NonNullable<ReturnType<typeof getMap>>
+
+    // Re-derive the marker's lng/lat from the current cursor position and the
+    // grab offset, then publish it so the marker re-renders under the cursor.
+    const syncMarker = (map: MapboxMap, st: DragState) => {
+      const rect = map.getCanvas().getBoundingClientRect()
+      const px = st.lastCx - rect.left - st.offsetX
+      const py = st.lastCy - rect.top - st.offsetY
+      const ll = map.unproject([px, py])
+      st.curLng = ll.lng
+      st.curLat = ll.lat
+      setActiveDrag({ id: st.cfg.id, lng: ll.lng, lat: ll.lat })
+    }
+
+    const updateVelocity = (map: MapboxMap, st: DragState) => {
+      const rect = map.getCanvas().getBoundingClientRect()
+      st.vx = edgeVelocity(st.lastCx - rect.left, rect.width)
+      st.vy = edgeVelocity(st.lastCy - rect.top, rect.height)
+    }
+
+    const tick = () => {
+      const st = state
+      if (!st) return
+      st.raf = null
+      const map = getMap()
+      if (!map) return
+      if (!st.vx && !st.vy) return // idle out; a later pointermove restarts it
+      map.panBy([st.vx, st.vy], { duration: 0 })
+      st.moved = true // an auto-pan is, by definition, a real move
+      syncMarker(map, st) // keep the dot under the (stationary) cursor
+      st.raf = requestAnimationFrame(tick)
+    }
+
+    const ensureRaf = (st: DragState) => {
+      if (st.raf == null && (st.vx || st.vy)) st.raf = requestAnimationFrame(tick)
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      const st = state
+      if (!st || e.pointerId !== st.pointerId) return
+      const map = getMap()
+      if (!map) return
+      st.lastCx = e.clientX
+      st.lastCy = e.clientY
+      syncMarker(map, st)
+      const threshold = st.cfg.clickThresholdPx ?? DEFAULT_CLICK_THRESHOLD_PX
+      const ddx = e.clientX - st.startCx
+      const ddy = e.clientY - st.startCy
+      if (!st.moved && ddx * ddx + ddy * ddy >= threshold * threshold) st.moved = true
+      updateVelocity(map, st)
+      ensureRaf(st)
+    }
+
+    const removeWindowListeners = () => {
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerCancel)
+      window.removeEventListener('blur', onBlur)
+      window.removeEventListener('keydown', onKeyDown)
+    }
+
+    const endDrag = (commit: boolean) => {
+      const st = state
+      removeWindowListeners()
+      if (!st) {
+        setActiveDrag(null)
+        return
+      }
+      if (st.raf != null) cancelAnimationFrame(st.raf)
+      state = null
+      if (commit) {
+        if (st.moved) st.cfg.onCommit(st.curLng, st.curLat)
+        else st.cfg.onClick?.()
+      }
+      // On cancel (Escape / blur / pointercancel) we simply drop the override;
+      // the marker snaps back to its prop-driven (original) position.
+      setActiveDrag(null)
+    }
+
+    function onPointerUp(e: PointerEvent) {
+      const st = state
+      if (st && e.pointerId !== st.pointerId) return
+      endDrag(true)
+    }
+    function onPointerCancel() {
+      endDrag(false)
+    }
+    function onBlur() {
+      endDrag(false)
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') endDrag(false)
+    }
+
+    const startDrag = (e: PointerEvent, cfg: DragHandleConfig) => {
+      const map = getMap()
+      if (!map) return
+      // Defensively end any prior drag (no stray RAF/listeners).
+      if (state) endDrag(false)
+      const rect = map.getCanvas().getBoundingClientRect()
+      const anchor = map.project([cfg.lng, cfg.lat])
+      const cursorX = e.clientX - rect.left
+      const cursorY = e.clientY - rect.top
+      state = {
+        cfg,
+        pointerId: e.pointerId,
+        offsetX: cursorX - anchor.x,
+        offsetY: cursorY - anchor.y,
+        startCx: e.clientX,
+        startCy: e.clientY,
+        lastCx: e.clientX,
+        lastCy: e.clientY,
+        vx: 0,
+        vy: 0,
+        raf: null,
+        moved: false,
+        curLng: cfg.lng,
+        curLat: cfg.lat,
+      }
+      setActiveDrag({ id: cfg.id, lng: cfg.lng, lat: cfg.lat })
+      window.addEventListener('pointermove', onPointerMove)
+      window.addEventListener('pointerup', onPointerUp)
+      window.addEventListener('pointercancel', onPointerCancel)
+      window.addEventListener('blur', onBlur)
+      window.addEventListener('keydown', onKeyDown)
+    }
+
+    return { startDrag, destroy: () => endDrag(false) }
+}
+
+export function useEdgePanDrag(mapRef: React.RefObject<MapRef | null>): {
+  activeDrag: ActiveDrag
+  controller: EdgePanDragController
+} {
+  const [activeDrag, setActiveDrag] = useState<ActiveDrag>(null)
+  // The controller is built lazily on first use *inside* a callback (never
+  // during render), so the ref is only ever touched outside render — keeping
+  // the react-hooks/refs rule happy while staying a stable singleton.
+  const ctrlRef = useRef<(EdgePanDragController & { destroy: () => void }) | null>(null)
+  const getController = useCallback(() => {
+    if (!ctrlRef.current) ctrlRef.current = createEdgePanController(mapRef, setActiveDrag)
+    return ctrlRef.current
+  }, [mapRef, setActiveDrag])
+
+  // Tear down a drag in flight if the map unmounts mid-gesture.
+  useEffect(() => () => { ctrlRef.current?.destroy() }, [])
+
+  const controller = useMemo<EdgePanDragController>(
+    () => ({ startDrag: (e, cfg) => getController().startDrag(e, cfg) }),
+    [getController],
+  )
+  return { activeDrag, controller }
+}

--- a/frontend/map-corridors/src/map/useEdgePanDrag.ts
+++ b/frontend/map-corridors/src/map/useEdgePanDrag.ts
@@ -47,14 +47,17 @@ export type EdgePanDragController = {
 }
 
 type DragState = {
-  cfg: DragHandleConfig
-  pointerId: number
+  // Captured once at grab time and never reassigned — `readonly` so a future
+  // edit can't corrupt the click-threshold baseline or grab offset mid-gesture.
+  readonly cfg: DragHandleConfig
+  readonly pointerId: number
   /** Cursor-to-anchor pixel offset captured at grab time (keeps the grab point
    *  under the cursor as it moves). */
-  offsetX: number
-  offsetY: number
-  startCx: number
-  startCy: number
+  readonly offsetX: number
+  readonly offsetY: number
+  readonly startCx: number
+  readonly startCy: number
+  // Mutated as the gesture progresses.
   lastCx: number
   lastCy: number
   vx: number
@@ -85,8 +88,9 @@ type ActiveDrag = { id: string; lng: number; lat: number } | null
 // Builds the stable drag controller once. Every handler closes over the same
 // `state` + `mapRef`, so add/removeEventListener stays symmetric. The mutable
 // drag state is a plain closure variable (not a React ref) so it's never read
-// during render.
-function createEdgePanController(
+// during render. Exported so the drag state machine can be unit-tested with a
+// fake map + fake requestAnimationFrame (see useEdgePanDrag.test.ts).
+export function createEdgePanController(
   mapRef: React.RefObject<MapRef | null>,
   setActiveDrag: (d: ActiveDrag) => void,
 ): EdgePanDragController & { destroy: () => void } {
@@ -136,11 +140,18 @@ function createEdgePanController(
       if (!map) return
       st.lastCx = e.clientX
       st.lastCy = e.clientY
-      syncMarker(map, st)
-      const threshold = st.cfg.clickThresholdPx ?? DEFAULT_CLICK_THRESHOLD_PX
-      const ddx = e.clientX - st.startCx
-      const ddy = e.clientY - st.startCy
-      if (!st.moved && ddx * ddx + ddy * ddy >= threshold * threshold) st.moved = true
+      // Below the click threshold the gesture is still a potential tap: track
+      // the cursor but DON'T move the dot or start auto-pan yet, so a click
+      // never visually nudges the marker (parity with the native draggable,
+      // which only repositioned once the drag was recognised).
+      if (!st.moved) {
+        const threshold = st.cfg.clickThresholdPx ?? DEFAULT_CLICK_THRESHOLD_PX
+        const ddx = e.clientX - st.startCx
+        const ddy = e.clientY - st.startCy
+        if (ddx * ddx + ddy * ddy < threshold * threshold) return
+        st.moved = true
+      }
+      syncMarker(map, st) // keep the grab point under the cursor
       updateVelocity(map, st)
       ensureRaf(st)
     }


### PR DESCRIPTION
## Summary
- When zoomed in, you can now drag a marker (photo, KML/click, ground, or no-GPS provisional pin) toward any viewport edge and the **map auto-scrolls** in that direction, with the dot staying under the cursor — drag a marker anywhere, including off the current screen, in one continuous motion. No more zoom-out → place → zoom-in → nudge dance.
- Replaces react-map-gl's built-in `draggable` (pointer-event driven, so it can't scroll the map mid-drag without the dot detaching) with a custom pointer drag (`useEdgePanDrag` hook + `MarkerDragHandle` wrapper) that owns a `requestAnimationFrame` loop: cursor in a 64px edge zone → `panBy` every frame (quadratic ease, clamps to full speed off-screen) → re-derive the marker's lng/lat from the cursor each frame.
- Preserves all existing behavior: 8px click-vs-drag threshold, per-type click actions (photo popup, label/type pickers), auto-fan suppression of the dragged dot, and moved-photo fill. Escape / window-blur / pointercancel cancel the pan and revert. Works on mouse + touch, and on both the Mapbox and MapLibre-fallback renderers.

## Test plan
- [x] `pnpm build` (tsc -b + vite) — clean
- [x] `pnpm test` — 657 pass (652 existing + 5 new), 2 todo
- [x] `eslint` clean on new files
- [x] New unit test for the edge-velocity ramp (dead zone, edge direction signs, off-screen clamp, quadratic ease)
- [ ] **Manual:** zoom in, drag a photo dot to the top edge and hold → map scrolls up, dot stays under cursor; repeat for bottom/left/right + a corner
- [ ] **Manual:** release mid-scroll → marker commits at cursor position and persists (OPFS round-trip)
- [ ] **Manual:** plain click still opens the photo popup; Escape mid-drag stops the pan and snaps the marker back
- [ ] **Manual:** repeat edge-drag for KML/click, ground, and provisional pin (popup tracks the pin); verify on touch + MapLibre fallback style

🤖 Generated with [Claude Code](https://claude.com/claude-code)