### PR TITLE
fix(map-corridors): sort compare-modal photos by filename, then EXIF time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.25.2] - 2026-05-31
+
+### Fixed
+- **Map Corridors:** photos in the side-by-side compare view now appear in
+  shooting order (by original filename, then EXIF capture time) instead of the
+  order you happened to click or select them. Affects both compare routes — the
+  right-panel selection and the map's **⇄ N** cluster pill / Compare bar — and
+  the 1/2/3 keyboard shortcuts stay aligned with the tile numbering. (#99)
+
 ## [2.25.0] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [2.25.2] - 2026-05-31
+## [2.25.3] - 2026-05-31
 
 ### Fixed
 - **Map Corridors:** photos in the side-by-side compare view now appear in
@@ -18,6 +18,14 @@ new desktop release.
   order you happened to click or select them. Affects both compare routes — the
   right-panel selection and the map's **⇄ N** cluster pill / Compare bar — and
   the 1/2/3 keyboard shortcuts stay aligned with the tile numbering. (#99)
+
+## [2.25.2] - 2026-05-31
+
+### Fixed
+- **Map Corridors:** a precisely-placed photo marker no longer drifts off its
+  true point when you zoom out past a transient overlap and back. The marker now
+  snaps back to its anchor once it un-fans, instead of staying stuck at its last
+  fan offset. (#98)
 
 ## [2.25.0] - 2026-05-31
 

--- a/frontend/map-corridors/src/__tests__/markersDisplay.test.ts
+++ b/frontend/map-corridors/src/__tests__/markersDisplay.test.ts
@@ -7,10 +7,16 @@ import { describe, it, expect } from 'vitest'
 import {
   buildPhotoMarkerKmlName,
   compareFilenames,
+  comparePhotoMarkers,
   noGpsPhotoDisplayName,
   normalizeDisplayName,
   photoMarkerDisplayName,
 } from '../types/markers'
+import type { PhotoMarker } from '../types/markers'
+
+function pm(over: Partial<PhotoMarker>): PhotoMarker {
+  return { id: 'm-1', lng: 0, lat: 0, name: 'x.jpg', ...over } as PhotoMarker
+}
 
 describe('photoMarkerDisplayName', () => {
   it('returns the custom displayName when set', () => {
@@ -42,6 +48,51 @@ describe('compareFilenames', () => {
 
   it('returns 0 for identical strings', () => {
     expect(compareFilenames('same.jpg', 'same.jpg')).toBe(0)
+  })
+})
+
+describe('comparePhotoMarkers — compare-modal order (filename primary, EXIF timestamp tie-break)', () => {
+  // The side-by-side compare modal receives markers in click/cluster order; this
+  // comparator re-orders them into shooting sequence so tile badges + 1/2/3 keys
+  // follow the filenames regardless of how the user selected them.
+  it('orders by filename ASC even when capture time disagrees', () => {
+    const sorted = [
+      pm({ id: 'b', name: 'b.jpg', capturedAt: { lng: 0, lat: 0, timestamp: '2024-01-01T00:00:00Z' } }),
+      pm({ id: 'a', name: 'a.jpg', capturedAt: { lng: 0, lat: 0, timestamp: '2024-02-01T00:00:00Z' } }),
+    ].sort(comparePhotoMarkers).map(m => m.id)
+    expect(sorted).toEqual(['a', 'b'])
+  })
+
+  it('is numeric-aware: IMG_9 sorts before IMG_10', () => {
+    const sorted = [
+      pm({ id: 'ten', name: 'IMG_10.jpg' }),
+      pm({ id: 'nine', name: 'IMG_9.jpg' }),
+    ].sort(comparePhotoMarkers).map(m => m.id)
+    expect(sorted).toEqual(['nine', 'ten'])
+  })
+
+  it('tie-breaks by EXIF timestamp when filenames are identical', () => {
+    const sorted = [
+      pm({ id: 'late', name: 'same.jpg', capturedAt: { lng: 0, lat: 0, timestamp: '2024-02-01T00:00:00Z' } }),
+      pm({ id: 'early', name: 'same.jpg', capturedAt: { lng: 0, lat: 0, timestamp: '2024-01-01T00:00:00Z' } }),
+    ].sort(comparePhotoMarkers).map(m => m.id)
+    expect(sorted).toEqual(['early', 'late'])
+  })
+
+  it('sorts a marker without capturedAt last among identical filenames', () => {
+    const sorted = [
+      pm({ id: 'none', name: 'same.jpg' }),
+      pm({ id: 'early', name: 'same.jpg', capturedAt: { lng: 0, lat: 0, timestamp: '2024-01-01T00:00:00Z' } }),
+    ].sort(comparePhotoMarkers).map(m => m.id)
+    expect(sorted).toEqual(['early', 'none'])
+  })
+
+  it('orders by filename even when entries lack a timestamp', () => {
+    const sorted = [
+      pm({ id: 'z', name: 'z.jpg' }),
+      pm({ id: 'a', name: 'a.jpg' }),
+    ].sort(comparePhotoMarkers).map(m => m.id)
+    expect(sorted).toEqual(['a', 'z'])
   })
 })
 

--- a/frontend/map-corridors/src/components/PhotoCompareModal.tsx
+++ b/frontend/map-corridors/src/components/PhotoCompareModal.tsx
@@ -6,7 +6,7 @@
 // rejected variants are NOT deleted from OPFS — they live in the
 // "Odmítnuté" list group as the undo path if the user changes their mind.
 
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import {
   Box,
   Button,
@@ -21,13 +21,18 @@ import {
 import { Close } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import type { PhotoMarker } from '../types/markers'
-import { photoMarkerDisplayName } from '../types/markers'
+import { comparePhotoMarkers, photoMarkerDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoFullUrl } from './usePhotoFullUrl'
 
 export interface PhotoCompareModalProps {
   open: boolean
-  /** Selected variants, in the order the user picked them. */
+  /**
+   * Selected variants. Received in selection/cluster order; the modal sorts them
+   * by original filename (numeric-aware) with EXIF timestamp as tie-break before
+   * rendering, so tiles + the 1/2/3 shortcuts follow shooting sequence regardless
+   * of click order. See {@link comparePhotoMarkers}.
+   */
   markers: readonly PhotoMarker[]
   storage: StorageInterface | null
   photosDir: DirectoryHandle | null
@@ -45,6 +50,14 @@ export function PhotoCompareModal(props: PhotoCompareModalProps) {
   const { open, markers, storage, photosDir, onClose, onResolve } = props
   const { t } = useI18n()
 
+  // Display in shooting sequence (filename, then EXIF time), not click/cluster
+  // order. Both the keyboard handler and the tile render read this single sorted
+  // array so the number badge always matches its 1/2/3 shortcut.
+  const sortedMarkers = useMemo(
+    () => [...markers].sort(comparePhotoMarkers),
+    [markers],
+  )
+
   const handlePick = useCallback((winnerId: string) => {
     const loserIds = markers
       .filter(m => m.id !== winnerId)
@@ -61,15 +74,15 @@ export function PhotoCompareModal(props: PhotoCompareModalProps) {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === '1' || e.key === '2' || e.key === '3') {
         const idx = Number(e.key) - 1
-        if (idx >= 0 && idx < markers.length) {
+        if (idx >= 0 && idx < sortedMarkers.length) {
           e.preventDefault()
-          handlePick(markers[idx].id)
+          handlePick(sortedMarkers[idx].id)
         }
       }
     }
     window.addEventListener('keydown', onKey)
     return () => { window.removeEventListener('keydown', onKey) }
-  }, [open, markers, handlePick])
+  }, [open, sortedMarkers, handlePick])
 
   if (!open) return null
   // Defensive: 0 or 1 variants makes the "compare" framing nonsensical.
@@ -102,11 +115,11 @@ export function PhotoCompareModal(props: PhotoCompareModalProps) {
             // 1 col on narrow screens (mobile), N cols otherwise. Capped at
             // 3 by PhotoListPanel's selection limit, so this never grows
             // past 3 columns regardless of viewport.
-            gridTemplateColumns: { xs: '1fr', sm: `repeat(${markers.length}, 1fr)` },
+            gridTemplateColumns: { xs: '1fr', sm: `repeat(${sortedMarkers.length}, 1fr)` },
             gap: 1.5,
           }}
         >
-          {markers.map((m, idx) => (
+          {sortedMarkers.map((m, idx) => (
             <CompareTile
               key={m.id}
               marker={m}

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -286,6 +286,21 @@ export function compareNoGpsPhotos(a: NoGpsPhoto, b: NoGpsPhoto): number {
   return ta < tb ? -1 : ta > tb ? 1 : 0
 }
 
+/**
+ * Sort comparator for compare-modal variants ({@link PhotoMarker}). Filename-first
+ * (numeric-aware via {@link compareFilenames}, so `IMG_9` < `IMG_10`), with EXIF
+ * capture time as the tie-break for identical filenames. Sorts by the immutable
+ * original `name` — not the user's `displayName` — so a rename never reorders the
+ * compare tiles, mirroring {@link compareNoGpsPhotos}. Missing timestamps sort last.
+ */
+export function comparePhotoMarkers(a: PhotoMarker, b: PhotoMarker): number {
+  const byName = compareFilenames(a.name, b.name)
+  if (byName !== 0) return byName
+  const ta = a.capturedAt?.timestamp ?? '￿'
+  const tb = b.capturedAt?.timestamp ?? '￿'
+  return ta < tb ? -1 : ta > tb ? 1 : 0
+}
+
 export function sanitizeNoGpsPhotos(input: unknown): NoGpsPhoto[] {
   if (!Array.isArray(input)) return []
   // Strip an empty/redundant displayName rather than dropping the photo.


### PR DESCRIPTION
## Summary
- The side-by-side **PhotoCompareModal** showed variants in arrival order — click order from the panel selection, cluster order from the map **⇄ N** pill / Compare bar — so photos appeared out of shooting sequence instead of by filename/timestamp.
- Fixed at the single chokepoint inside the modal: a memoized `sortedMarkers` now feeds both the tile render and the `1/2/3` keyboard handler, so both compare entry points are corrected at once and the shortcut numbers stay aligned with the tile badges.
- Added `comparePhotoMarkers` to `types/markers.ts` — numeric-aware `compareFilenames` with EXIF `capturedAt.timestamp` as tie-break, sorting by the immutable original `name` so a rename never reorders tiles (mirrors the existing `compareNoGpsPhotos`).

## Test plan
- [x] `pnpm test` — 703 passed (incl. 5 new `comparePhotoMarkers` cases: filename-ASC over disagreeing timestamps, numeric-aware order, timestamp tie-break, missing-`capturedAt` sorts last)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: select 3 photos out of filename order (e.g. IMG_003 → IMG_001 → IMG_002), open Compare → tiles render 1=IMG_001, 2=IMG_002, 3=IMG_003 and `1/2/3` pick the matching tile
- [ ] Manual: repeat via the map cluster **⇄ N** pill to confirm the map entry point is also sorted

🤖 Generated with [Claude Code](https://claude.com/claude-code)