### PR TITLE
feat(map-corridors): drag a Bez GPS panel row onto the map to place it #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.21.0] - 2026-05-31
+
+### Added
+- **Map Corridors:** you can now drag a "Bez GPS" photo row from the right-side
+  panel straight onto the map to place it — it lands at the drop point as a
+  track pick (blue), the same as dragging from the bottom no-GPS tray. Clicking
+  the row (provisional pin at map centre) and double-clicking it (full-res
+  preview) still work as before.
+
 ## [2.20.0] - 2026-05-30
 
 ### Added

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -25,6 +25,7 @@ import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { noGpsPhotoDisplayName, photoMarkerDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
+import { NO_GPS_PHOTO_DRAG_TYPE } from './NoGpsTray'
 import { groupPhotosByFlag } from './groupPhotosByFlag'
 import { flagForGroup, canRecategorize } from '../recategorize/recategorize'
 import type { PhotoFlag } from '../types/markers'
@@ -525,13 +526,23 @@ function renderGroupItems(
         storage={ctx.storage}
         photosDir={ctx.photosDir}
         // Phase 14 — clicking a no-GPS row starts placing it on the map
-        // (provisional pin at map center). Not draggable-for-recat (no flag).
+        // (provisional pin at map center). Distinct from the drag below: a
+        // drag fires only on motion, a click only without it.
         onClick={ctx.onNoGpsPhotoClick ? () => ctx.onNoGpsPhotoClick!(p.photoId) : undefined}
         // Double-click opens the full-res preview (same as GPS rows).
         onDoubleClick={ctx.onRowDoubleClick ? () => ctx.onRowDoubleClick!(p.photoId) : undefined}
         selected={false}
         active={false}
-        recatDraggable={false}
+        // Drag the row straight onto the map to place it — same drag type the
+        // bottom tray uses, so it lands at the drop point as a Track pick via
+        // the map's existing NO_GPS_PHOTO_DRAG_TYPE drop handler. NOT the
+        // recategorise drag (that's GPS-rows-only, drops onto panel groups), so
+        // we deliberately don't touch onRowDragStart's group-highlight state.
+        recatDraggable
+        onRecatDragStart={(e) => {
+          e.dataTransfer.setData(NO_GPS_PHOTO_DRAG_TYPE, p.photoId)
+          e.dataTransfer.effectAllowed = 'move'
+        }}
         onDelete={ctx.onPhotoDelete}
         deleteTooltip={ctx.deleteTooltip}
         {...commonRenameCtx}


### PR DESCRIPTION
## Summary
- The right-side **"Bez GPS"** list rows are now a **drag source**: drag a row onto the map to place the photo at the drop point as a **track pick (blue)** — same behaviour as dragging from the bottom no-GPS tray.
- Reuses the existing `NO_GPS_PHOTO_DRAG_TYPE` + map canvas drop handler and `placeNoGpsPhoto`/`onNoGpsPhotoPlaced` — no changes to `MapProviderView`, `App`, or the OPFS hook. One-file change in `PhotoListPanel.tsx` (+ CHANGELOG).
- Existing row gestures preserved: single-click → provisional pin at map centre; double-click → full-res preview (a drag fires only on motion).

## Test plan
- [x] `tsc -b` clean
- [x] `vitest run` — 694 pass (45 files)
- [ ] Drag a "Bez GPS" row onto the map → photo leaves the group, appears as a blue track-pick marker at the drop point; custom name preserved
- [ ] Single-click still starts provisional placement; double-click still opens preview
- [ ] Tray drag still works and still lands as track (no regression)
- [ ] Drop outside the map does nothing; no duplicate left in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)