### PR TITLE
chore(desktop): bump version to 2.25.1

### DIFF
--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.20.0",
+  "version": "2.25.1",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",


### PR DESCRIPTION
## Summary
Bumps `frontend/desktop/package.json` from `2.20.0` → `2.25.1` — one patch above the latest `desktop-v2.25.0` tag — so locally built portable `.exe` artifacts carry a unique version and filename.

No functional changes. Release tagging still auto-detects the version from the tag name; this only affects local build filenames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)