### PR TITLE
docs(changelog): backfill 2.19.0–2.25.0 + add changelog CI gate

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,105 @@
+name: changelog
+
+# Enforce that every pull request updates CHANGELOG.md, so the
+# `desktop-v*` release notes stay complete. Exemptions:
+#   - PRs opened by bots (Dependabot, github-actions, Renovate, …)
+#   - PRs that only bump a package.json "version" field and/or lockfiles
+#   - PRs explicitly labelled `skip-changelog` (no user-facing change)
+#
+# Make this a *required* status check in branch-protection for `main` so it
+# actually blocks merges; the workflow only reports pass/fail on its own.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: changelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require CHANGELOG.md update
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          # 1) Bot authors (Dependabot / github-actions / Renovate) are exempt.
+          #    `user.type == Bot` covers GitHub App bots; the suffix/name checks
+          #    are belt-and-braces for legacy bot accounts.
+          if [ "$AUTHOR_TYPE" = "Bot" ] || [[ "$AUTHOR" == *"[bot]" ]] \
+             || [[ "$AUTHOR" =~ ^(dependabot|github-actions|github|renovate)$ ]]; then
+            echo "Author '$AUTHOR' (type=$AUTHOR_TYPE) is a bot — changelog not required."
+            exit 0
+          fi
+
+          # 2) Explicit opt-out label for changes with no user-facing impact.
+          if printf ',%s,' "$LABELS" | grep -q ',skip-changelog,'; then
+            echo "'skip-changelog' label present — changelog not required."
+            exit 0
+          fi
+
+          # 3) Gather the PR's changed files.
+          mapfile -t FILES < <(gh api --paginate "repos/$GH_REPO/pulls/$PR/files" --jq '.[].filename')
+          echo "Changed files:"
+          printf '  %s\n' "${FILES[@]}"
+
+          # 4) CHANGELOG touched → pass.
+          for f in "${FILES[@]}"; do
+            if [ "$f" = "CHANGELOG.md" ]; then
+              echo "CHANGELOG.md updated — OK."
+              exit 0
+            fi
+          done
+
+          # 5) Allow pure version bumps / lockfile-only PRs.
+          #    Skip lockfiles; for each package.json, confirm its diff only
+          #    touches the "version" field. Anything else makes the changelog
+          #    mandatory.
+          LOCKFILE_RE='(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$'
+          PKGJSON_RE='(^|/)package\.json$'
+          changelog_required=false
+          for f in "${FILES[@]}"; do
+            if [[ "$f" =~ $LOCKFILE_RE ]]; then
+              continue
+            fi
+            if [[ "$f" =~ $PKGJSON_RE ]]; then
+              patch="$(gh api --paginate "repos/$GH_REPO/pulls/$PR/files" \
+                --jq ".[] | select(.filename==\"$f\") | .patch")"
+              # Added/removed content lines that are NOT the "version" field.
+              offending="$(printf '%s\n' "$patch" \
+                | grep -E '^[+-]' \
+                | grep -vE '^(\+\+\+|---)' \
+                | grep -vE '^[+-][[:space:]]*"version":[[:space:]]*"[^"]+",?[[:space:]]*$' \
+                || true)"
+              if [ -n "$offending" ]; then
+                changelog_required=true
+                break
+              fi
+              continue
+            fi
+            # Any other path → real change → changelog required.
+            changelog_required=true
+            break
+          done
+
+          if [ "$changelog_required" = false ]; then
+            echo "Only lockfiles and/or package.json version bumps changed — changelog not required."
+            exit 0
+          fi
+
+          # 6) Otherwise the changelog is mandatory.
+          echo "::error::CHANGELOG.md was not updated. Add an entry to the top section describing the user-facing change, or apply the 'skip-changelog' label if this PR has no user-facing impact."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,58 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [2.21.0] - 2026-05-31
+## [2.25.0] - 2026-05-31
 
 ### Added
 - **Map Corridors:** you can now drag a "Bez GPS" photo row from the right-side
   panel straight onto the map to place it — it lands at the drop point as a
   track pick (blue), the same as dragging from the bottom no-GPS tray. Clicking
   the row (provisional pin at map centre) and double-clicking it (full-res
-  preview) still work as before.
+  preview) still work as before. (#95)
+
+## [2.24.0] - 2026-05-31
+
+### Added
+- **Map Corridors:** compare co-located photos straight from the map. Each
+  fanned cluster shows a small **⇄ N** pill at its centre — click it to open the
+  photos side-by-side and pick the best one (2–3 open immediately; larger groups
+  drop into a selection to trim down). You can also **Ctrl/Cmd/Shift-click** any
+  dots to multi-select them (highlighted with a ring); a floating **Compare**
+  bar then opens the side-by-side view. Both routes feed the existing compare
+  modal (winner stays, the rest move to Odmítnuté). (#94)
+
+## [2.23.1] - 2026-05-31
+
+### Fixed
+- **Map Corridors:** rejected photos no longer reappear in PNG and KML exports.
+  The live map already hid them, but both export paths rendered the unfiltered
+  marker list, so a rejected co-located variant reprinted as a duplicate dot at
+  its original EXIF location. Exports now ship exactly what is visible on the
+  map. (#93)
+
+## [2.23.0] - 2026-05-31
+
+### Fixed
+- **Map Corridors:** fixed a white-screen crash when rotating the map and then
+  tilting it (an `Invalid LngLat (NaN, NaN)` error thrown by the auto-fan
+  projection). The fan now guards against off-screen / NaN projections. (#92)
+
+## [2.22.0] - 2026-05-31
+
+### Added
+- **Map Corridors:** when zoomed in, dragging a marker (photo, KML/click,
+  ground, or no-GPS provisional pin) toward the edge of the map now auto-pans
+  the map in that direction, with the dot staying under the cursor — so you can
+  move a marker anywhere, even off the current screen, in one continuous motion
+  (no more zoom-out / place / zoom-in / nudge dance). (#91)
+
+## [2.21.0] - 2026-05-30
+
+### Added
+- **Map Corridors:** a Google-Earth-style **compass** button appears at the
+  top-left of the map whenever it is rotated; its needle shows the live bearing
+  and clicking it eases the map back to north-up. Pressing **N** does the same
+  (suppressed while typing in an input). (#90)
 
 ## [2.20.0] - 2026-05-30
 
@@ -31,14 +75,7 @@ new desktop release.
   handoff into Photo Helper, so the editor knows which print set each photo
   belongs to. Picking does not auto-place the photo; the existing "Send to set"
   / "Send to TP photos" controls still do that. Sessions saved before this
-  release load their existing picks as track photos (no picks are lost).
-- **Map Corridors:** compare co-located photos straight from the map. Each
-  fanned cluster shows a small **⇄ N** pill at its centre — click it to open the
-  photos side-by-side and pick the best one (2–3 open immediately; larger groups
-  drop into a selection to trim down). You can also **Ctrl/Cmd/Shift-click** any
-  dots to multi-select them (highlighted with a ring); a floating **Compare**
-  bar then opens the side-by-side view. Both routes feed the existing compare
-  modal (winner stays, the rest move to Odmítnuté).
+  release load their existing picks as track photos (no picks are lost). (#87)
 
 ## [2.19.0] - 2026-05-30
 
@@ -52,10 +89,24 @@ new desktop release.
   one back to the spot, so every photo stays individually clickable. The fan
   recomputes as you zoom and pan, and collapses once the dots are far enough
   apart on their own.
+- **Map Corridors:** neutral / unselected photo dots are now high-contrast
+  **amber** instead of near-invisible grey, and all markers are bigger (18px)
+  with a larger transparent click/tap halo so they are easier to grab.
+- **Photo Editor:** the photo modal gains prev/next arrows and
+  ArrowLeft/ArrowRight keyboard navigation within the current set/pool, plus a
+  new "Send to TP photos" candidate-tray button that switches to turning-point
+  mode and places the photo.
+- **Desktop launcher:** you can now rename an existing competition inline.
 
 ### Changed
+- **Map Corridors / Photo Editor:** the app-switch button moved to the top-left
+  and is now a labelled button ("Editor fotek" / "Umístění fotek") instead of a
+  bare icon.
+- **Photo Editor:** the editor expands full-width on wide screens (removed the
+  previous 75% cap); the candidate-tray star/deny flagging UI is hidden (that
+  workflow lives in Map Corridors).
 - **Desktop launcher:** the app now opens maximised (filling the screen) on
-  every launch instead of a fixed-size window.
+  every launch instead of a fixed-size window. (#85)
 
 ## [2.18.0] - 2026-05-24
 


### PR DESCRIPTION
## Summary

Two things:

1. **Backfill & realign CHANGELOG.md.** The version headers had drifted from the actual `desktop-v*` release tags — entries were filed under the wrong versions and five user-facing PRs were undocumented. Realigned every entry from `2.19.0` upward to its real tag (verified via tag → merge-commit mapping):

   | Tag | PR | Status before |
   |-----|----|----|
   | 2.25.0 | #95 Bez GPS row drag-to-map | was mis-filed under 2.21.0 |
   | 2.24.0 | #94 Compare co-located photos | was mis-filed under 2.20.0 |
   | 2.23.1 | #93 Hide rejected photos in PNG/KML exports | **undocumented** |
   | 2.23.0 | #92 Fix white-screen crash on rotate-then-tilt | **undocumented** |
   | 2.22.0 | #91 Auto-pan map on marker drag past edge | **undocumented** |
   | 2.21.0 | #90 Reset-to-north compass + N shortcut | **undocumented** |
   | 2.20.0 | #87 Track vs turning-point categorization | OK (compare bullet moved out) |
   | 2.19.0 | #85 UX pass (amber/bigger markers, editor full-width, modal arrow nav, "Send to TP photos", launcher rename) | preview/auto-fan only; **UX pass undocumented** |

   > `2.20.1` (#88, tests) and `2.20.2` (#89, changelog) have no user-facing changes, so per Keep a Changelog they get no section.
   > #86 (`tmp` CVE) is a build-time devDependency with nil runtime exposure — intentionally not listed.

2. **Add `.github/workflows/changelog.yml`.** Every PR must update `CHANGELOG.md`. Exemptions:
   - Bot authors (Dependabot / github-actions / Renovate — detected via `user.type == Bot`, `[bot]` suffix, and known names).
   - Pure `package.json` `"version"` bumps and/or lockfile-only changes (the diff is inspected — a dependency change still requires a changelog).
   - PRs labelled **`skip-changelog`** (escape hatch for no-impact changes).

## Notes
- The new workflow only reports pass/fail. **To actually block merges, add `require-changelog` as a required status check** in branch protection for `main`.
- Validated locally: YAML parses (no tabs, LF endings), embedded bash passes `bash -n`, and the version-bump regex correctly passes a version-only diff while flagging a dependency add.

## Test plan
- [ ] CI `changelog` check runs green on this PR (it modifies `CHANGELOG.md`).
- [ ] Open a throwaway code-only PR → check fails; add `skip-changelog` label → check passes.
- [ ] A Dependabot PR → check skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)