### PR TITLE
fix(map-corridors): guard auto-fan projection against NaN on tilt #minor

### DIFF
--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.test.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterAll } from 'vitest'
+import { buildMarkerFan, type ProjectionMap } from './useMarkerFan'
+import type { PhotoMarker } from '../../types/markers'
+
+// Regression coverage for the tilt white-screen crash (PR #92). When the map is
+// pitched, photo markers above the horizon (or behind the camera) project to
+// non-finite screen pixels; feeding those into the clusterer and the downstream
+// `unproject` makes the LngLat constructor throw. Because the fan runs in a
+// useMemo DURING RENDER, an uncaught throw unmounts the React tree → blank app.
+// `buildMarkerFan` is the pure projection boundary extracted from the hook so
+// both guards can be exercised here with a fake map — no live map, no jsdom.
+// The clustering/layout maths themselves live in markerFan.test.ts.
+
+// `safeUnproject` warns once in dev when it swallows an unexpected error —
+// silence it so a passing run has clean output.
+const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+afterAll(() => warnSpy.mockRestore())
+
+function photo(id: string, lng: number, lat = 0): PhotoMarker {
+  return { id, lng, lat, name: `${id}.JPG`, photoId: `p-${id}` }
+}
+
+function fakeMap(overrides: Partial<ProjectionMap>): ProjectionMap {
+  return {
+    project: ([lng]) => ({ x: lng, y: 0 }),
+    unproject: () => ({ lng: 0, lat: 0 }),
+    ...overrides,
+  }
+}
+
+// a@x0 and b@x5 sit within the 20px default overlap threshold → one fanned group.
+const overlappingProject = ([lng]: [number, number]) => ({ x: lng === 10 ? 0 : 5, y: 0 })
+
+describe('buildMarkerFan — projection guards', () => {
+  it('fans two overlapping markers and emits finite leader coordinates', () => {
+    const map = fakeMap({
+      project: overlappingProject,
+      unproject: ([x, y]) => ({ lng: x / 100, lat: y / 100 }),
+    })
+    const res = buildMarkerFan(map, [photo('a', 10), photo('b', 11)])
+
+    expect(res.offsets.size).toBe(2)
+    expect(res.leaders.features).toHaveLength(2)
+    for (const f of res.leaders.features) {
+      for (const [lng, lat] of f.geometry.coordinates) {
+        expect(Number.isFinite(lng)).toBe(true)
+        expect(Number.isFinite(lat)).toBe(true)
+      }
+    }
+  })
+
+  it('drops a marker whose project() is NaN (above horizon) without throwing', () => {
+    // c projects to NaN; a,b stay finite & overlapping. The NaN point must never
+    // reach the clusterer.
+    const map = fakeMap({
+      project: ([lng]) => (lng === 99 ? { x: NaN, y: NaN } : overlappingProject([lng, 0])),
+      unproject: ([x, y]) => ({ lng: x / 100, lat: y / 100 }),
+    })
+
+    let res!: ReturnType<typeof buildMarkerFan>
+    expect(() => { res = buildMarkerFan(map, [photo('a', 10), photo('b', 11), photo('c', 99)]) }).not.toThrow()
+    expect(res.offsets.has('c')).toBe(false)
+    expect(res.offsets.size).toBe(2)
+  })
+
+  it('does not throw when unproject() throws on an above-horizon leader endpoint', () => {
+    const map = fakeMap({
+      project: overlappingProject,
+      unproject: () => { throw new Error('Invalid LngLat object: (NaN, NaN)') },
+    })
+
+    let res!: ReturnType<typeof buildMarkerFan>
+    expect(() => { res = buildMarkerFan(map, [photo('a', 10), photo('b', 11)]) }).not.toThrow()
+    // Markers still fan (offsets are screen-space); only the leader lines drop.
+    expect(res.offsets.size).toBe(2)
+    expect(res.leaders.features).toHaveLength(0)
+  })
+
+  it('drops a leader whose unproject() yields non-finite lng/lat', () => {
+    const map = fakeMap({
+      project: overlappingProject,
+      unproject: () => ({ lng: NaN, lat: NaN }),
+    })
+    const res = buildMarkerFan(map, [photo('a', 10), photo('b', 11)])
+
+    expect(res.leaders.features).toHaveLength(0)
+  })
+
+  it('returns no fan for fewer than two visible markers', () => {
+    const res = buildMarkerFan(fakeMap({}), [photo('a', 10)])
+    expect(res.offsets.size).toBe(0)
+    expect(res.leaders.features).toHaveLength(0)
+  })
+})

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -33,6 +33,86 @@ const EMPTY: UseMarkerFanResult = {
   leaders: { type: 'FeatureCollection', features: [] },
 }
 
+// A leader endpoint landing above the horizon makes `unproject` throw; that is
+// an expected, recoverable case (we just drop the line), so we must NOT rethrow
+// — doing so during render is the white-screen bug this hook guards against. But
+// silently swallowing every error hides genuinely unexpected failures, so warn
+// once in dev. Module-level latch keeps it to a single line instead of one per
+// off-horizon leader per recompute (which fires on every map settle).
+let unprojectWarned = false
+function warnUnprojectOnce(err: unknown): void {
+  if (unprojectWarned || !import.meta.env.DEV) return
+  unprojectWarned = true
+  console.warn('[useMarkerFan] unproject failed for a leader endpoint; dropping its line.', err)
+}
+
+/**
+ * The slice of the map API the fan needs: project lng/lat → screen pixels and
+ * back. Declared structurally (a mapbox `Map` satisfies it) so the projection
+ * boundary can be unit-tested with a plain fake — no live map, no jsdom.
+ */
+export interface ProjectionMap {
+  project(lngLat: [number, number]): { x: number; y: number }
+  unproject(pt: [number, number]): { lng: number; lat: number }
+}
+
+/**
+ * Pure projection boundary for the fan: screen-project the visible markers,
+ * cluster them, and unproject the leader segments back to lng/lat. Split out of
+ * the hook's `useMemo` so it carries no React/map-instance dependency and can be
+ * tested directly. Guards the two ways a pitched map produces non-finite
+ * geometry:
+ *
+ *  1. Markers above the horizon (or behind the camera) `project()` to NaN/Inf.
+ *     Feeding those into the clusterer poisons the fan and the downstream
+ *     `unproject` throws on NaN via the LngLat constructor — and because the
+ *     caller runs this during render, an uncaught throw blanks the whole app
+ *     (white screen). Drop non-finite points up front.
+ *  2. Belt-and-suspenders: even from finite inputs an `unproject` can land above
+ *     the horizon and throw, so `safeUnproject` skips any leader endpoint it
+ *     can't resolve instead of propagating.
+ */
+export function buildMarkerFan(
+  map: ProjectionMap,
+  visible: readonly PhotoMarker[],
+  thresholdPx?: number,
+): UseMarkerFanResult {
+  if (visible.length < 2) return EMPTY
+
+  const points: ScreenPoint[] = visible.flatMap(m => {
+    const p = map.project([m.lng, m.lat])
+    return Number.isFinite(p.x) && Number.isFinite(p.y) ? [{ id: m.id, x: p.x, y: p.y }] : []
+  })
+  if (points.length < 2) return EMPTY
+
+  const fan = computeMarkerFan(points, thresholdPx ? { thresholdPx } : undefined)
+  if (fan.offsets.size === 0) return EMPTY
+
+  const safeUnproject = (pt: [number, number]): [number, number] | null => {
+    try {
+      const ll = map.unproject(pt)
+      return Number.isFinite(ll.lng) && Number.isFinite(ll.lat) ? [ll.lng, ll.lat] : null
+    } catch (err) {
+      warnUnprojectOnce(err)
+      return null
+    }
+  }
+
+  const features = fan.leaders.flatMap<FeatureCollection<LineString>['features'][number]>(l => {
+    const from = safeUnproject(l.from)
+    const to = safeUnproject(l.to)
+    if (!from || !to) return []
+    return [{
+      type: 'Feature',
+      id: l.id,
+      geometry: { type: 'LineString', coordinates: [from, to] },
+      properties: {},
+    }]
+  })
+
+  return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+}
+
 export function useMarkerFan(params: {
   mapRef: RefObject<MapRef | null>
   isMapLoaded: boolean
@@ -74,47 +154,7 @@ export function useMarkerFan(params: {
   return useMemo<UseMarkerFanResult>(() => {
     if (!isMapLoaded || !mapRef.current || !markers) return EMPTY
     const visible = markers.filter(m => isPhotoMarkerVisible(m) && m.id !== draggingMarkerId)
-    if (visible.length < 2) return EMPTY
-
-    const map = mapRef.current.getMap()
-    // When the map is pitched, markers above the horizon (or behind the camera)
-    // project to non-finite screen pixels. Feeding NaN/Infinity into the
-    // clusterer poisons the fan, and downstream `unproject` throws on NaN via
-    // the LngLat constructor — which, since this runs in a useMemo during
-    // render, blanks the whole app (white screen). Drop those points up front.
-    const points: ScreenPoint[] = visible.flatMap(m => {
-      const p = map.project([m.lng, m.lat])
-      return Number.isFinite(p.x) && Number.isFinite(p.y) ? [{ id: m.id, x: p.x, y: p.y }] : []
-    })
-    if (points.length < 2) return EMPTY
-
-    const fan = computeMarkerFan(points, thresholdPx ? { thresholdPx } : undefined)
-    if (fan.offsets.size === 0) return EMPTY
-
-    // Belt-and-suspenders: even with finite inputs, an unproject can land above
-    // the horizon and throw. Skip any leader whose endpoint can't be resolved.
-    const safeUnproject = (pt: [number, number]): [number, number] | null => {
-      try {
-        const ll = map.unproject(pt)
-        return Number.isFinite(ll.lng) && Number.isFinite(ll.lat) ? [ll.lng, ll.lat] : null
-      } catch {
-        return null
-      }
-    }
-
-    const features = fan.leaders.flatMap<FeatureCollection<LineString>['features'][number]>(l => {
-      const from = safeUnproject(l.from)
-      const to = safeUnproject(l.to)
-      if (!from || !to) return []
-      return [{
-        type: 'Feature',
-        id: l.id,
-        geometry: { type: 'LineString', coordinates: [from, to] },
-        properties: {},
-      }]
-    })
-
-    return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+    return buildMarkerFan(mapRef.current.getMap(), visible, thresholdPx)
     // settleTick intentionally in deps: it's the signal that the viewport
     // moved and projections must be recomputed.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -77,29 +77,41 @@ export function useMarkerFan(params: {
     if (visible.length < 2) return EMPTY
 
     const map = mapRef.current.getMap()
-    const points: ScreenPoint[] = visible.map(m => {
+    // When the map is pitched, markers above the horizon (or behind the camera)
+    // project to non-finite screen pixels. Feeding NaN/Infinity into the
+    // clusterer poisons the fan, and downstream `unproject` throws on NaN via
+    // the LngLat constructor — which, since this runs in a useMemo during
+    // render, blanks the whole app (white screen). Drop those points up front.
+    const points: ScreenPoint[] = visible.flatMap(m => {
       const p = map.project([m.lng, m.lat])
-      return { id: m.id, x: p.x, y: p.y }
+      return Number.isFinite(p.x) && Number.isFinite(p.y) ? [{ id: m.id, x: p.x, y: p.y }] : []
     })
+    if (points.length < 2) return EMPTY
 
     const fan = computeMarkerFan(points, thresholdPx ? { thresholdPx } : undefined)
     if (fan.offsets.size === 0) return EMPTY
 
-    const features: FeatureCollection<LineString>['features'] = fan.leaders.map(l => {
-      const from = map.unproject(l.from)
-      const to = map.unproject(l.to)
-      return {
+    // Belt-and-suspenders: even with finite inputs, an unproject can land above
+    // the horizon and throw. Skip any leader whose endpoint can't be resolved.
+    const safeUnproject = (pt: [number, number]): [number, number] | null => {
+      try {
+        const ll = map.unproject(pt)
+        return Number.isFinite(ll.lng) && Number.isFinite(ll.lat) ? [ll.lng, ll.lat] : null
+      } catch {
+        return null
+      }
+    }
+
+    const features = fan.leaders.flatMap<FeatureCollection<LineString>['features'][number]>(l => {
+      const from = safeUnproject(l.from)
+      const to = safeUnproject(l.to)
+      if (!from || !to) return []
+      return [{
         type: 'Feature',
         id: l.id,
-        geometry: {
-          type: 'LineString',
-          coordinates: [
-            [from.lng, from.lat],
-            [to.lng, to.lat],
-          ],
-        },
+        geometry: { type: 'LineString', coordinates: [from, to] },
         properties: {},
-      }
+      }]
     })
 
     return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }


### PR DESCRIPTION
## Problem

Rotating the map then tilting it blanked the entire app (white screen) with:

\`\`\`
Uncaught Error: Invalid LngLat object: (NaN, NaN)
  at IC.unproject ...
  at Proxy.coordinateLocation ...
  at Object.useMemo (useMarkerFan)
\`\`\`

When the map is **pitched**, photo markers above the horizon (or behind the camera) project to non-finite screen pixels. Those `NaN` points poison the marker-fan clusterer, and the downstream `map.unproject()` throws via the `LngLat` constructor. Since `useMarkerFan` does this inside a `useMemo` **during render**, the throw unmounts the React tree → white screen.

## Fix

Guard two layers in `useMarkerFan.ts`:

1. **Root cause** — filter non-finite `project()` results *before* clustering, so a NaN screen-point can never enter the fan.
2. **Belt-and-suspenders** — `safeUnproject()` wraps `unproject()` in try/catch + a finite check and skips any leader endpoint above the horizon instead of throwing.

Markers still on-screen fan normally; off-horizon ones just drop their leader line until they re-enter the viewport.

## Testing

- `tsc --noEmit -p tsconfig.app.json` → clean ✅
- `markerFan.test.ts` → 9/9 pass ✅

> Note: the full suite has ~76 pre-existing failures unrelated to this change — all jsdom-environment errors (`document`/`window`/`DOMParser` not defined) in KML/PNG test files.

## Manual verification

- [ ] Rotate + tilt the map with ≥2 overlapping photo markers — no white screen, fan/leaders behave.