### PR TITLE
fix(map-corridors): clear stuck marker offset when a fanned photo un-fans

### DIFF
--- a/frontend/map-corridors/src/__tests__/markerOffset.test.ts
+++ b/frontend/map-corridors/src/__tests__/markerOffset.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { resolveFanOffset } from '../map/photoLayers/markerOffset'
+
+// Regression guard for the "placed photo drifts off the map on zoom-out" bug:
+// the react-mapbox <Marker>/<Popup> wrappers ignore a falsy `offset` prop, so
+// an un-fanned marker must be handed an explicit [0,0] — never undefined — or it
+// stays stuck at its last fan offset. See markerOffset.ts for the full why.
+describe('resolveFanOffset', () => {
+  it('returns [0,0] (never undefined) when the marker has no fan offset', () => {
+    const result = resolveFanOffset(undefined)
+    expect(result).toEqual([0, 0])
+    // The exact contract that fixes the bug: the value must be truthy so the
+    // wrapper's `if (offset && …)` guard runs `setOffset` and clears a stale one.
+    expect(result).not.toBeUndefined()
+  })
+
+  it('passes a real fan offset through unchanged', () => {
+    expect(resolveFanOffset([16, -8])).toEqual([16, -8])
+  })
+
+  it('preserves a zero-valued fan offset as a concrete [0,0]', () => {
+    expect(resolveFanOffset([0, 0])).toEqual([0, 0])
+  })
+
+  it('returns a fresh tuple, not the caller-supplied reference', () => {
+    // Defensive: the marker reads from a Map it does not own; returning a copy
+    // keeps the offset immutable from the <Marker>'s perspective.
+    const input: [number, number] = [3, 4]
+    const out = resolveFanOffset(input)
+    expect(out).toEqual(input)
+    expect(out).not.toBe(input)
+  })
+})

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -13,6 +13,7 @@ import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
 import { useMarkerFan } from './photoLayers/useMarkerFan'
+import { resolveFanOffset } from './photoLayers/markerOffset'
 import { useEdgePanDrag } from './useEdgePanDrag'
 import { decideCompareOrSelect } from './compareSelection'
 import { MarkerDragHandle } from './MarkerDragHandle'
@@ -870,7 +871,12 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
             // Auto-fan: nudge overlapping markers apart by a pixel offset
             // (anchor stays at the true lng/lat). Suppressed while THIS marker
             // is being dragged so its dot tracks the cursor without a jump.
-            offset={activeDrag?.id === m.id ? undefined : photoFan.offsets.get(m.id)}
+            // `resolveFanOffset` guarantees a non-undefined [0,0] when this
+            // marker isn't fanned — see markerOffset.ts. A falsy offset would
+            // leave a stale fan offset stuck on the marker (the "placed photo
+            // drifts off the map on zoom-out" bug). Suppressed to [0,0] while
+            // THIS marker is dragged so its dot tracks the cursor without a jump.
+            offset={activeDrag?.id === m.id ? [0, 0] : resolveFanOffset(photoFan.offsets.get(m.id))}
             style={isActive || isSelected ? { zIndex: 2 } : undefined}
           >
             <MarkerDragHandle
@@ -1067,8 +1073,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
         const popupId = activePhotoMarkerId
         // When the active marker is fanned, shift the popup by the same pixel
         // offset so its tail points at the fanned dot the user clicked rather
-        // than the (now-empty) true GPS point under the cluster.
-        const fanOffset = photoFan.offsets.get(popupId)
+        // than the (now-empty) true GPS point under the cluster. `resolveFanOffset`
+        // returns [0,0] (never undefined) when un-fanned — the <Popup> wrapper has
+        // the same falsy-offset-ignored bug as <Marker> (see markerOffset.ts).
+        const fanOffset = resolveFanOffset(photoFan.offsets.get(popupId))
         return (
           <Popup
             longitude={marker.lng}

--- a/frontend/map-corridors/src/map/photoLayers/markerOffset.ts
+++ b/frontend/map-corridors/src/map/photoLayers/markerOffset.ts
@@ -1,0 +1,29 @@
+// Resolve the pixel offset handed to a react-map-gl <Marker>/<Popup>.
+//
+// WHY THIS EXISTS — a subtle wrapper bug we must defend against:
+// The `@vis.gl/react-mapbox` <Marker> and <Popup> components guard their
+// imperative `setOffset` call behind a truthiness check:
+//
+//     if (offset && !arePointsEqual(marker.getOffset(), offset)) marker.setOffset(offset)
+//
+// So a FALSY offset (`undefined`/`null`) is silently ignored — it never resets
+// a previously-applied offset. The auto-fan only emits an offset for markers
+// that are currently part of an overlapping cluster; an un-clustered marker has
+// no entry in the offsets map (`.get` → undefined). Passing that undefined
+// straight through means a marker that was briefly fanned at low zoom (where
+// far-apart photos collide in screen pixels) stays stuck at its last fan offset
+// once it un-fans — drifted off its true lng/lat, with no leader line to
+// explain it. That was the "I placed a photo precisely and it moves vs. the map
+// on zoom-out" bug.
+//
+// Returning an explicit [0,0] makes the offset a real, comparable value: the
+// wrapper's `arePointsEqual([0,0], <stale Point>)` is false, so `setOffset`
+// fires and snaps the marker back to its anchor.
+
+/** Fan offset for a marker, or [0,0] when it isn't fanned. Never returns
+ *  undefined — see the module note for why a falsy offset is a bug. */
+export function resolveFanOffset(
+  offset: readonly [number, number] | undefined,
+): [number, number] {
+  return offset ? [offset[0], offset[1]] : [0, 0]
+}


### PR DESCRIPTION
## Summary
- Fixes a precisely-placed photo marker visibly drifting off its true point on zoom-out (with no leader line) — it looked like a placement bug but was a stale pixel offset.
- Root cause: the `@vis.gl/react-mapbox` `<Marker>`/`<Popup>` wrappers guard `setOffset` with `if (offset && …)`, so a **falsy** offset never clears a previously-applied one. The auto-fan passed `undefined` for "no offset", so once a marker was transiently fanned at low zoom (where far-apart photos collide in screen pixels) it stayed stuck at its last fan offset after un-fanning.
- Fix: route both the marker (`MapProviderView.tsx`) and active-popup offsets through a new `resolveFanOffset()` helper that returns an explicit `[0,0]` when un-fanned. `[0,0]` is truthy and compares unequal to a stale `Point`, so `setOffset` fires and snaps the dot back to its anchor.
- Adds `markerOffset.ts` (documented helper explaining the wrapper trap) and `markerOffset.test.ts` (4 regression tests pinning the contract).

## Test plan
- [x] `tsc -b` — clean
- [x] Full suite — 694 passed / 2 todo (45 files), no new lint errors
- [x] New `resolveFanOffset` unit tests — 4 passed
- [ ] Manual: place a photo precisely, zoom out past a transient overlap, zoom/pan back → dot stays on its true point (no drift, no orphaned offset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)