### PR TITLE
fix(map-corridors): hide rejected photos in PNG/KML exports

### DIFF
--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -44,6 +44,7 @@ import { PhotoPreviewModal } from './components/PhotoPreviewModal'
 import { resolveVariantFlags } from './photoVariants/resolveVariantFlags'
 import { resolveActivePhotoId } from './activePhoto/activePhoto'
 import { isProvisionalValid, type ProvisionalPlacement } from './provisionalPlacement/provisionalPlacement'
+import { isMarkerVisibleOnMap } from './map/photoLayers/markerVisibility'
 import type { PhotoMarker } from './types/markers'
 import {
   buildMapPicks,
@@ -929,8 +930,13 @@ function App() {
     }
     // Export photo markers and ground markers — no corridors, gates, or exact point labels
     const features: any[] = []
-    if (markers.length) {
-      const markerFeatures = markers.map(m => {
+    // Rejected photos are hidden on the live map — keep the KML export
+    // consistent so a rejected co-located variant doesn't ship a stray pin at
+    // its original EXIF spot. Non-photo (KML / click-placed) markers always
+    // export. (isMarkerVisibleOnMap — same gate the PNG print uses.)
+    const exportableMarkers = markers.filter(isMarkerVisibleOnMap)
+    if (exportableMarkers.length) {
+      const markerFeatures = exportableMarkers.map(m => {
         // KML <name>: custom name (with original filename in parens) prefixed by
         // the competition label when present — e.g. "A - TP1 (DSC_0123.JPG)".
         // See buildPhotoMarkerKmlName for the exact branches (unit-tested).

--- a/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerVisibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { isPhotoMarkerVisible } from '../map/photoLayers/markerVisibility'
+import { isPhotoMarkerVisible, isMarkerVisibleOnMap } from '../map/photoLayers/markerVisibility'
 import type { PhotoMarker } from '../types/markers'
 
 // The live-pin filter for the map. Rejecting a photo must remove its pin (it
@@ -26,5 +26,26 @@ describe('isPhotoMarkerVisible', () => {
 
   it('hides a marker without a photoId (KML/click-placed, not a photo pin)', () => {
     expect(isPhotoMarkerVisible(pm({ photoId: undefined }))).toBe(false)
+  })
+})
+
+// The export gate (PNG print + KML). Must equal the union of the live map's two
+// render passes — photo pins AND non-photo (KML/click) pins — so an export ships
+// exactly what's on screen. Regression: the print path used to render EVERY
+// marker, reprinting a rejected co-located variant at its original EXIF spot
+// next to the kept photo the user dragged into place (the "duplicate dot" bug).
+describe('isMarkerVisibleOnMap (export gate)', () => {
+  it('keeps neutral and picked photos (both track and turning categories)', () => {
+    expect(isMarkerVisibleOnMap(pm({}))).toBe(true)
+    expect(isMarkerVisibleOnMap(pm({ flag: 'pick-track' }))).toBe(true)
+    expect(isMarkerVisibleOnMap(pm({ flag: 'pick-turning' }))).toBe(true)
+  })
+
+  it('drops a rejected photo so it is not reprinted at its original location', () => {
+    expect(isMarkerVisibleOnMap(pm({ flag: 'reject' }))).toBe(false)
+  })
+
+  it('keeps KML/click-placed markers (no photoId — always rendered on the live map)', () => {
+    expect(isMarkerVisibleOnMap(pm({ photoId: undefined }))).toBe(true)
   })
 })

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -6,7 +6,7 @@ import type { LngLatBoundsLike, LngLatLike, StyleSpecification } from 'mapbox-gl
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useI18n } from '../contexts/I18nContext'
 import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
-import { isPhotoMarkerVisible } from './photoLayers/markerVisibility'
+import { isPhotoMarkerVisible, isMarkerVisibleOnMap } from './photoLayers/markerVisibility'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
 import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
@@ -351,7 +351,13 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           layout: ov.layout,
         }))
 
-      const printMarkers = (props.markers || []).map(m => ({
+      // Match the live map: rejected photos are hidden on screen, so the print
+      // must skip them too — otherwise a rejected co-located variant prints a
+      // stray dot at its original EXIF location next to the kept photo the user
+      // dragged into place, looking like a duplicate. (isMarkerVisibleOnMap.)
+      const printMarkers = (props.markers || [])
+        .filter(isMarkerVisibleOnMap)
+        .map(m => ({
           lng: m.lng,
           lat: m.lat,
           label: m.label,

--- a/frontend/map-corridors/src/map/photoLayers/markerVisibility.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerVisibility.ts
@@ -10,3 +10,18 @@ import type { PhotoMarker } from '../../types/markers'
 export function isPhotoMarkerVisible(m: PhotoMarker): boolean {
   return !!m.photoId && m.flag !== 'reject'
 }
+
+/**
+ * Does this marker draw a pin ANYWHERE on the live map? The live map renders
+ * markers in two passes — photo pins (`isPhotoMarkerVisible`) and non-photo
+ * KML/click-placed pins (`!m.photoId`, always shown) — so the on-screen set is
+ * their union: everything except a rejected photo.
+ *
+ * Exports (PNG print, KML) MUST gate on this so they ship exactly what the user
+ * sees. Filtering on `isPhotoMarkerVisible` alone would wrongly drop manually
+ * placed markers (no `photoId`); not filtering at all reprints rejected photos
+ * at their original EXIF spot — the "duplicate dot after dragging" bug.
+ */
+export function isMarkerVisibleOnMap(m: PhotoMarker): boolean {
+  return !m.photoId || isPhotoMarkerVisible(m)
+}


### PR DESCRIPTION
## Summary
- The live map hides rejected photos (`isPhotoMarkerVisible` → `flag === 'reject'` excluded), but both export paths rendered the **raw, unfiltered** marker array.
- A rejected co-located variant therefore reprinted at its original EXIF location next to the kept photo the user dragged into place — appearing as a duplicate dot in the export only ("looks ok on the map, doubled in the export").
- Adds a shared `isMarkerVisibleOnMap` gate (union of the live map's two render passes: photo pins via `isPhotoMarkerVisible` + non-photo KML/click pins) and applies it in `captureForPrint` (PNG) and the KML export, so exports ship exactly what's on screen.

## Test plan
- [x] `tsc -b` clean
- [x] `vitest run` — 678 pass (43 files), incl. 3 new `isMarkerVisibleOnMap` regression tests
- [ ] Manual: drag a photo to a new position, reject a co-located variant → PNG print + KML export show only the kept photo at the new spot (no stray dot at the original EXIF location)
- [ ] Manual: KML/click-placed (non-photo) markers still export

🤖 Generated with [Claude Code](https://claude.com/claude-code)