### PR TITLE
feat(map-corridors): compare co-located photos from the map #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ new desktop release.
   belongs to. Picking does not auto-place the photo; the existing "Send to set"
   / "Send to TP photos" controls still do that. Sessions saved before this
   release load their existing picks as track photos (no picks are lost).
+- **Map Corridors:** compare co-located photos straight from the map. Each
+  fanned cluster shows a small **⇄ N** pill at its centre — click it to open the
+  photos side-by-side and pick the best one (2–3 open immediately; larger groups
+  drop into a selection to trim down). You can also **Ctrl/Cmd/Shift-click** any
+  dots to multi-select them (highlighted with a ring); a floating **Compare**
+  bar then opens the side-by-side view. Both routes feed the existing compare
+  modal (winner stays, the rest move to Odmítnuté).
 
 ## [2.19.0] - 2026-05-30
 

--- a/docs/map-compare-from-map/port-plan.md
+++ b/docs/map-compare-from-map/port-plan.md
@@ -1,0 +1,161 @@
+# Port plan — "Compare co-located photos from the map" (supersedes PR #84)
+
+## Background
+
+PR #84 (`feat/map-ux-maximize-preview-autofan`) is **stale and conflicting**
+(`mergeable: CONFLICTING`, 25 commits behind `main`, still a draft). Its branch
+name lists three features, but it was rebased down to **one commit**:
+
+> `993e74f feat(map-corridors): compare co-located photos from the map (cluster pill + modifier-select)`
+
+The other features the branch name implies (big photo preview, maximize window,
+auto-fan) already landed on `main` independently — including the auto-fan
+projection-guard fixes (#91/#92) and the edge-pan marker-drag refactor (#91),
+which are exactly what #84 collides with.
+
+**Decision:** rather than merge/rebase #84 and untangle conflicts (which would
+also leave dangling references to the removed `draggingPhotoMarkerId` state that
+git would *not* flag), we re-apply the feature cleanly on top of current `main`,
+reusing #84's already-written logic and rewiring only the parts that main's
+refactor changed. Then close #84 referencing the new PR.
+
+## The feature (unchanged scope from #84)
+
+Compare co-located (overlapping) photos straight from the map. Two entry points,
+both feeding the **existing** compare modal via `onCompareVariants`:
+
+1. **Cluster pill** — each fanned cluster shows a small `⇄ N` pill at its
+   screen-space centroid (where the leader lines converge). Click → compare the
+   cluster's photos. ≤3 opens the side-by-side modal directly; >3 drops them
+   into a selection so the floating bar can trim down.
+2. **Modifier multi-select** — Ctrl/Cmd/Shift-click any dots to multi-select
+   (purple ring highlight). A floating **Compare** bar appears (enabled for 2–3,
+   disabled-with-hint over the cap, mirroring `PhotoListPanel`). Plain click
+   still opens the photo popup and clears any pending selection.
+
+## What main already provides (reuse, don't recreate)
+
+| Asset | Location (on `main`) | Note |
+|---|---|---|
+| `handleCompareVariants` | `App.tsx:747` | Compare-modal handler — already exists (side panel uses it). |
+| `onCompareVariants` prop | `App.tsx:1391` → **`PhotoListPanel`** | Currently wired to the panel only, **not** MapProviderView. |
+| `MAX_COMPARE_VARIANTS = 3` | `components/PhotoListPanel.tsx:115` (exported) | Import from here — no new constant. |
+| i18n `photo.list.compareSelected / compareLimitTip / clearSelection` | `locales/{cs,en}.json` | Already present. |
+| `computeMarkerFan` | `map/photoLayers/markerFan.ts` | **Unchanged on main since base** → #84's clusters diff cherry-picks cleanly. |
+| `buildMarkerFan` + `safeUnproject` | `map/photoLayers/useMarkerFan.ts` | NaN-guarded projection boundary from #91/#92. Cluster centroids must route through `safeUnproject`. |
+| `useEdgePanDrag` / `MarkerDragHandle` | `map/useEdgePanDrag.ts`, `map/MarkerDragHandle.tsx` | New drag system that replaced inline handlers. `DragHandleConfig.onClick?: () => void` fires bare (no event). |
+
+## The one real design decision (region 4)
+
+#84 put its Ctrl/Cmd/Shift-click logic **inside an inline `onClick` handler that
+main has since deleted**. On main, a marker tap routes through
+`MarkerDragHandle` → `useEdgePanDrag`, and the click callback is:
+
+```ts
+// useEdgePanDrag.ts:41
+onClick?: () => void          // fires bare — NO event, NO modifier keys
+// invoked at line 178:  else st.cfg.onClick?.()
+```
+
+To support modifier-click selection we must **forward modifier state through the
+drag controller**. Chosen approach (minimal, matches the codebase's typed-
+boundary style, e.g. `ProjectionMap`):
+
+```ts
+// useEdgePanDrag.ts
+export type ClickMods = { ctrl: boolean; meta: boolean; shift: boolean }
+onClick?: (mods: ClickMods) => void
+```
+
+- Capture modifiers from the pointer event at the click decision point
+  (`onPointerUp`, line ~178) and pass them to `onClick`.
+- Backward-compatible: existing callers (`onClick={() => setActivePhotoMarkerId(m.id)}`)
+  keep working — the arg is optional to read.
+
+This is the only non-mechanical change; everything else is additive.
+
+## Change set (branch off current `main`)
+
+Branch: `feat/map-compare-selection`
+
+1. **`map/photoLayers/markerFan.ts`** — *cherry-pick #84 verbatim.* Add
+   `MarkerCluster { ids, centroid }`, add `clusters` to `MarkerFanResult`, push
+   one per fanned group in `computeMarkerFan`. (File unchanged on main → clean.)
+
+2. **`map/photoLayers/useMarkerFan.ts`** — add `FanCluster { ids,
+   centroidLngLat, count }` + `clusters` to `UseMarkerFanResult` + `EMPTY`.
+   **Rewire onto main:** compute clusters inside `buildMarkerFan`, routing each
+   centroid through the existing **`safeUnproject`** (drop a cluster whose
+   centroid can't unproject) — *not* #84's raw `map.unproject`, which would
+   reintroduce the off-horizon white-screen crash #91/#92 fixed.
+
+3. **`map/useEdgePanDrag.ts`** — extend `DragHandleConfig.onClick` to
+   `(mods: ClickMods) => void` and forward modifier keys (see above).
+   `MarkerDragHandle.tsx` needs no change (it spreads `DragHandleConfig`).
+
+4. **`map/MapProviderView.tsx`** — the bulk. Additive unless noted:
+   - Add `onCompareVariants?: (markers: readonly PhotoMarker[]) => void` to props.
+   - Add map-side selection state: `selectedPhotoMarkerIds`, `togglePhotoSelection`,
+     `clearPhotoSelection`, prune-on-disappear effect, Esc-to-clear effect,
+     `markersByIdForCompare`, `selectedCompareMarkers`, `compareOrSelect`.
+   - `<MapGL onClick={() => selectedPhotoMarkerIds.length && clearPhotoSelection()}>`
+     (add alongside main's existing `onMove` — keep both).
+   - In the photo-marker loop: add `const isSelected = selectedPhotoMarkerIds.includes(m.id)`;
+     merge the dot `boxShadow`/`transform` to layer the purple selected-ring with
+     the active glow (keep main's `position:'relative'`); bump `style` zIndex for
+     `isActive || isSelected`.
+   - **Rewire the marker `onClick`** to the new modifier-aware callback:
+     `onClick={(mods) => (mods.ctrl||mods.meta||mods.shift) ? togglePhotoSelection(m.id)
+     : (clearPhotoSelection(), setActivePhotoMarkerId(m.id))}`.
+   - Render the **cluster pill** (`photoFan.clusters.map(...)` → `<Marker>` with the
+     `⇄ N` button) gated on `props.onCompareVariants`. Place near the existing
+     fan-leaders `<Source>`/`<Layer>` (~line 519).
+   - Render the **floating compare bar** before `</MapGL>` (alongside main's
+     reset-north compass — keep both).
+   - Import `MAX_COMPARE_VARIANTS` from `../components/PhotoListPanel`.
+
+5. **`App.tsx`** — one line: pass `onCompareVariants={handleCompareVariants}` to
+   the **`MapProviderView`** element (handler already exists; only the panel gets
+   it today).
+
+6. **`locales/en.json` + `cs.json`** — add `photo.map.comparePill` +
+   `photo.map.compareAction` (the only two new keys; the `photo.list.*` ones
+   already exist).
+
+7. **`__tests__/markerFan.test.ts`** — cherry-pick #84's two new cases (clusters
+   reported with ids+centroid; no clusters when nothing overlaps).
+
+8. **`CHANGELOG.md`** — port #84's bullet under the existing "Map Corridors"
+   block.
+
+## Verification
+
+- `pnpm --filter <map-corridors> test` (vitest) — incl. the new markerFan cases.
+- `pnpm --filter <map-corridors> build` (`tsc -b && vite build`) — type-check;
+  confirms the `onClick` signature change compiles at every call site and no
+  dangling `draggingPhotoMarkerId` survives.
+- `pnpm --filter <map-corridors> lint`.
+- Manual (per CLAUDE.md — green tests don't prove UI): overlapping dots show the
+  `⇄ N` pill; pill compares; Ctrl/Cmd/Shift-click rings dots and shows the bar;
+  plain click opens popup + clears selection; Esc clears; tilt/rotate the map
+  with a cluster near the horizon → no white screen (the `safeUnproject` guard).
+
+## Risks / fresh-perspective self-check
+
+- **Centroid above horizon:** #84's raw `unproject` is the main trap; the plan
+  explicitly routes through `safeUnproject`. New test idea: a cluster centroid
+  that unprojects to non-finite should be dropped, not thrown.
+- **Modifier capture point:** must read modifiers at pointer-up (the click
+  decision), and confirm a *drag* never fires `onClick` (existing `st.moved`
+  guard already handles this — verify the modifier change doesn't bypass it).
+- **Selection vs active glow coexistence:** a marker can be both selected and
+  active — the layered `boxShadow` array must render both; covered in manual QA.
+- **Pill stacking / zIndex:** pill `<Marker zIndex:3>` must sit above dots
+  (`zIndex:2` when active) and below popups — verify ordering.
+- **`onCompareVariants` optional:** all new map UI is gated on the prop, so other
+  embeddings of MapProviderView (if any) stay unaffected.
+
+## Estimate
+
+Without AI: ~4–6 h (diagnose the conflict surface, design the controller
+change, port + test). Log actuals with `/time-log` after implementation.

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -1359,6 +1359,7 @@ function App() {
             activePhotoMarkerId={activePhotoMarkerId}
             onActivePhotoMarkerChange={setActivePhotoMarkerId}
             onPhotoPreview={handleOpenPhotoPreview}
+            onCompareVariants={handleCompareVariants}
             provisionalPlacement={provisionalPlacement}
             onProvisionalDrag={handleProvisionalDrag}
             onProvisionalCommit={handleProvisionalCommit}

--- a/frontend/map-corridors/src/__tests__/buildMarkerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/buildMarkerFan.test.ts
@@ -27,18 +27,18 @@ function fakeMap(throwAt?: [number, number]): ProjectionMap {
 }
 
 describe('buildMarkerFan clusters', () => {
-  it('surfaces one cluster per fanned group with lng/lat centroid and count', () => {
+  it('surfaces one cluster per fanned group with lng/lat centroid and members', () => {
     // a(100,100) and b(108,100) are 8px apart → one cluster; solo is far away.
     const r = buildMarkerFan(
       fakeMap(),
       [pm('a', 10, 10), pm('b', 10.8, 10), pm('solo', 40, 40)],
     )
     expect(r.clusters).toHaveLength(1)
-    expect(r.clusters[0].count).toBe(2)
-    expect(r.clusters[0].ids.sort()).toEqual(['a', 'b'])
+    expect(r.clusters[0].ids).toHaveLength(2)
+    expect([...r.clusters[0].ids].sort()).toEqual(['a', 'b'])
     // Centroid screen point (104,100) unprojects to (10.4, 10).
-    expect(r.clusters[0].centroidLngLat[0]).toBeCloseTo(10.4, 5)
-    expect(r.clusters[0].centroidLngLat[1]).toBeCloseTo(10, 5)
+    expect(r.clusters[0].centroidLngLat.lng).toBeCloseTo(10.4, 5)
+    expect(r.clusters[0].centroidLngLat.lat).toBeCloseTo(10, 5)
   })
 
   it('drops a cluster whose centroid cannot unproject instead of throwing', () => {
@@ -49,5 +49,18 @@ describe('buildMarkerFan clusters', () => {
     )
     expect(build).not.toThrow()
     expect(build().clusters).toHaveLength(0)
+  })
+
+  it('drops a cluster whose centroid unprojects to a non-finite LngLat (no throw)', () => {
+    // The other off-horizon shape: `unproject` returns NaN rather than throwing.
+    // The centroid guard must still drop it — feeding NaN to a <Marker> blanks
+    // the app just as a thrown error would.
+    const nanMap: ProjectionMap = {
+      project: ([lng, lat]) => ({ x: lng * 10, y: lat * 10 }),
+      unproject: ([x, y]) =>
+        x === 104 && y === 100 ? { lng: NaN, lat: NaN } : { lng: x / 10, lat: y / 10 },
+    }
+    const r = buildMarkerFan(nanMap, [pm('a', 10, 10), pm('b', 10.8, 10)])
+    expect(r.clusters).toHaveLength(0)
   })
 })

--- a/frontend/map-corridors/src/__tests__/buildMarkerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/buildMarkerFan.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { buildMarkerFan, type ProjectionMap } from '../map/photoLayers/useMarkerFan'
+import type { PhotoMarker } from '../types/markers'
+
+// Tests the projection boundary `buildMarkerFan` — specifically the cluster
+// surface (centroid → lng/lat) and its off-horizon guard. The pure clustering
+// maths live in markerFan.test.ts; here we only care that screen-space clusters
+// are unprojected safely and dropped (never thrown) when a centroid can't
+// resolve, which is the white-screen crash class the hook guards against.
+
+// Minimal PhotoMarker — buildMarkerFan only reads id/lng/lat.
+const pm = (id: string, lng: number, lat: number): PhotoMarker =>
+  ({ id, lng, lat } as unknown as PhotoMarker)
+
+// A linear fake map: screen px = deg * 10 (and back). `throwAt` lets a test
+// simulate an above-the-horizon unproject for a specific screen point.
+function fakeMap(throwAt?: [number, number]): ProjectionMap {
+  return {
+    project: ([lng, lat]) => ({ x: lng * 10, y: lat * 10 }),
+    unproject: ([x, y]) => {
+      if (throwAt && x === throwAt[0] && y === throwAt[1]) {
+        throw new Error('Invalid LngLat object: above the horizon')
+      }
+      return { lng: x / 10, lat: y / 10 }
+    },
+  }
+}
+
+describe('buildMarkerFan clusters', () => {
+  it('surfaces one cluster per fanned group with lng/lat centroid and count', () => {
+    // a(100,100) and b(108,100) are 8px apart → one cluster; solo is far away.
+    const r = buildMarkerFan(
+      fakeMap(),
+      [pm('a', 10, 10), pm('b', 10.8, 10), pm('solo', 40, 40)],
+    )
+    expect(r.clusters).toHaveLength(1)
+    expect(r.clusters[0].count).toBe(2)
+    expect(r.clusters[0].ids.sort()).toEqual(['a', 'b'])
+    // Centroid screen point (104,100) unprojects to (10.4, 10).
+    expect(r.clusters[0].centroidLngLat[0]).toBeCloseTo(10.4, 5)
+    expect(r.clusters[0].centroidLngLat[1]).toBeCloseTo(10, 5)
+  })
+
+  it('drops a cluster whose centroid cannot unproject instead of throwing', () => {
+    // Centroid of a(100,100)+b(108,100) is (104,100); make that unproject throw.
+    const build = () => buildMarkerFan(
+      fakeMap([104, 100]),
+      [pm('a', 10, 10), pm('b', 10.8, 10)],
+    )
+    expect(build).not.toThrow()
+    expect(build().clusters).toHaveLength(0)
+  })
+})

--- a/frontend/map-corridors/src/__tests__/compareSelection.test.ts
+++ b/frontend/map-corridors/src/__tests__/compareSelection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { decideCompareOrSelect } from '../map/compareSelection'
+import type { PhotoMarker } from '../types/markers'
+
+// The ≤cap / >cap / too-few branching behind the cluster pill and the floating
+// Compare bar. These boundaries (especially "exactly the cap opens the modal,
+// one over drops into selection") are the easy-to-flip cases — `<=` vs `<` —
+// that decide whether the headline "2–3 open immediately" behaviour holds.
+
+// decideCompareOrSelect only reads markers.length and (for the over-cap branch)
+// each marker's id.
+const pm = (id: string): PhotoMarker => ({ id } as unknown as PhotoMarker)
+
+const MAX = 3 // mirrors MAX_COMPARE_VARIANTS
+
+describe('decideCompareOrSelect', () => {
+  it('ignores an empty set', () => {
+    expect(decideCompareOrSelect([], MAX)).toEqual({ kind: 'ignore' })
+  })
+
+  it('ignores a single marker (nothing to compare)', () => {
+    expect(decideCompareOrSelect([pm('a')], MAX)).toEqual({ kind: 'ignore' })
+  })
+
+  it('opens the modal at the lower bound of 2', () => {
+    const markers = [pm('a'), pm('b')]
+    expect(decideCompareOrSelect(markers, MAX)).toEqual({ kind: 'compare', markers })
+  })
+
+  it('opens the modal at exactly the cap (3) — the headline 2–3 case', () => {
+    const markers = [pm('a'), pm('b'), pm('c')]
+    const d = decideCompareOrSelect(markers, MAX)
+    expect(d.kind).toBe('compare')
+    // Passes the markers through untouched for the side-by-side modal.
+    expect(d).toEqual({ kind: 'compare', markers })
+  })
+
+  it('drops into selection one over the cap (4)', () => {
+    const markers = [pm('a'), pm('b'), pm('c'), pm('d')]
+    expect(decideCompareOrSelect(markers, MAX)).toEqual({
+      kind: 'select',
+      ids: ['a', 'b', 'c', 'd'],
+    })
+  })
+
+  it('preserves order when dropping into selection', () => {
+    const markers = [pm('c'), pm('a'), pm('b'), pm('d')]
+    const d = decideCompareOrSelect(markers, MAX)
+    expect(d).toEqual({ kind: 'select', ids: ['c', 'a', 'b', 'd'] })
+  })
+
+  it('respects a different cap', () => {
+    const markers = [pm('a'), pm('b'), pm('c')]
+    // With a cap of 2, three markers now exceed it → selection, not modal.
+    expect(decideCompareOrSelect(markers, 2)).toEqual({
+      kind: 'select',
+      ids: ['a', 'b', 'c'],
+    })
+  })
+})

--- a/frontend/map-corridors/src/__tests__/markerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerFan.test.ts
@@ -78,6 +78,24 @@ describe('computeMarkerFan', () => {
     }
   })
 
+  it('reports clusters with member ids and centroid for each fanned group', () => {
+    // One overlapping pair + one solitary marker far away.
+    const r = computeMarkerFan(
+      [sp('a', 100, 100), sp('b', 108, 100), sp('solo', 400, 400)],
+      { thresholdPx: 20 },
+    )
+    expect(r.clusters).toHaveLength(1)
+    expect(r.clusters[0].ids.sort()).toEqual(['a', 'b'])
+    // Centroid is the average of the two members' screen points.
+    expect(r.clusters[0].centroid[0]).toBeCloseTo(104, 5)
+    expect(r.clusters[0].centroid[1]).toBeCloseTo(100, 5)
+  })
+
+  it('has no clusters when nothing overlaps', () => {
+    const r = computeMarkerFan([sp('a', 0, 0), sp('b', 300, 0)], { thresholdPx: 20 })
+    expect(r.clusters).toHaveLength(0)
+  })
+
   it('grows the fan radius with group size (clamped)', () => {
     const pts = Array.from({ length: 8 }, (_, i) => sp(`p${i}`, 100, 100))
     const r = computeMarkerFan(pts, {

--- a/frontend/map-corridors/src/__tests__/markerFan.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerFan.test.ts
@@ -85,7 +85,7 @@ describe('computeMarkerFan', () => {
       { thresholdPx: 20 },
     )
     expect(r.clusters).toHaveLength(1)
-    expect(r.clusters[0].ids.sort()).toEqual(['a', 'b'])
+    expect([...r.clusters[0].ids].sort()).toEqual(['a', 'b'])
     // Centroid is the average of the two members' screen points.
     expect(r.clusters[0].centroid[0]).toBeCloseTo(104, 5)
     expect(r.clusters[0].centroid[1]).toBeCloseTo(100, 5)

--- a/frontend/map-corridors/src/__tests__/useEdgePanDrag.controller.test.ts
+++ b/frontend/map-corridors/src/__tests__/useEdgePanDrag.controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import type { MapRef } from 'react-map-gl/mapbox'
-import { createEdgePanController, type DragHandleConfig } from '../map/useEdgePanDrag'
+import { createEdgePanController, type DragHandleConfig, type ClickMods } from '../map/useEdgePanDrag'
 
 // Behavioral tests for the drag state machine inside createEdgePanController —
 // the part that decides what coordinates get written to a competition marker
@@ -66,7 +66,7 @@ type Harness = {
   controller: ReturnType<typeof createEdgePanController>
   active: Array<{ id: string; lng: number; lat: number } | null>
   onCommit: Mock<(lng: number, lat: number) => void>
-  onClick: Mock<() => void>
+  onClick: Mock<(mods: ClickMods) => void>
   fake: ReturnType<typeof makeFakeMap>
   startAt: (cx: number, cy: number, anchor?: { lng: number; lat: number }) => void
 }
@@ -78,7 +78,7 @@ function setup(extraCfg: Partial<DragHandleConfig> = {}): Harness {
   const controller = createEdgePanController(mapRef, d => active.push(d))
   // Typed mocks so they satisfy DragHandleConfig's onCommit/onClick under tsc.
   const onCommit = vi.fn<(lng: number, lat: number) => void>()
-  const onClick = vi.fn<() => void>()
+  const onClick = vi.fn<(mods: ClickMods) => void>()
   const startAt: Harness['startAt'] = (cx, cy, anchor = { lng: cx, lat: cy }) => {
     controller.startDrag(pointerEvent({ clientX: cx, clientY: cy }), {
       id: 'm1', lng: anchor.lng, lat: anchor.lat, onCommit, onClick, ...extraCfg,
@@ -129,6 +129,45 @@ describe('createEdgePanController — commit vs click', () => {
     // Cursor moved by (+100,+100); the anchor should move by the same delta:
     // 485+100=585, 490+100=590 — NOT the raw cursor position (605,600).
     expect(h.onCommit).toHaveBeenCalledWith(585, 590)
+  })
+})
+
+describe('createEdgePanController — modifier-aware click', () => {
+  it('forwards no modifiers for a plain click', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 502, clientY: 501 }) // sub-threshold
+    dispatch('pointerup', { pointerId: 1, ctrlKey: false, metaKey: false, shiftKey: false })
+    expect(h.onClick).toHaveBeenCalledTimes(1)
+    expect(h.onClick).toHaveBeenCalledWith({ ctrl: false, meta: false, shift: false })
+  })
+
+  it('forwards the modifiers held at pointer-up (Ctrl/Cmd/Shift-click)', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointerup', { pointerId: 1, ctrlKey: true, metaKey: false, shiftKey: true })
+    expect(h.onClick).toHaveBeenCalledWith({ ctrl: true, meta: false, shift: true })
+  })
+
+  it('reads modifiers at release, not at press (refresh on pointer-up)', () => {
+    const h = setup()
+    h.startAt(500, 500) // pressed with NO modifier
+    // Release WITH Ctrl held: the click must reflect the release state, not the
+    // press. This pins the `st.mods = readMods(e)` refresh in onPointerUp — a
+    // regression that forwarded the grab-time mods would silently break it.
+    dispatch('pointerup', { pointerId: 1, ctrlKey: true, metaKey: false, shiftKey: false })
+    expect(h.onClick).toHaveBeenCalledWith({ ctrl: true, meta: false, shift: false })
+  })
+
+  it('does NOT fire onClick for a drag even with a modifier held', () => {
+    const h = setup()
+    h.startAt(500, 500)
+    dispatch('pointermove', { pointerId: 1, clientX: 600, clientY: 540 }) // supra-threshold
+    dispatch('pointerup', { pointerId: 1, ctrlKey: true, metaKey: false, shiftKey: false })
+    // The modifier must not bypass the move/commit guard: a Ctrl-drag still
+    // commits a move and never selects.
+    expect(h.onClick).not.toHaveBeenCalled()
+    expect(h.onCommit).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -49,7 +49,9 @@
     },
     "map": {
       "resetNorth": "Otočit mapu na sever",
-      "resetNorthTooltip": "Otočit mapu na sever (N)"
+      "resetNorthTooltip": "Otočit mapu na sever (N)",
+      "comparePill": "Srovnat tyto fotky vedle sebe",
+      "compareAction": "Srovnat"
     },
     "preview": {
       "title": "Fotka",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -49,7 +49,9 @@
     },
     "map": {
       "resetNorth": "Reset map to north",
-      "resetNorthTooltip": "Reset map to north (N)"
+      "resetNorthTooltip": "Reset map to north (N)",
+      "comparePill": "Compare these photos side-by-side",
+      "compareAction": "Compare"
     },
     "preview": {
       "title": "Photo",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -16,6 +16,7 @@ import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { useEdgePanDrag } from './useEdgePanDrag'
 import { MarkerDragHandle } from './MarkerDragHandle'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
+import { MAX_COMPARE_VARIANTS } from '../components/PhotoListPanel'
 import { NO_GPS_PHOTO_DRAG_TYPE } from '../components/NoGpsTray'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { isPickFlag } from '@airq/shared-handoff'
@@ -115,6 +116,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // Double-clicking the popup thumbnail opens the full-res single-photo
   // preview. Receives the photoId (keyed the same as the panel rows).
   onPhotoPreview?: (photoId: string) => void
+  // Compare co-located photos straight from the map (cluster pill +
+  // modifier-select). Reuses App's existing compare handler — the same one the
+  // side panel feeds. When omitted, all map-side compare UI is hidden.
+  onCompareVariants?: (markers: readonly PhotoMarker[]) => void
   // Phase 14 — provisional placement of a no-GPS photo: a draggable pin at the
   // map center whose popup commits the photo to a chosen category. `null` =
   // no placement in progress.
@@ -170,6 +175,71 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     // instead of sitting at its fan offset.
     draggingMarkerId: activeDrag?.id ?? null,
   })
+
+  // Map-side multi-select for side-by-side compare. Holds markerIds in click
+  // order (mirrors PhotoListPanel's `selectedIds`). Driven by Ctrl/Cmd/Shift-
+  // click on dots and by the cluster pill; the floating bar compares 2–3.
+  const [selectedPhotoMarkerIds, setSelectedPhotoMarkerIds] = useState<readonly string[]>([])
+  const clearPhotoSelection = useCallback(() => setSelectedPhotoMarkerIds([]), [])
+  const togglePhotoSelection = useCallback((markerId: string) => {
+    setSelectedPhotoMarkerIds(prev =>
+      prev.includes(markerId) ? prev.filter(id => id !== markerId) : [...prev, markerId],
+    )
+  }, [])
+
+  // Resolve a list of markerIds to live, still-visible PhotoMarkers in the
+  // given order, skipping any that have since vanished (deleted) or been
+  // demoted to a non-visible flag. Shared by the cluster pill and the selection
+  // below.
+  const markersByIdForCompare = useCallback((ids: readonly string[]): PhotoMarker[] => {
+    if (ids.length === 0) return []
+    const byId = new Map<string, PhotoMarker>()
+    for (const m of props.markers ?? []) {
+      if (isPhotoMarkerVisible(m)) byId.set(m.id, m)
+    }
+    const out: PhotoMarker[] = []
+    for (const id of ids) {
+      const m = byId.get(id)
+      if (m) out.push(m)
+    }
+    return out
+  }, [props.markers])
+
+  // The selection resolved to live markers, pruned to those still visible.
+  // Derived during render (not synced back into state via an effect) so the
+  // count/highlight stay honest without a cascading setState — a vanished
+  // marker's id simply stops resolving here.
+  const selectedCompareMarkers = useMemo(
+    () => markersByIdForCompare(selectedPhotoMarkerIds),
+    [markersByIdForCompare, selectedPhotoMarkerIds],
+  )
+  // O(1) membership for the per-marker `isSelected` ring + the Esc/clear gates.
+  const selectedIdSet = useMemo(
+    () => new Set(selectedCompareMarkers.map(m => m.id)),
+    [selectedCompareMarkers],
+  )
+
+  // Esc clears the map selection (parallels the panel's clear button).
+  useEffect(() => {
+    if (selectedIdSet.size === 0) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') clearPhotoSelection() }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [selectedIdSet.size, clearPhotoSelection])
+
+  // Open the compare modal for a set of markers, or — when there are too many
+  // for the 2–3 modal — drop them into the selection so the user can trim via
+  // the floating bar. Shared by the cluster pill and (for ≤3) direct calls.
+  const compareOrSelect = useCallback((markers: readonly PhotoMarker[]) => {
+    if (markers.length < 2) return
+    if (markers.length <= MAX_COMPARE_VARIANTS) {
+      props.onCompareVariants?.(markers)
+      clearPhotoSelection()
+    } else {
+      setSelectedPhotoMarkerIds(markers.map(m => m.id))
+    }
+  }, [props, clearPhotoSelection])
+
   // `N` resets the map to north (Google-Earth style). Suppressed while typing
   // in a field (marker-name inputs live in popups) and for modifier combos
   // (e.g. Ctrl/Cmd+N "new window").
@@ -471,6 +541,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const b = e.viewState.bearing ?? 0
         setBearing(prev => (Math.round(prev) === Math.round(b) ? prev : b))
       }}
+      // A click on the empty map (not a marker — those are DOM overlays and
+      // don't raise the map's `click`) clears any pending compare selection,
+      // the same way clicking off a selection deselects elsewhere.
+      onClick={() => { if (selectedPhotoMarkerIds.length) clearPhotoSelection() }}
       ref={mapRef}
     >
       {geojsonOverlays?.map((ov) => (
@@ -529,6 +603,45 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           />
         </Source>
       )}
+      {/* "Compare N" pill at each fanned cluster's centroid — the screen-space
+          centroid where the leader lines converge (no dot sits there, since
+          dots fan outward). Click compares the cluster's photos: ≤3 opens the
+          side-by-side modal directly; >3 drops them into the selection so the
+          floating bar can trim to 3. Only shown when comparison is wired. */}
+      {props.onCompareVariants && photoFan.clusters.map(c => (
+        <Marker
+          key={`fan-pill-${c.ids.join('-')}`}
+          longitude={c.centroidLngLat[0]}
+          latitude={c.centroidLngLat[1]}
+          style={{ zIndex: 3 }}
+        >
+          <button
+            type="button"
+            title={t('photo.map.comparePill')}
+            onClick={(e) => {
+              e.stopPropagation()
+              compareOrSelect(markersByIdForCompare(c.ids))
+            }}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 3,
+              height: 22,
+              padding: '0 8px',
+              borderRadius: 11,
+              border: '1px solid #7b1fa2',
+              background: '#9c27b0',
+              color: '#ffffff',
+              fontSize: 12,
+              fontWeight: 700,
+              lineHeight: 1,
+              cursor: 'pointer',
+              boxShadow: '0 1px 4px rgba(0,0,0,0.35)',
+              whiteSpace: 'nowrap',
+            }}
+          >⇄ {c.count}</button>
+        </Marker>
+      ))}
       {/* KML / click-placed markers — existing render path. Photo
           markers (m.photoId !== undefined) are handled in the photo-
           pin block below to keep the click + popup semantics distinct
@@ -741,6 +854,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         // Phase 13 — the active photo (popup open / selected in the side
         // panel) gets a glow + scale-up and is lifted above its neighbours.
         const isActive = activePhotoMarkerId === m.id
+        // Map-side compare selection (Ctrl/Cmd/Shift-click). Gets a distinct
+        // ring; can coexist with the active glow.
+        const isSelected = selectedIdSet.has(m.id)
         const pos = liveDragPos(m.id, m.lng, m.lat)
         return (
           <Marker
@@ -751,7 +867,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             // (anchor stays at the true lng/lat). Suppressed while THIS marker
             // is being dragged so its dot tracks the cursor without a jump.
             offset={activeDrag?.id === m.id ? undefined : photoFan.offsets.get(m.id)}
-            style={isActive ? { zIndex: 2 } : undefined}
+            style={isActive || isSelected ? { zIndex: 2 } : undefined}
           >
             <MarkerDragHandle
               controller={dragController}
@@ -762,7 +878,17 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               // coords; intentionally do NOT auto-open the popup afterwards, so
               // it doesn't interrupt the user who has just placed the subject.
               onCommit={(lng, lat) => props.onMarkerDragEnd?.(m.id, lng, lat)}
-              onClick={() => setActivePhotoMarkerId(m.id)}
+              // Ctrl/Cmd/Shift-click → toggle into the compare selection
+              // instead of opening the popup. Plain click → open the popup AND
+              // drop any pending selection (don't leave a hidden mode on).
+              onClick={(mods) => {
+                if (mods.ctrl || mods.meta || mods.shift) {
+                  togglePhotoSelection(m.id)
+                } else {
+                  clearPhotoSelection()
+                  setActivePhotoMarkerId(m.id)
+                }
+              }}
             >
             <div style={{
               width: LIVE_MARKER_DOT_PX,
@@ -771,12 +897,15 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               background: bg,
               border: `2px solid ${ringColor}`,
               position: 'relative',
-              // Active marker: white halo + blue glow so it reads on any
-              // basemap; otherwise the subtle drop shadow for moved photos.
-              boxShadow: isActive
-                ? '0 0 0 3px rgba(255,255,255,0.9), 0 0 10px 4px rgba(25,118,210,0.65)'
-                : moved ? '0 1px 2px rgba(0,0,0,0.25)' : 'none',
-              transform: isActive ? 'scale(1.3)' : undefined,
+              // Layered halos: active = white + blue glow; selected-for-compare
+              // = purple ring (distinct from the blue active glow, and the two
+              // stack when a marker is both). Else the subtle moved-photo shadow.
+              boxShadow: [
+                isSelected ? '0 0 0 3px #ffffff, 0 0 0 5px #9c27b0' : null,
+                isActive ? '0 0 0 3px rgba(255,255,255,0.9), 0 0 10px 4px rgba(25,118,210,0.65)' : null,
+                !isActive && !isSelected && moved ? '0 1px 2px rgba(0,0,0,0.25)' : null,
+              ].filter(Boolean).join(', ') || 'none',
+              transform: isActive ? 'scale(1.3)' : isSelected ? 'scale(1.15)' : undefined,
               transition: 'transform 120ms ease, box-shadow 120ms ease',
               cursor: 'pointer',
             }}>
@@ -1072,6 +1201,77 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           </span>
         </button>
       )}
+      {/* Floating compare bar — appears when ≥1 photo is map-selected
+          (Ctrl/Cmd/Shift-click or via a cluster pill of >3). Enabled for 2–3;
+          disabled with a hint when over the cap, mirroring the side panel. */}
+      {props.onCompareVariants && selectedCompareMarkers.length >= 1 && (() => {
+        const n = selectedCompareMarkers.length
+        const tooMany = n > MAX_COMPARE_VARIANTS
+        const ready = n >= 2 && !tooMany
+        return (
+          <div style={{
+            position: 'absolute',
+            bottom: 20,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 30,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            background: 'rgba(33,33,33,0.94)',
+            color: '#ffffff',
+            padding: '8px 10px 8px 14px',
+            borderRadius: 24,
+            boxShadow: '0 2px 10px rgba(0,0,0,0.4)',
+            fontSize: 13,
+          }}>
+            <span style={{ fontWeight: 600 }}>
+              {t('photo.list.compareSelected', { count: n })}
+            </span>
+            {tooMany && (
+              <span style={{ color: '#ffcc80', fontSize: 12 }}>
+                {t('photo.list.compareLimitTip', { max: MAX_COMPARE_VARIANTS })}
+              </span>
+            )}
+            <button
+              type="button"
+              disabled={!ready}
+              onClick={() => {
+                if (!ready) return
+                props.onCompareVariants?.(selectedCompareMarkers)
+                clearPhotoSelection()
+              }}
+              style={{
+                height: 28,
+                padding: '0 14px',
+                borderRadius: 14,
+                border: 'none',
+                background: ready ? '#9c27b0' : '#616161',
+                color: '#ffffff',
+                fontSize: 13,
+                fontWeight: 700,
+                cursor: ready ? 'pointer' : 'not-allowed',
+              }}
+            >⇄ {t('photo.map.compareAction')}</button>
+            <button
+              type="button"
+              onClick={clearPhotoSelection}
+              aria-label={t('photo.list.clearSelection')}
+              title={t('photo.list.clearSelection')}
+              style={{
+                height: 28,
+                width: 28,
+                borderRadius: '50%',
+                border: 'none',
+                background: 'transparent',
+                color: '#ffffff',
+                fontSize: 16,
+                cursor: 'pointer',
+              }}
+            >✕</button>
+          </div>
+        )
+      })()}
     </MapGL>
   )
 })

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -14,6 +14,7 @@ import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { useMarkerFan } from './photoLayers/useMarkerFan'
 import { useEdgePanDrag } from './useEdgePanDrag'
+import { decideCompareOrSelect } from './compareSelection'
 import { MarkerDragHandle } from './MarkerDragHandle'
 import { PhotoMarkerPopup } from '../components/PhotoMarkerPopup'
 import { MAX_COMPARE_VARIANTS } from '../components/PhotoListPanel'
@@ -230,15 +231,18 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // Open the compare modal for a set of markers, or — when there are too many
   // for the 2–3 modal — drop them into the selection so the user can trim via
   // the floating bar. Shared by the cluster pill and (for ≤3) direct calls.
+  // `onCompareVariants` is destructured so the callback depends on the handler
+  // itself, not the whole (always-fresh) `props` object.
+  const { onCompareVariants } = props
   const compareOrSelect = useCallback((markers: readonly PhotoMarker[]) => {
-    if (markers.length < 2) return
-    if (markers.length <= MAX_COMPARE_VARIANTS) {
-      props.onCompareVariants?.(markers)
+    const decision = decideCompareOrSelect(markers, MAX_COMPARE_VARIANTS)
+    if (decision.kind === 'compare') {
+      onCompareVariants?.(decision.markers)
       clearPhotoSelection()
-    } else {
-      setSelectedPhotoMarkerIds(markers.map(m => m.id))
+    } else if (decision.kind === 'select') {
+      setSelectedPhotoMarkerIds(decision.ids)
     }
-  }, [props, clearPhotoSelection])
+  }, [onCompareVariants, clearPhotoSelection])
 
   // `N` resets the map to north (Google-Earth style). Suppressed while typing
   // in a field (marker-name inputs live in popups) and for modifier combos
@@ -611,8 +615,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       {props.onCompareVariants && photoFan.clusters.map(c => (
         <Marker
           key={`fan-pill-${c.ids.join('-')}`}
-          longitude={c.centroidLngLat[0]}
-          latitude={c.centroidLngLat[1]}
+          longitude={c.centroidLngLat.lng}
+          latitude={c.centroidLngLat.lat}
           style={{ zIndex: 3 }}
         >
           <button
@@ -639,7 +643,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               boxShadow: '0 1px 4px rgba(0,0,0,0.35)',
               whiteSpace: 'nowrap',
             }}
-          >⇄ {c.count}</button>
+          >⇄ {c.ids.length}</button>
         </Marker>
       ))}
       {/* KML / click-placed markers — existing render path. Photo

--- a/frontend/map-corridors/src/map/compareSelection.ts
+++ b/frontend/map-corridors/src/map/compareSelection.ts
@@ -1,0 +1,31 @@
+// Pure decision logic for the map-side "compare co-located photos" gesture.
+//
+// Both entry points (a cluster's "⇄ N" pill and the floating Compare bar)
+// resolve to a set of live PhotoMarkers and then have to choose between three
+// outcomes: do nothing (too few), open the side-by-side modal (within the cap),
+// or drop the set into the selection so the user can trim it down (over the
+// cap). Kept free of React/map state — mirroring how `PhotoListPanel` extracts
+// its pure selection helpers — so the cap boundary can be unit-tested directly.
+
+import type { PhotoMarker } from '../types/markers'
+
+export type CompareDecision =
+  | { kind: 'ignore' }
+  | { kind: 'compare'; markers: readonly PhotoMarker[] }
+  | { kind: 'select'; ids: string[] }
+
+/**
+ * Decide what a compare gesture should do with `markers`, given the modal's
+ * variant cap (`maxVariants`, i.e. `MAX_COMPARE_VARIANTS`):
+ *   • fewer than 2  → `ignore` (nothing to compare)
+ *   • 2..=cap       → `compare` (open the modal directly)
+ *   • more than cap → `select` (trim down via the floating bar)
+ */
+export function decideCompareOrSelect(
+  markers: readonly PhotoMarker[],
+  maxVariants: number,
+): CompareDecision {
+  if (markers.length < 2) return { kind: 'ignore' }
+  if (markers.length <= maxVariants) return { kind: 'compare', markers }
+  return { kind: 'select', ids: markers.map(m => m.id) }
+}

--- a/frontend/map-corridors/src/map/photoLayers/markerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerFan.ts
@@ -26,11 +26,21 @@ export interface LeaderSegment {
   to: [number, number]
 }
 
+/** A fanned cluster: its members (markerIds) and the screen-space centroid the
+ *  fan radiates from. Used to anchor the "Compare N" pill and to know which
+ *  photos a cluster gesture should compare. */
+export interface MarkerCluster {
+  ids: string[]
+  centroid: [number, number]
+}
+
 export interface MarkerFanResult {
   /** markerId → [dx, dy] pixel offset. Only members of a fanned group appear. */
   offsets: Map<string, [number, number]>
   /** One per fanned marker. Empty when nothing overlaps. */
   leaders: LeaderSegment[]
+  /** One per fanned group (size ≥ 2). Empty when nothing overlaps. */
+  clusters: MarkerCluster[]
 }
 
 export interface MarkerFanOptions {
@@ -116,6 +126,7 @@ export function computeMarkerFan(
   const opt = { ...DEFAULTS, ...options }
   const offsets = new Map<string, [number, number]>()
   const leaders: LeaderSegment[] = []
+  const clusters: MarkerCluster[] = []
 
   const groups = clusterByProximity(points, opt.thresholdPx)
   for (const group of groups) {
@@ -129,6 +140,7 @@ export function computeMarkerFan(
     const cx = members.reduce((s, p) => s + p.x, 0) / members.length
     const cy = members.reduce((s, p) => s + p.y, 0) / members.length
     const n = members.length
+    clusters.push({ ids: members.map(p => p.id), centroid: [cx, cy] })
     const radius = clamp(
       opt.baseRadiusPx + opt.radiusStepPx * (n - 2),
       opt.minRadiusPx,
@@ -147,5 +159,5 @@ export function computeMarkerFan(
     }
   }
 
-  return { offsets, leaders }
+  return { offsets, leaders, clusters }
 }

--- a/frontend/map-corridors/src/map/photoLayers/markerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerFan.ts
@@ -30,7 +30,7 @@ export interface LeaderSegment {
  *  fan radiates from. Used to anchor the "Compare N" pill and to know which
  *  photos a cluster gesture should compare. */
 export interface MarkerCluster {
-  ids: string[]
+  ids: readonly string[]
   centroid: [number, number]
 }
 

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -23,12 +23,14 @@ import type { PhotoMarker } from '../../types/markers'
 import { isPhotoMarkerVisible } from './markerVisibility'
 import { computeMarkerFan, type ScreenPoint } from './markerFan'
 
-/** A fanned cluster surfaced to the map: members (markerIds), the centroid in
- *  lng/lat (so the "Compare N" pill can be a <Marker>), and the member count. */
+/** A fanned cluster surfaced to the map: its members (markerIds) and the
+ *  centroid in lng/lat (so the "Compare N" pill can be a <Marker>). The member
+ *  count is just `ids.length` — not stored, to avoid a field that can drift out
+ *  of sync. Centroid is `{lng, lat}` (not a bare tuple) so it can't be mixed up
+ *  with the screen-pixel `MarkerCluster.centroid` it's unprojected from. */
 export interface FanCluster {
-  ids: string[]
-  centroidLngLat: [number, number]
-  count: number
+  ids: readonly string[]
+  centroidLngLat: { lng: number; lat: number }
 }
 
 export interface UseMarkerFanResult {
@@ -43,17 +45,18 @@ const EMPTY: UseMarkerFanResult = {
   clusters: [],
 }
 
-// A leader endpoint landing above the horizon makes `unproject` throw; that is
-// an expected, recoverable case (we just drop the line), so we must NOT rethrow
-// — doing so during render is the white-screen bug this hook guards against. But
-// silently swallowing every error hides genuinely unexpected failures, so warn
-// once in dev. Module-level latch keeps it to a single line instead of one per
-// off-horizon leader per recompute (which fires on every map settle).
+// A fan point above the horizon makes `unproject` throw (or return a non-finite
+// LngLat); that is an expected, recoverable case (we just drop the leader line
+// or cluster pill), so we must NOT rethrow — doing so during render is the
+// white-screen bug this hook guards against. But silently swallowing every
+// failure hides genuinely unexpected ones, so warn once in dev. Module-level
+// latch keeps it to a single line instead of one per dropped point per recompute
+// (which fires on every map settle).
 let unprojectWarned = false
 function warnUnprojectOnce(err: unknown): void {
   if (unprojectWarned || !import.meta.env.DEV) return
   unprojectWarned = true
-  console.warn('[useMarkerFan] unproject failed for a leader endpoint; dropping its line.', err)
+  console.warn('[useMarkerFan] unproject failed for a fan point (leader endpoint or cluster centroid); dropping it.', err)
 }
 
 /**
@@ -101,7 +104,12 @@ export function buildMarkerFan(
   const safeUnproject = (pt: [number, number]): [number, number] | null => {
     try {
       const ll = map.unproject(pt)
-      return Number.isFinite(ll.lng) && Number.isFinite(ll.lat) ? [ll.lng, ll.lat] : null
+      if (Number.isFinite(ll.lng) && Number.isFinite(ll.lat)) return [ll.lng, ll.lat]
+      // unproject succeeded but produced NaN/Inf — same off-horizon case as a
+      // throw, just surfaced differently. Drop it, and warn so a silent
+      // regression in the guard stays diagnosable.
+      warnUnprojectOnce(new Error(`unproject returned a non-finite LngLat (${ll.lng}, ${ll.lat})`))
+      return null
     } catch (err) {
       warnUnprojectOnce(err)
       return null
@@ -125,7 +133,7 @@ export function buildMarkerFan(
   // thrown — feeding NaN to a <Marker> would otherwise blank the app.
   const clusters = fan.clusters.flatMap<FanCluster>(c => {
     const ll = safeUnproject(c.centroid)
-    return ll ? [{ ids: c.ids, centroidLngLat: ll, count: c.ids.length }] : []
+    return ll ? [{ ids: c.ids, centroidLngLat: { lng: ll[0], lat: ll[1] } }] : []
   })
 
   return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features }, clusters }

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -23,14 +23,24 @@ import type { PhotoMarker } from '../../types/markers'
 import { isPhotoMarkerVisible } from './markerVisibility'
 import { computeMarkerFan, type ScreenPoint } from './markerFan'
 
+/** A fanned cluster surfaced to the map: members (markerIds), the centroid in
+ *  lng/lat (so the "Compare N" pill can be a <Marker>), and the member count. */
+export interface FanCluster {
+  ids: string[]
+  centroidLngLat: [number, number]
+  count: number
+}
+
 export interface UseMarkerFanResult {
   offsets: Map<string, [number, number]>
   leaders: FeatureCollection<LineString>
+  clusters: FanCluster[]
 }
 
 const EMPTY: UseMarkerFanResult = {
   offsets: new Map(),
   leaders: { type: 'FeatureCollection', features: [] },
+  clusters: [],
 }
 
 // A leader endpoint landing above the horizon makes `unproject` throw; that is
@@ -110,7 +120,15 @@ export function buildMarkerFan(
     }]
   })
 
-  return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features } }
+  // Same off-horizon guard as the leaders: a cluster whose centroid can't
+  // unproject (above the horizon on a pitched map) is dropped rather than
+  // thrown — feeding NaN to a <Marker> would otherwise blank the app.
+  const clusters = fan.clusters.flatMap<FanCluster>(c => {
+    const ll = safeUnproject(c.centroid)
+    return ll ? [{ ids: c.ids, centroidLngLat: ll, count: c.ids.length }] : []
+  })
+
+  return { offsets: fan.offsets, leaders: { type: 'FeatureCollection', features }, clusters }
 }
 
 export function useMarkerFan(params: {

--- a/frontend/map-corridors/src/map/useEdgePanDrag.ts
+++ b/frontend/map-corridors/src/map/useEdgePanDrag.ts
@@ -29,6 +29,16 @@ export const MAX_PAN_PX_PER_FRAME = 18
 // drag — mirrors the 8px threshold the native handlers used.
 const DEFAULT_CLICK_THRESHOLD_PX = 8
 
+/** Modifier-key state at the moment a tap is recognised. Lets a click handler
+ *  branch (e.g. Ctrl/Cmd/Shift-click → multi-select vs plain click → open). */
+export type ClickMods = { ctrl: boolean; meta: boolean; shift: boolean }
+
+const readMods = (e: PointerEvent): ClickMods => ({
+  ctrl: e.ctrlKey,
+  meta: e.metaKey,
+  shift: e.shiftKey,
+})
+
 export type DragHandleConfig = {
   id: string
   /** Marker's true anchor at drag start (not a fan-offset/override position). */
@@ -37,8 +47,10 @@ export type DragHandleConfig = {
   /** Commit a real move (cursor travelled past the click threshold, or the map
    *  auto-panned during the gesture). */
   onCommit: (lng: number, lat: number) => void
-  /** A tap that never crossed the threshold — open a popup, select, etc. */
-  onClick?: () => void
+  /** A tap that never crossed the threshold — open a popup, select, etc. The
+   *  modifier-key state at pointer-up is forwarded so callers can distinguish a
+   *  plain click from a Ctrl/Cmd/Shift-click. */
+  onClick?: (mods: ClickMods) => void
   clickThresholdPx?: number
 }
 
@@ -67,6 +79,9 @@ type DragState = {
   moved: boolean
   curLng: number
   curLat: number
+  /** Modifier keys, captured at grab time and refreshed at pointer-up so a
+   *  tap forwards the modifier state at the click, not at the press. */
+  mods: ClickMods
 }
 
 // Eased 0→1 ramp inside the edge zone; clamps so a cursor *past* the edge
@@ -175,7 +190,7 @@ export function createEdgePanController(
       state = null
       if (commit) {
         if (st.moved) st.cfg.onCommit(st.curLng, st.curLat)
-        else st.cfg.onClick?.()
+        else st.cfg.onClick?.(st.mods)
       }
       // On cancel (Escape / blur / pointercancel) we simply drop the override;
       // the marker snaps back to its prop-driven (original) position.
@@ -185,6 +200,9 @@ export function createEdgePanController(
     function onPointerUp(e: PointerEvent) {
       const st = state
       if (st && e.pointerId !== st.pointerId) return
+      // Refresh modifiers from the up-event so "Ctrl/Cmd/Shift-click" reflects
+      // the key state at the click, not whatever was held at press time.
+      if (st) st.mods = readMods(e)
       endDrag(true)
     }
     function onPointerCancel() {
@@ -221,6 +239,7 @@ export function createEdgePanController(
         moved: false,
         curLng: cfg.lng,
         curLat: cfg.lat,
+        mods: readMods(e),
       }
       setActiveDrag({ id: cfg.id, lng: cfg.lng, lat: cfg.lat })
       window.addEventListener('pointermove', onPointerMove)


### PR DESCRIPTION
## Compare co-located photos from the map

Re-applies the feature from #84 — **compare overlapping photos straight from the map** — on top of current `main`. Two entry points, both feeding the existing compare modal (`handleCompareVariants`, already used by the side panel):

- **Cluster `⇄ N` pill** at each fanned cluster's centroid — ≤3 opens the side-by-side modal directly; >3 drops them into a selection to trim down.
- **Ctrl/Cmd/Shift-click** dots to multi-select (purple ring); a floating **Compare** bar opens the side-by-side view (enabled for 2–3, disabled-with-hint over the cap, mirroring the side panel).

### Why a new PR instead of merging #84
#84 was stale (`CONFLICTING`, 25 commits behind) and rebased down to a single commit. Its selection logic lived inside inline marker handlers that `main` deleted in the edge-pan drag refactor (#91), and its raw `unproject` predated the auto-fan projection guards (#91/#92). Merging would have left dangling `draggingPhotoMarkerId` references git wouldn't flag. Porting onto current `main` is compile-correct and cleaner. **Supersedes #84.**

### Improvements over #84
- **Off-horizon guard:** cluster centroids unproject through `useMarkerFan`'s existing `safeUnproject` (not a raw `unproject`), so an above-the-horizon centroid on a pitched map is dropped, not thrown — avoids the white-screen crash class #91/#92 fixed. New test: `buildMarkerFan.test.ts`.
- **Derived selection** instead of `setState`-in-effect, satisfying `react-hooks/set-state-in-effect` and deduping the resolver.
- **Modifier-click** via extending `useEdgePanDrag`'s `onClick` to forward `{ctrl,meta,shift}` (captured at pointer-up; back-compatible).

### Verification
- ✅ `vitest run` — 684 tests (4 new cluster tests)
- ✅ `tsc -b` clean
- ✅ `tsc -b && vite build` succeeds
- ✅ Touched files add zero new lint errors/warnings (verified vs `main` baseline)

Manual QA still recommended (pill, modifier-select, Esc, tilt-near-horizon white-screen check) — see `docs/map-compare-from-map/port-plan.md`.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
