### PR TITLE
feat(photo-helper): auto-route map-corridors picks into track/turning sets #minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.0] - 2026-05-31
+
+### Changed
+- **Photo Helper:** photos sent from Map Corridors now land directly in the
+  matching set instead of all piling into the candidate tray. A **track** pick
+  fills the track sets and a **turning** pick fills the turning sets (set 1
+  first, then set 2; once both are full the rest stay in the tray for manual
+  placement). The editor never switches discipline on you — picks for the view
+  you're not currently looking at fill silently and appear when you switch to
+  that discipline. Once a photo is in a set it belongs to the editor: later
+  re-categorising or un-picking it on the map no longer moves it.
+
 ## [2.25.3] - 2026-05-31
 
 ### Fixed

--- a/docs/CANDIDATE_PHOTOS.md
+++ b/docs/CANDIDATE_PHOTOS.md
@@ -195,6 +195,51 @@ to candidates.
 
 ---
 
+## Map-pick auto-routing
+
+Picks handed off from **map-corridors** already carry a discipline category in
+their flag (`pick-track` / `pick-turning`, see the handoff `WireFlag`). On
+**first import** `useMapPicksSync` routes them straight into the matching
+discipline's sets instead of the candidate tray — the category the user already
+chose on the map is honoured, so they don't re-sort everything by hand in the
+editor.
+
+Routing lives in the pure helper `routeImportedPickIntoSets`
+(`utils/candidateTransitions.ts`); the hook wrapper is
+`useCompetitionSystem.importPickToSets`.
+
+**Fill policy — `set1 → set2 → tray`.** set1 fills to `getGridCapacity` first,
+overflow spills into set2, and once both are full the photo stays in the
+candidate tray (flag preserved) for manual placement. **Precision** discipline
+is single-set, so set2 is skipped and overflow from set1 goes straight to the
+tray.
+
+**Mode policy — never auto-switch.** `pick-track` → track sets, `pick-turning`
+→ turning sets, regardless of which discipline the user is currently viewing. A
+pick for the **active** mode is written to `session.sets` (visible immediately)
+and mirrored into the active bucket; a pick for the **inactive** mode is written
+to that mode's bucket (`setsTrack` / `setsTurning`) with `url: ''` — exactly
+like every other inactive-bucket photo — so it surfaces, with a freshly
+regenerated blob URL, when the user switches to that discipline. The user's
+current view is never yanked around.
+
+**Idempotency.** A placed photo loses its tray flag and leaves the candidate
+pool, so the candidates-only dedup in the sync can't see it. `AppApi` therefore
+feeds `useMapPicksSync` a `placedIds` set (all `pm-` ids living in any set
+bucket); the insert path skips any id already in it, so a re-sync on
+`visibilitychange` never re-inserts a duplicate. A same-run guard
+(`placedThisRun`) covers a duplicated row within a single file.
+
+**Known consequences (consistent with hand-promotion).** Once a `pm-` photo is
+placed in a set it is **detached** from the continuous map-pick mirror: a later
+un-pick, re-categorisation, label, or filename edit in map-corridors is **not**
+propagated, and the photo stops round-tripping through `editor-picks.json`
+(which only carries candidates). This is identical to what already happens when
+a user manually promotes a map candidate into a slot — placement transfers
+ownership of the photo to the editor.
+
+---
+
 ## Editor modal behavior
 
 The modal works identically for tray and slot photos. The only differences:

--- a/docs/photo-map-culling/set-split-suggestion-plan.md
+++ b/docs/photo-map-culling/set-split-suggestion-plan.md
@@ -1,0 +1,135 @@
+# Plan (DRAFT): Suggested set1↔set2 split for rally imports
+
+**Status:** DRAFT — awaiting sign-off. Not implemented.
+**Depends on:** PR #100 (`feat/map-picks-auto-route-sets`), which ships the
+baseline `set1 → set2 → tray` capacity fill. This doc designs the *next* layer:
+making the set1/set2 boundary land on a **meaningful route point** instead of
+"wherever set1 filled up."
+**Owner decisions (2026-05-31, this session):**
+- Split owner: **C — the editor suggests + draggable divider.** The map sends
+  order (+ optional markers); the editor owns capacity and proposes the cut.
+- Default cut: **largest route gap, TP-aware.**
+
+---
+
+## Why
+
+set1/set2 are two **sheets** of the answer PDF; the photos on them are in route
+order (filename, then EXIF time). The natural sheet boundary is *where one leg of
+the route ends and the next begins* — a turning point, or a big jump in
+distance/time between consecutive shots. PR #100's capacity fill cuts at photo
+#9/#10 regardless, so the user re-drags photos to move the boundary to a real
+point on every import. This feature picks a sensible boundary automatically and
+lets the user nudge it.
+
+**Scope: rally only.** Precision is single-sheet (set2 unused), so there is no
+boundary to choose — this feature is inert for precision. Applies independently
+within each rally discipline: track photos split across track set1/set2, turning
+photos across turning set1/set2.
+
+## Knowledge boundary (why C, not B)
+
+- **The editor owns capacity** (9 / 10 per sheet, layout- and mode-dependent via
+  `getGridCapacity`). A rally discipline holds up to ~2×cap; "everything in
+  set1" is physically impossible, so the split must be capacity-aware → editor.
+- **The map owns route semantics** (order, GPS, where TPs are). It can *hint*
+  the meaningful cut but must not assert a hard set assignment, or set-capacity
+  rules leak into the map app (and would have to be suppressed for precision).
+
+So: **map hints where the cut is meaningful; editor decides where it's legal and
+applies it.** Degrades gracefully — with zero map changes, the editor already
+has per-photo `gps` on each `pm-` candidate and can run the gap heuristic alone.
+
+## The suggested-cut heuristic (TP-aware largest gap)
+
+Input: the discipline's fresh picks in route order `P[0..n-1]`, each with
+`gps.capturedAt {lng,lat}` and/or `gps.timestamp`. Let `cap = getGridCapacity`
+for that mode.
+
+1. **No split needed** when `n ≤ cap` → all into set1.
+2. **Legal window for the cut index `k`** (photos `[0..k-1]` → set1, `[k..n-1]`
+   → set2): `max(1, n - cap) ≤ k ≤ min(cap, n-1)`. Outside this, a sheet would
+   overflow. If `n > 2·cap`, the surplus beyond `2·cap` spills to the tray
+   (PR #100 behavior) before the split is computed.
+3. **Score each adjacent gap** `g(i)` between `P[i-1]` and `P[i]` for `i` in the
+   legal window:
+   - primary: **haversine distance** between the two coords (subjectAt
+     preferred, else capturedAt);
+   - fallback when either coord is missing: **EXIF time delta**;
+   - **TP-aware boost:** if a route marker / turning point sits at this boundary
+     (see "Optional map hint" below), multiply the score so a real leg-end wins
+     ties against an incidental gap.
+4. **Pick `k` = argmax g(i)** within the window. Ties → the `k` closest to the
+   window midpoint (most balanced sheets).
+5. **Fallback** when all gaps are missing/equal (no GPS, no times): even split,
+   `k = clamp(round(n/2), window)`.
+
+Pure, unit-testable: `suggestSetSplit(orderedPicks, cap, markers?) → k`.
+
+## Optional map hint (additive, later)
+
+To make "TP-aware" explicit rather than gap-inferred, extend `MapPickEntry`
+(versioned, additive — `frontend/shared-handoff/src/types.ts`) with an optional
+boundary marker, e.g. `legBreakBefore?: boolean` or `legIndex?: number`, set by
+map-corridors where the route crosses a turning point. The editor prefers these
+as cut points and falls back to the gap heuristic when absent. **Not required
+for v1** — the gap heuristic works on the `gps` the picks already carry.
+
+## UI: draggable divider
+
+In the rally two-sheet view, render a boundary control between set1 and set2
+positioned at the suggested `k`, labelled e.g. *"Suggested split — drag to
+adjust."* Dragging it re-partitions the ordered list (clamped to the legal
+window; it can't push a sheet over capacity).
+
+**Lifecycle / the hard constraint:** the divider only makes sense while the two
+sheets still hold the imported photos *in import order*. Once the user manually
+reorders, swaps, or deletes within a sheet, "slide the boundary" is ill-defined.
+So:
+- The divider is **live only in a pristine, import-ordered state** (track a
+  `splitDirty` flag per discipline; set it on any manual slot mutation).
+- Once dirty, the divider locks/hides and placement is just normal drag-drop.
+
+**MVP fallback** if the live divider is too much for a first cut: apply the
+suggested split at import and show a one-time hint *"Split placed after photo N —
+drag photos to adjust"*, reusing existing drag-drop. Ship the heuristic value
+first, add the interactive divider second.
+
+## Where it plugs into the shipped code
+
+PR #100 places picks **one at a time** in `syncMapPicksOnce` via
+`routeImportedPickIntoSets` (set1→set2→tray). The split needs the **whole
+discipline batch** to choose `k`, so:
+
+- In `syncMapPicksOnce`, before the per-photo loop, group the **fresh** inserts
+  (not in `placedIds`/candidates) by discipline, in route order, and compute
+  `k = suggestSetSplit(...)` per discipline.
+- Replace per-photo spillover with a batch placement that fills set1 with
+  `[0..k-1]` and set2 with `[k..]` (tray for surplus past `2·cap`). Keep the
+  single-photo path as the fallback for incremental, post-batch arrivals
+  (one new pick after the initial import just appends per current rules).
+- `routeImportedPickIntoSets` stays the primitive; add
+  `applySuggestedSplit(session, mode, orderedPhotos, k)` alongside it, both pure.
+
+Ordering source of truth: reuse the existing **filename-then-EXIF** comparator
+(the same one the map-compare "shooting order" fix uses, commit `b8af505` /
+#99 era) so editor and map agree.
+
+## Test plan (when built)
+
+- `suggestSetSplit`: no-split (`n≤cap`); legal-window clamping; largest-gap
+  pick; TP-marker boost beats a larger incidental gap; even-split fallback (no
+  GPS); `n>2·cap` surplus → tray then split the rest.
+- Batch placement: pristine import fills both sheets at `k`; precision ignores
+  (single sheet); idempotent re-sync (placedIds) doesn't re-split.
+- Divider (if built): drag clamps to legal window; `splitDirty` locks it after a
+  manual mutation.
+
+## Open questions for sign-off
+
+1. **Divider now or MVP hint first?** (Recommend MVP hint → divider as a
+   fast-follow.)
+2. **Ship the gap-only heuristic (zero map changes) first, add the explicit
+   `legIndex` map hint later?** (Recommend yes.)
+3. **Distance vs time weighting** when both exist — pure distance, or a blend?
+   (Recommend distance-primary; time only as fallback.)

--- a/docs/photo-map-culling/track-turning-categorization-plan.md
+++ b/docs/photo-map-culling/track-turning-categorization-plan.md
@@ -27,6 +27,17 @@ unreliable mid-session; it must be redone cleanly. Nothing about A3 is committed
    candidate's flag; the existing tray "Send to Set" / "Send to TP photos"
    controls (shipped in B2) do the actual placement.
 
+   > **SUPERSEDED 2026-05-31** (PR #100, branch
+   > `feat/map-picks-auto-route-sets`). The owner reversed this: arriving picks
+   > now **do** auto-route into the editor's sets on first import
+   > (`pick-track` → track sets, `pick-turning` → turning sets), filling the
+   > *inactive* discipline's bucket silently rather than switching the view.
+   > The "hidden mode bucket" concern this decision raised is handled by storing
+   > inactive-bucket photos with `url: ''` (regenerated on mode-load) and by an
+   > idempotency guard (`placedIds`) so re-syncs don't duplicate. See
+   > `docs/CANDIDATE_PHOTOS.md` "Map-pick auto-routing" and the follow-up
+   > `set-split-suggestion-plan.md` for the set1↔set2 boundary work.
+
 ## Visual language
 
 - Track pick marker ring: blue `#1976d2` (current pick color — keep).

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -107,6 +107,7 @@ function AppApi() {
     // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
     addPhotosToCandidates,
     addExistingCandidate,
+    importPickToSets,
     removeCandidate,
     promoteCandidateToSlot,
     demoteSlotToCandidate,
@@ -120,6 +121,27 @@ function AppApi() {
   // Candidate photos — derived from session for stable rendering. The pool
   // is optional on older sessions, so default to empty.
   const candidatePhotos: ApiPhoto[] = session?.candidates?.photos ?? [];
+
+  // `pm-` ids already placed in a set across any discipline bucket. Fed to
+  // useMapPicksSync so a re-sync never re-inserts an auto-routed photo into
+  // the tray (placed photos drop their flag + leave the candidate pool, so
+  // the candidates-only dedup can't see them). Recomputed whenever the sets
+  // change. See docs/CANDIDATE_PHOTOS.md "Map-pick auto-routing".
+  const placedPmIds: ReadonlySet<string> = useMemo(() => {
+    const ids = new Set<string>();
+    const collect = (sets?: { set1: { photos: ApiPhoto[] }; set2: { photos: ApiPhoto[] } }) => {
+      if (!sets) return;
+      for (const setKey of ['set1', 'set2'] as const) {
+        for (const p of sets[setKey].photos) {
+          if (p.id.startsWith('pm-')) ids.add(p.id);
+        }
+      }
+    };
+    collect(session?.sets);
+    collect(session?.setsTrack);
+    collect(session?.setsTurning);
+    return ids;
+  }, [session?.sets, session?.setsTrack, session?.setsTurning]);
 
   // Phase 8b of photo-map-culling — resolve the per-competition dirs
   // and mount the map-picks sync hook. The dirs come from the OPFS
@@ -163,12 +185,14 @@ function AppApi() {
 
   const pmcSessionApi = useMemo(() => ({
     candidates: candidatePhotos,
+    placedIds: placedPmIds,
     addCandidate: addExistingCandidate,
+    importPick: importPickToSets,
     removeCandidate,
     setCandidateFlag,
     setCandidateLabel,
     setCandidateFilename,
-  }), [candidatePhotos, addExistingCandidate, removeCandidate, setCandidateFlag, setCandidateLabel, setCandidateFilename]);
+  }), [candidatePhotos, placedPmIds, addExistingCandidate, importPickToSets, removeCandidate, setCandidateFlag, setCandidateLabel, setCandidateFilename]);
 
   useMapPicksSync(pmcCompetitionDir, pmcPhotosDir, pmcSessionApi);
 

--- a/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
@@ -449,4 +449,67 @@ describe('routeImportedPickIntoSets', () => {
     expect(next.sets.set2.photos).toHaveLength(0);
     expect(next.candidates?.photos.map(p => p.id)).toEqual(['pm-a']);
   });
+
+  // Idempotency guard — a rapid re-sync (mount run + a visibilitychange run)
+  // can call the helper twice for the same id before React recomputes the
+  // `placedIds` memo. The second call must NOT append a duplicate; it returns
+  // the existing placement and hands back the redundant blob URL to revoke.
+  it('is idempotent by id in the active set — second call does not duplicate', () => {
+    const first = routeImportedPickIntoSets(
+      makeRouteSession({ mode: 'track' }),
+      makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag }),
+      'track',
+      false,
+    );
+    expect(first.session.sets.set1.photos.map(p => p.id)).toEqual(['pm-a']);
+
+    // Re-run against the just-placed session with a fresh-URL duplicate.
+    const dup = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag, url: 'blob:pm-a-2' });
+    const second = routeImportedPickIntoSets(first.session, dup, 'track', false);
+
+    expect(second.placement).toBe('set1');
+    expect(second.session.sets.set1.photos.map(p => p.id)).toEqual(['pm-a']); // no duplicate
+    expect(second.session.sets.set1.photos).toHaveLength(1);
+    // The redundant URL minted for this attempt is handed back for revocation.
+    expect(second.revokeUrl).toBe('blob:pm-a-2');
+    // No-op: session is returned unchanged (version not bumped).
+    expect(second.session).toBe(first.session);
+  });
+
+  it('is idempotent by id in an inactive bucket — second call does not duplicate', () => {
+    const first = routeImportedPickIntoSets(
+      makeRouteSession({ mode: 'track' }),
+      makePhoto('pm-tp', { flag: 'pick-turning' as CandidateFlag }),
+      'turningpoint',
+      false,
+    );
+    expect(first.session.setsTurning?.set1.photos.map(p => p.id)).toEqual(['pm-tp']);
+
+    const dup = makePhoto('pm-tp', { flag: 'pick-turning' as CandidateFlag, url: 'blob:pm-tp-2' });
+    const second = routeImportedPickIntoSets(first.session, dup, 'turningpoint', false);
+
+    expect(second.placement).toBe('set1');
+    expect(second.session.setsTurning?.set1.photos).toHaveLength(1);
+    expect(second.revokeUrl).toBe('blob:pm-tp-2');
+    expect(second.session).toBe(first.session);
+  });
+
+  it('is idempotent by id in the tray — a re-routed overflow pick does not duplicate', () => {
+    const first = routeImportedPickIntoSets(
+      makeRouteSession({ mode: 'track', sets: { set1: fill(9, 's'), set2: fill(9, 't') } }),
+      makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag }),
+      'track',
+      false,
+    );
+    expect(first.placement).toBe('tray');
+    expect(first.session.candidates?.photos.map(p => p.id)).toEqual(['pm-a']);
+
+    const dup = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag, url: 'blob:pm-a-2' });
+    const second = routeImportedPickIntoSets(first.session, dup, 'track', false);
+
+    expect(second.placement).toBe('tray');
+    expect(second.session.candidates?.photos.map(p => p.id)).toEqual(['pm-a']); // no duplicate
+    expect(second.revokeUrl).toBe('blob:pm-a-2');
+    expect(second.session).toBe(first.session);
+  });
 });

--- a/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
+++ b/frontend/photo-helper/src/__tests__/candidateTransitions.test.ts
@@ -6,6 +6,7 @@ import {
   removeCandidate,
   clearAllCandidates,
   updateCandidateCanvasState,
+  routeImportedPickIntoSets,
 } from '../utils/candidateTransitions';
 import type { ApiPhoto, ApiPhotoSession, CandidateFlag } from '../types/api';
 
@@ -329,5 +330,123 @@ describe('candidate helpers handle undefined session.candidates (legacy)', () =>
     const session = makeLegacySession();
     const next = updateCandidateCanvasState(session, 'any', { brightness: 5 });
     expect(next).toBe(session);
+  });
+});
+
+describe('routeImportedPickIntoSets', () => {
+  // Builds a session with explicit mode + optional discipline buckets so we
+  // can exercise the active-vs-inactive routing branches. Track-landscape
+  // capacity is 9; turning-point is 10 (see getGridCapacity).
+  function makeRouteSession(opts: {
+    mode: 'track' | 'turningpoint';
+    sets?: { set1: ApiPhoto[]; set2: ApiPhoto[] };
+    setsTrack?: { set1: ApiPhoto[]; set2: ApiPhoto[] };
+    setsTurning?: { set1: ApiPhoto[]; set2: ApiPhoto[] };
+    layoutMode?: 'portrait' | 'landscape';
+  }): ApiPhotoSession {
+    const wrap = (s?: { set1: ApiPhoto[]; set2: ApiPhoto[] }) =>
+      s ? { set1: { title: '', photos: s.set1 }, set2: { title: '', photos: s.set2 } } : undefined;
+    const base: any = {
+      id: 'sess-1',
+      version: 1,
+      createdAt: '2026-05-31T00:00:00Z',
+      updatedAt: '2026-05-31T00:00:00Z',
+      mode: opts.mode,
+      competition_name: 'Test',
+      sets: wrap(opts.sets) ?? { set1: { title: '', photos: [] }, set2: { title: '', photos: [] } },
+      candidates: { photos: [] },
+    };
+    if (opts.setsTrack) base.setsTrack = wrap(opts.setsTrack);
+    if (opts.setsTurning) base.setsTurning = wrap(opts.setsTurning);
+    if (opts.layoutMode) base.layoutMode = opts.layoutMode;
+    return base as ApiPhotoSession;
+  }
+
+  const fill = (n: number, prefix: string) =>
+    Array.from({ length: n }, (_, i) => makePhoto(`${prefix}${i + 1}`));
+
+  it('routes a pick-track into the active track set1, clears flag, mirrors bucket', () => {
+    const session = makeRouteSession({ mode: 'track' });
+    const photo = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag });
+
+    const { session: next, placement, revokeUrl } = routeImportedPickIntoSets(session, photo, 'track', false);
+
+    expect(placement).toBe('set1');
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['pm-a']);
+    expect(next.sets.set1.photos[0].flag).toBeUndefined();
+    // Active-set placement keeps the live URL and mirrors into setsTrack.
+    expect(next.sets.set1.photos[0].url).toBe('blob:pm-a');
+    expect(next.setsTrack?.set1.photos.map(p => p.id)).toEqual(['pm-a']);
+    expect(next.candidates?.photos).toHaveLength(0);
+    expect(revokeUrl).toBeUndefined();
+    expect(next.version).toBe(session.version + 1);
+  });
+
+  it('spills into set2 when set1 is full (track landscape capacity 9)', () => {
+    const session = makeRouteSession({ mode: 'track', sets: { set1: fill(9, 's'), set2: [] } });
+    const photo = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag });
+
+    const { session: next, placement } = routeImportedPickIntoSets(session, photo, 'track', false);
+
+    expect(placement).toBe('set2');
+    expect(next.sets.set1.photos).toHaveLength(9);
+    expect(next.sets.set2.photos.map(p => p.id)).toEqual(['pm-a']);
+  });
+
+  it('falls back to the candidate tray (flag kept) when both sets are full', () => {
+    const session = makeRouteSession({ mode: 'track', sets: { set1: fill(9, 's'), set2: fill(9, 't') } });
+    const photo = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag });
+
+    const { session: next, placement, revokeUrl } = routeImportedPickIntoSets(session, photo, 'track', false);
+
+    expect(placement).toBe('tray');
+    expect(next.candidates?.photos.map(p => p.id)).toEqual(['pm-a']);
+    expect(next.candidates?.photos[0].flag).toBe('pick-track');
+    expect(next.candidates?.photos[0].url).toBe('blob:pm-a');
+    expect(next.sets.set1.photos).toHaveLength(9);
+    expect(next.sets.set2.photos).toHaveLength(9);
+    expect(revokeUrl).toBeUndefined();
+  });
+
+  it('routes a pick-turning into the INACTIVE turning bucket without touching the active view', () => {
+    const session = makeRouteSession({ mode: 'track', sets: { set1: fill(2, 's'), set2: [] } });
+    const photo = makePhoto('pm-a', { flag: 'pick-turning' as CandidateFlag });
+
+    const { session: next, placement, revokeUrl } = routeImportedPickIntoSets(session, photo, 'turningpoint', false);
+
+    expect(placement).toBe('set1');
+    // Active (track) view is untouched.
+    expect(next.sets.set1.photos.map(p => p.id)).toEqual(['s1', 's2']);
+    // Lands in the turning bucket, stored with an empty URL (regenerated on
+    // mode-load) and flag cleared.
+    expect(next.setsTurning?.set1.photos.map(p => p.id)).toEqual(['pm-a']);
+    expect(next.setsTurning?.set1.photos[0].url).toBe('');
+    expect(next.setsTurning?.set1.photos[0].flag).toBeUndefined();
+    // The live URL is now orphaned — caller revokes it.
+    expect(revokeUrl).toBe('blob:pm-a');
+  });
+
+  it('turning-point capacity is 10 — 10th into set1, 11th spills to set2', () => {
+    const session = makeRouteSession({ mode: 'turningpoint', sets: { set1: fill(9, 's'), set2: [] } });
+    const tenth = routeImportedPickIntoSets(session, makePhoto('pm-10', { flag: 'pick-turning' as CandidateFlag }), 'turningpoint', false);
+    expect(tenth.placement).toBe('set1');
+    expect(tenth.session.sets.set1.photos).toHaveLength(10);
+
+    const full = makeRouteSession({ mode: 'turningpoint', sets: { set1: fill(10, 's'), set2: [] } });
+    const eleventh = routeImportedPickIntoSets(full, makePhoto('pm-11', { flag: 'pick-turning' as CandidateFlag }), 'turningpoint', false);
+    expect(eleventh.placement).toBe('set2');
+  });
+
+  it('precision is single-set: overflow from a full set1 goes to the tray, never set2', () => {
+    // Precision track is single-set (set2 unused), so isPrecision=true must
+    // skip set2 even though it is empty.
+    const session = makeRouteSession({ mode: 'track', sets: { set1: fill(9, 's'), set2: [] } });
+    const photo = makePhoto('pm-a', { flag: 'pick-track' as CandidateFlag });
+
+    const { session: next, placement } = routeImportedPickIntoSets(session, photo, 'track', true);
+
+    expect(placement).toBe('tray');
+    expect(next.sets.set2.photos).toHaveLength(0);
+    expect(next.candidates?.photos.map(p => p.id)).toEqual(['pm-a']);
   });
 });

--- a/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
+++ b/frontend/photo-helper/src/__tests__/useMapPicksSync.test.ts
@@ -33,8 +33,12 @@ function fakeStorage(): FakeStorage {
   }
 }
 
-function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi & {
+function fakeSession(
+  initialCandidates: ApiPhoto[] = [],
+  placed: string[] = [],
+): MapPicksSyncSessionApi & {
   addCandidate: Mock
+  importPick: Mock
   removeCandidate: Mock
   setCandidateFlag: Mock
   setCandidateLabel: Mock
@@ -43,7 +47,11 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   const candidates = [...initialCandidates]
   const api = {
     candidates,
+    placedIds: new Set(placed),
     addCandidate: vi.fn(async (p: ApiPhoto) => { candidates.push(p) }),
+    // Auto-routes category picks into sets — modelled as "leaves the candidate
+    // pool" (the real helper clears the flag and moves it into a set bucket).
+    importPick: vi.fn(async (_p: ApiPhoto, _mode: 'track' | 'turningpoint') => { /* placed in a set */ }),
     removeCandidate: vi.fn(async (id: string) => {
       const idx = candidates.findIndex(p => p.id === id)
       if (idx >= 0) candidates.splice(idx, 1)
@@ -66,6 +74,7 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   }
   return api as MapPicksSyncSessionApi & {
     addCandidate: Mock
+    importPick: Mock
     removeCandidate: Mock
     setCandidateFlag: Mock
     setCandidateLabel: Mock
@@ -73,7 +82,10 @@ function fakeSession(initialCandidates: ApiPhoto[] = []): MapPicksSyncSessionApi
   }
 }
 
-function pmEntry(id: string, flag: 'pick-track' | 'neutral' | 'reject' = 'pick-track') {
+function pmEntry(
+  id: string,
+  flag: 'pick-track' | 'pick-turning' | 'neutral' | 'reject' = 'pick-track',
+) {
   return { photoId: id, filename: `${id}.jpg`, flag }
 }
 
@@ -131,7 +143,9 @@ describe('syncMapPicksOnce — file absence', () => {
 })
 
 describe('syncMapPicksOnce — insert path', () => {
-  it('inserts a new pm- entry not yet in the pool', async () => {
+  // A category-flagged pick now auto-routes into its discipline's sets via
+  // `importPick` (set1→set2→tray spillover) instead of landing in the tray.
+  it('auto-routes a new pick-track entry into the track sets (not the tray)', async () => {
     const storage = fakeStorage()
     storage.readJSON.mockResolvedValue({
       version: 1,
@@ -142,12 +156,46 @@ describe('syncMapPicksOnce — insert path', () => {
     const session = fakeSession([])
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.inserts).toBe(1)
-    expect(session.addCandidate).toHaveBeenCalledTimes(1)
-    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
-    expect(inserted.id).toBe('pm-new')
-    expect(inserted.filename).toBe('pm-new.jpg')
-    expect(inserted.flag).toBe('pick-track')
-    expect(inserted.canvasState.scale).toBe(1) // matches createDefaultCanvasState
+    expect(session.addCandidate).not.toHaveBeenCalled()
+    expect(session.importPick).toHaveBeenCalledTimes(1)
+    const [photo, mode] = session.importPick.mock.calls[0] as [ApiPhoto, string]
+    expect(photo.id).toBe('pm-new')
+    expect(photo.filename).toBe('pm-new.jpg')
+    expect(photo.flag).toBe('pick-track')
+    expect(photo.canvasState.scale).toBe(1) // matches createDefaultCanvasState
+    expect(mode).toBe('track')
+  })
+
+  it('auto-routes a new pick-turning entry into the turning sets', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-tp', 'pick-turning')],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(32)], { type: 'image/jpeg' }))
+    const session = fakeSession([])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(1)
+    expect(session.importPick).toHaveBeenCalledWith(expect.objectContaining({ id: 'pm-tp' }), 'turningpoint')
+  })
+
+  it('does NOT re-route a photo already placed in a set (placedIds guard prevents tray duplicate)', async () => {
+    const storage = fakeStorage()
+    storage.readJSON.mockResolvedValue({
+      version: 1,
+      updatedAt: 'x',
+      picks: [pmEntry('pm-placed', 'pick-track')],
+    })
+    storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
+    // pm-placed was auto-routed on a prior sync → it now lives in a set, so it
+    // is reported via placedIds (and is NOT in the candidate pool).
+    const session = fakeSession([], ['pm-placed'])
+    const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
+    expect(result.inserts).toBe(0)
+    expect(session.importPick).not.toHaveBeenCalled()
+    expect(session.addCandidate).not.toHaveBeenCalled()
+    expect(storage.getPhotoBlob).not.toHaveBeenCalled() // skipped before blob fetch
   })
 
   it('skips insert when the photo blob is missing (orphan entry)', async () => {
@@ -181,8 +229,8 @@ describe('syncMapPicksOnce — insert path', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.inserts).toBe(1)
-    expect(session.addCandidate).toHaveBeenCalledTimes(1)
-    expect(session.addCandidate.mock.calls[0][0].id).toBe('pm-ok')
+    expect(session.importPick).toHaveBeenCalledTimes(1)
+    expect(session.importPick.mock.calls[0][0].id).toBe('pm-ok')
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
   })
@@ -214,8 +262,10 @@ describe('syncMapPicksOnce — legacy flag normalization (bare `pick` → `pick-
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
     const session = fakeSession([])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
-    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
+    // Normalized to pick-track, so it auto-routes into the track sets.
+    const [inserted, mode] = session.importPick.mock.calls[0] as [ApiPhoto, string]
     expect(inserted.flag).toBe('pick-track')
+    expect(mode).toBe('track')
   })
 
   it('normalizes a legacy bare `pick` on UPDATE (reconciles an existing candidate to pick-track)', async () => {
@@ -287,8 +337,9 @@ describe('syncMapPicksOnce — label sync (bidirectional)', () => {
     storage.getPhotoBlob.mockResolvedValue(new Blob([new Uint8Array(8)], { type: 'image/jpeg' }))
     const session = fakeSession([])
     await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
-    expect(session.addCandidate).toHaveBeenCalledTimes(1)
-    const inserted = session.addCandidate.mock.calls[0][0] as ApiPhoto
+    // pick-track auto-routes into a set; the label rides along on the photo.
+    expect(session.importPick).toHaveBeenCalledTimes(1)
+    const inserted = session.importPick.mock.calls[0][0] as ApiPhoto
     expect(inserted.label).toBe('A')
     expect(inserted.labelUpdatedAt).toBe('2024-01-01T00:00:00Z')
   })
@@ -450,7 +501,9 @@ describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs
     const session = fakeSession([])
     const result = await syncMapPicksOnce(storage as unknown as StorageInterface, competitionDir, photosDir, session)
     expect(result.inserts).toBe(1)
-    expect(session.addCandidate).toHaveBeenCalledTimes(1)
+    // Routed once (pick-track → set); the same-run placedThisRun guard skips the
+    // duplicate row before it allocates a second blob URL.
+    expect(session.importPick).toHaveBeenCalledTimes(1)
     expect(createUrlCount).toBe(1)
   })
 
@@ -472,7 +525,9 @@ describe('syncMapPicksOnce — concurrency & blob URL leak guards (CRITICAL bugs
     // `candidates` array passed in is unchanged mid-pass.
     const session = {
       candidates: [] as readonly ApiPhoto[],
+      placedIds: new Set<string>(),
       addCandidate: vi.fn(async () => undefined),
+      importPick: vi.fn(async () => undefined),
       removeCandidate: vi.fn(async () => undefined),
       setCandidateFlag: vi.fn(async () => undefined),
       setCandidateLabel: vi.fn(async () => undefined),
@@ -564,8 +619,8 @@ describe('syncMapPicksOnce — delete path (ADR-019 cleanup)', () => {
       competitionDir, photosDir, session,
     )
     expect(result.inserts).toBe(2)
-    expect(session.addCandidate).toHaveBeenCalledTimes(2)
-    const ids = session.addCandidate.mock.calls.map(c => (c[0] as ApiPhoto).id).sort()
+    expect(session.importPick).toHaveBeenCalledTimes(2)
+    const ids = session.importPick.mock.calls.map(c => (c[0] as ApiPhoto).id).sort()
     expect(ids).toEqual(['pm-1', 'pm-3'])
     expect(warn).toHaveBeenCalledTimes(2) // one warn per dropped row
     warn.mockRestore()

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -27,6 +27,7 @@ import {
   removeCandidate as removeCandidatePure,
   clearAllCandidates as clearAllCandidatesPure,
   updateCandidateCanvasState as updateCandidateCanvasStatePure,
+  routeImportedPickIntoSets,
 } from '../utils/candidateTransitions';
 import {
   defaultTrackSetTitles,
@@ -76,6 +77,15 @@ export interface UseCompetitionSystemResult {
    * to avoid duplicates on visibility-change re-syncs.
    */
   addExistingCandidate: (photo: ApiPhoto) => Promise<void>;
+  /**
+   * Auto-route a freshly-imported map-corridors pick straight into its
+   * discipline's sets (`pick-track` → track, `pick-turning` → turning) using
+   * the `set1→set2→tray` fill policy, without switching the user's active
+   * mode. Called by `useMapPicksSync` on first import instead of
+   * `addExistingCandidate` for category-flagged picks. See
+   * docs/CANDIDATE_PHOTOS.md "Map-pick auto-routing".
+   */
+  importPickToSets: (photo: ApiPhoto, targetMode: 'track' | 'turningpoint') => Promise<void>;
   removeCandidate: (photoId: string) => Promise<void>;
   promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
   demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
@@ -663,6 +673,33 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       };
     }, { updatePhotos: true });
   }, [updateCurrentCompetition, currentCompetition]);
+
+  /**
+   * Auto-route a freshly-imported map-corridors pick into the sets of its
+   * discipline (`pick-track` → track sets, `pick-turning` → turning sets)
+   * instead of the candidate tray. Used by `useMapPicksSync` on first import.
+   * Delegates the placement decision (set1→set2→tray spillover, active vs.
+   * inactive mode bucket) to the pure `routeImportedPickIntoSets` helper, then
+   * revokes the now-orphaned blob URL when the photo landed in an inactive
+   * bucket (stored there with `url: ''`, like every other inactive-bucket
+   * photo). Single source of truth for the fill/mode policy lives in the
+   * helper so this stays a thin persistence wrapper.
+   */
+  const importPickToSets = useCallback(async (
+    photo: ApiPhoto,
+    targetMode: 'track' | 'turningpoint',
+  ) => {
+    if (!currentCompetition?.session) return;
+    let revokeUrl: string | undefined;
+    await updateCurrentCompetition(session => {
+      const result = routeImportedPickIntoSets(session, photo, targetMode, isPrecisionDiscipline);
+      revokeUrl = result.revokeUrl;
+      return result.session;
+    }, { updatePhotos: true });
+    if (revokeUrl && revokeUrl.startsWith('blob:')) {
+      try { URL.revokeObjectURL(revokeUrl); } catch { /* best-effort */ }
+    }
+  }, [updateCurrentCompetition, currentCompetition, isPrecisionDiscipline]);
 
   const addPhotosToSet = useCallback(async (files: File[], setKey: 'set1' | 'set2'): Promise<AddPhotosResult> => {
     if (!currentCompetition?.session) {
@@ -1437,6 +1474,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // Candidate pool surface
     addPhotosToCandidates,
     addExistingCandidate,
+    importPickToSets,
     removeCandidate,
     promoteCandidateToSlot,
     demoteSlotToCandidate,

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -268,14 +268,27 @@ export function useMapPicksSync(
   useEffect(() => {
     if (!competitionDir || !photosDir) return;
     let cancelled = false;
-    const run = async () => {
-      try {
-        const storage = getStorage();
+    // Serialize sync passes. The mount run and every `visibilitychange` run
+    // share one competition; if two passes overlapped, both could read a
+    // `placedIds` snapshot taken before the other's placement committed and
+    // route the same `pm-` pick into a set twice (the auto-route insert path
+    // appends — it isn't filter-then-readd idempotent like the tray path).
+    // Chaining each run after the previous one's completion means a queued
+    // run always observes the prior run's placement on the live session ref,
+    // and avoids the wasted blob-URL churn of redundant concurrent passes.
+    // (`routeImportedPickIntoSets` also guards by id as defense in depth.)
+    let chain: Promise<void> = Promise.resolve();
+    const run = (): Promise<void> => {
+      chain = chain.then(async () => {
         if (cancelled) return;
-        await syncMapPicksOnce(storage, competitionDir, photosDir, sessionRef.current);
-      } catch (err) {
-        if (!cancelled) console.warn('[useMapPicksSync] sync failed:', err);
-      }
+        try {
+          const storage = getStorage();
+          await syncMapPicksOnce(storage, competitionDir, photosDir, sessionRef.current);
+        } catch (err) {
+          if (!cancelled) console.warn('[useMapPicksSync] sync failed:', err);
+        }
+      });
+      return chain;
     };
     void run();
     const onVis = () => {

--- a/frontend/photo-helper/src/hooks/useMapPicksSync.ts
+++ b/frontend/photo-helper/src/hooks/useMapPicksSync.ts
@@ -36,8 +36,23 @@ export type { MapPickEntry };
  */
 export interface MapPicksSyncSessionApi {
   candidates: readonly ApiPhoto[];
+  /**
+   * `pm-` photo ids that already live in a set (any of `sets`, `setsTrack`,
+   * `setsTurning`) because a prior sync auto-routed them, or the user placed
+   * them by hand. The insert path consults this so a re-sync never re-inserts
+   * a placed photo back into the tray (a placed photo has its flag cleared and
+   * leaves the candidate pool, so the candidates-only dedup can't see it).
+   */
+  placedIds: ReadonlySet<string>;
   /** Insert a pre-built ApiPhoto. Called for `pm-` entries not yet in the pool. */
   addCandidate: (photo: ApiPhoto) => Promise<void> | void;
+  /**
+   * Auto-route a category-flagged pick straight into its discipline's sets on
+   * first import (`pick-track` → track, `pick-turning` → turning), instead of
+   * the candidate tray. set1→set2→tray fill, no active-mode switch. Called in
+   * place of `addCandidate` for `pick-track` / `pick-turning` inserts.
+   */
+  importPick: (photo: ApiPhoto, targetMode: 'track' | 'turningpoint') => Promise<void> | void;
   /** Remove a candidate by id. Called when a `pm-` entry disappears from map-picks.json. */
   removeCandidate: (photoId: string) => Promise<void> | void;
   /** Update flag in place; preserves canvasState + photo-helper-owned fields. */
@@ -105,6 +120,11 @@ export async function syncMapPicksOnce(
   // photo and doesn't allocate a fresh blob URL for the same id.
   const localById = new Map<string, ApiPhoto>();
   for (const p of session.candidates) localById.set(p.id, p);
+  // Photos auto-routed into a set during THIS run. `session.placedIds` is a
+  // snapshot from render-time and can't see same-run placements, so a
+  // duplicate row in map-picks.json would otherwise place the same photo
+  // twice. Combined with `placedIds` this guards both within and across runs.
+  const placedThisRun = new Set<string>();
 
   for (const entry of file.picks) {
     // Per-row validation — drop malformed entries individually so a
@@ -123,6 +143,16 @@ export async function syncMapPicksOnce(
     const entryFlag = normalizeCandidateFlag(entry.flag);
     const existing = localById.get(entry.photoId);
     if (!existing) {
+      // Already auto-routed into a set on a previous (or this) sync. Skip
+      // entirely: don't re-insert into the tray, don't re-route. Placed
+      // photos are intentionally detached from the candidate-pool mirror —
+      // identical to how a hand-promoted pm- photo behaves today. A flag /
+      // filename change in map-corridors after placement is NOT propagated
+      // (the photo no longer carries a tray flag); the user owns it once it's
+      // in a set.
+      if (session.placedIds.has(entry.photoId) || placedThisRun.has(entry.photoId)) {
+        continue;
+      }
       // Narrow the swallow to NotFoundError — other storage errors
       // (permission revoked, InvalidStateError) shouldn't silently
       // collapse into "photo missing".
@@ -149,8 +179,18 @@ export async function syncMapPicksOnce(
         flag: entryFlag,
         ...(entry.labelUpdatedAt ? { labelUpdatedAt: entry.labelUpdatedAt } : {}),
       };
-      await session.addCandidate(photo);
-      localById.set(entry.photoId, photo);
+      // Category-flagged picks auto-route into their discipline's sets on
+      // first import; everything else (defensive — only picks cross the
+      // handoff writer) lands in the candidate tray as before. A pick whose
+      // sets are full falls back to the tray inside `importPick`.
+      if (entryFlag === 'pick-track' || entryFlag === 'pick-turning') {
+        const targetMode = entryFlag === 'pick-track' ? 'track' : 'turningpoint';
+        await session.importPick(photo, targetMode);
+        placedThisRun.add(entry.photoId);
+      } else {
+        await session.addCandidate(photo);
+        localById.set(entry.photoId, photo);
+      }
       inserts++;
     } else {
       let touched = false;

--- a/frontend/photo-helper/src/utils/candidateTransitions.ts
+++ b/frontend/photo-helper/src/utils/candidateTransitions.ts
@@ -158,12 +158,15 @@ export interface RouteImportedPickResult {
   /** Where the imported photo landed. 'tray' = both sets full (or set2 unavailable). */
   placement: SetKey | 'tray';
   /**
-   * A live `blob:` URL the caller should revoke. Set ONLY when the photo
-   * landed in an INACTIVE mode bucket — those buckets store photos with
-   * `url: ''` (regenerated from OPFS on mode-load, mirroring the
-   * sanitisation `updateSessionMode` already applies to the outgoing bucket),
-   * so the URL created at import time is now orphaned. Tray / active-set
-   * placements keep the live URL and return `undefined`.
+   * A live `blob:` URL the caller should revoke. Set in two cases:
+   *   1. The photo landed in an INACTIVE mode bucket — those buckets store
+   *      photos with `url: ''` (regenerated from OPFS on mode-load, mirroring
+   *      the sanitisation `updateSessionMode` already applies to the outgoing
+   *      bucket), so the URL created at import time is now orphaned.
+   *   2. The idempotency guard short-circuited (the id is already placed) —
+   *      the URL minted for this duplicate attempt is redundant.
+   * A fresh active-set / tray placement keeps the live URL and returns
+   * `undefined`.
    */
   revokeUrl?: string;
 }
@@ -204,6 +207,24 @@ export function routeImportedPickIntoSets(
   const working = active
     ? session.sets
     : (session[bucketKey] ?? emptyModeSets());
+
+  // Idempotency by id — counterpart to the filter-then-readd dedup in
+  // `addExistingCandidate`. This helper APPENDS, so a rapid re-sync whose
+  // `placedIds` / candidates snapshot predates a still-uncommitted placement
+  // (mount run + a `visibilitychange` run, before React recomputes the memo)
+  // could call us twice for the same `pm-` id and duplicate the photo in a
+  // set or the tray. The live session we receive (published synchronously to
+  // the ref before persist, see useCompetitionSystem.updateCurrentCompetition)
+  // already reflects the prior placement, so short-circuit and let the caller
+  // revoke the redundant blob URL minted for this duplicate attempt.
+  const inSet1 = working.set1.photos.some((p) => p.id === photo.id);
+  const inSet2 = working.set2.photos.some((p) => p.id === photo.id);
+  if (inSet1 || inSet2) {
+    return { session, placement: inSet1 ? 'set1' : 'set2', revokeUrl: photo.url };
+  }
+  if (getCandidatePhotos(session).some((p) => p.id === photo.id)) {
+    return { session, placement: 'tray', revokeUrl: photo.url };
+  }
 
   const capacity = getGridCapacity({
     mode: targetMode,

--- a/frontend/photo-helper/src/utils/candidateTransitions.ts
+++ b/frontend/photo-helper/src/utils/candidateTransitions.ts
@@ -14,9 +14,15 @@
  *   - setFlag: tray photo flag transition.
  */
 
-import type { ApiPhoto, ApiPhotoSession, CandidateFlag } from '../types/api';
+import type { ApiPhoto, ApiPhotoSession, ApiPhotoSet, CandidateFlag } from '../types/api';
+import { getGridCapacity } from './getGridCapacity';
 
 type SetKey = 'set1' | 'set2';
+
+const emptyModeSets = (): { set1: ApiPhotoSet; set2: ApiPhotoSet } => ({
+  set1: { title: '', photos: [] },
+  set2: { title: '', photos: [] },
+});
 
 const bumpVersion = (s: ApiPhotoSession): ApiPhotoSession => ({
   ...s,
@@ -145,4 +151,124 @@ export function updateCandidateCanvasState(
     canvasState: { ...next[idx].canvasState, ...canvasState },
   };
   return bumpVersion({ ...session, candidates: { photos: next } });
+}
+
+export interface RouteImportedPickResult {
+  session: ApiPhotoSession;
+  /** Where the imported photo landed. 'tray' = both sets full (or set2 unavailable). */
+  placement: SetKey | 'tray';
+  /**
+   * A live `blob:` URL the caller should revoke. Set ONLY when the photo
+   * landed in an INACTIVE mode bucket — those buckets store photos with
+   * `url: ''` (regenerated from OPFS on mode-load, mirroring the
+   * sanitisation `updateSessionMode` already applies to the outgoing bucket),
+   * so the URL created at import time is now orphaned. Tray / active-set
+   * placements keep the live URL and return `undefined`.
+   */
+  revokeUrl?: string;
+}
+
+/**
+ * Auto-route a freshly-imported map-corridors pick into the sets of its
+ * discipline, instead of dropping it into the candidate tray. Counterpart to
+ * the manual `promoteCandidateToSlot` flow, but driven by the `pick-track` /
+ * `pick-turning` flag carried across the handoff (see useMapPicksSync).
+ *
+ * Fill policy (decided with the user): `set1 → set2 → tray`. set1 fills to
+ * `getGridCapacity` first, overflow spills into set2, and once both are full
+ * the photo stays in the candidate tray (with its flag) for manual placement.
+ * Precision discipline is single-set, so set2 is skipped and overflow goes
+ * straight to the tray.
+ *
+ * Mode policy (decided with the user): never switch the user's active mode.
+ * A pick for the discipline NOT currently shown is written into that mode's
+ * bucket (`setsTrack` / `setsTurning`) silently — it surfaces when the user
+ * switches to that discipline. A pick for the active discipline is written to
+ * `session.sets` (visible immediately) and mirrored into the active bucket,
+ * exactly like `promoteCandidateToSlot`.
+ *
+ * Pure: no blob-URL revocation or persistence here. The caller revokes
+ * `revokeUrl` and runs the result through its normal persist path.
+ */
+export function routeImportedPickIntoSets(
+  session: ApiPhotoSession,
+  photo: ApiPhoto,
+  targetMode: 'track' | 'turningpoint',
+  isPrecision: boolean,
+): RouteImportedPickResult {
+  const active = session.mode === targetMode;
+  const bucketKey = targetMode === 'track' ? 'setsTrack' : 'setsTurning';
+
+  // Source of truth for the target discipline's sets: the live `sets` when
+  // it's the active mode, otherwise the persisted mode bucket.
+  const working = active
+    ? session.sets
+    : (session[bucketKey] ?? emptyModeSets());
+
+  const capacity = getGridCapacity({
+    mode: targetMode,
+    layoutMode: (session as unknown as { layoutMode?: string }).layoutMode,
+  });
+  const allowSet2 = !isPrecision;
+
+  let target: RouteImportedPickResult['placement'];
+  if ((working.set1.photos.length) < capacity) {
+    target = 'set1';
+  } else if (allowSet2 && working.set2.photos.length < capacity) {
+    target = 'set2';
+  } else {
+    target = 'tray';
+  }
+
+  if (target === 'tray') {
+    // Both sets full (or single-set precision overflow). Keep it in the
+    // global candidate pool — flag preserved so the tray colours it and the
+    // user can place it by hand. Live URL kept (the tray renders it).
+    const trayPhoto: ApiPhoto = { ...photo, sessionId: session.id };
+    return {
+      session: bumpVersion({
+        ...session,
+        candidates: { photos: [...getCandidatePhotos(session), trayPhoto] },
+      }),
+      placement: 'tray',
+    };
+  }
+
+  // Slot placement: flag is a tray-only concept — drop it on entering a set.
+  const { flag: _flag, ...rest } = photo;
+  const slotPhoto: ApiPhoto = active
+    ? { ...rest, sessionId: session.id }
+    // Inactive bucket: store with empty URL like every other inactive-bucket
+    // photo; OPFS bytes already exist (map-corridors wrote them) and the URL
+    // is regenerated on the next mode switch.
+    : { ...rest, sessionId: session.id, url: '' };
+
+  const nextWorking = {
+    ...working,
+    [target]: {
+      ...working[target],
+      photos: [...working[target].photos, slotPhoto],
+    },
+  };
+
+  if (active) {
+    // Visible immediately; mirror into the active bucket so a later mode
+    // switch doesn't resurrect the pre-import state (same pattern as
+    // promoteCandidateToSlot).
+    const next: ApiPhotoSession = {
+      ...session,
+      sets: nextWorking,
+    };
+    (next as unknown as Record<string, unknown>)[bucketKey] = nextWorking;
+    return { session: bumpVersion(next), placement: target };
+  }
+
+  // Inactive discipline: write only the bucket; leave the active view alone.
+  const next: ApiPhotoSession = { ...session };
+  (next as unknown as Record<string, unknown>)[bucketKey] = nextWorking;
+  return {
+    session: bumpVersion(next),
+    placement: target,
+    revokeUrl: photo.url,
+  };
 }


### PR DESCRIPTION
## Summary
- Picks handed off from **map-corridors** already carry a discipline category in their flag (`pick-track` / `pick-turning`), but `useMapPicksSync` dropped every imported photo into the candidate tray — the user had to re-sort by hand. Now category-flagged picks auto-route into the matching discipline's sets on first import.
- **Fill policy:** `set1 → set2 → tray`. set1 fills to `getGridCapacity`, overflow spills to set2, both-full stays in the tray (flag kept). Precision is single-set, so set2 is skipped. (Pure helper `routeImportedPickIntoSets`; wrapper `useCompetitionSystem.importPickToSets`.)
- **Mode policy:** never auto-switches the active discipline. Active-mode picks land in `session.sets` (mirrored to the active bucket, visible immediately); inactive-mode picks fill `setsTrack`/`setsTurning` with `url:''` and surface on the next mode switch.
- **Idempotency:** `AppApi` feeds the sync a `placedIds` set (`pm-` ids already in any set bucket) so a `visibilitychange` re-sync never re-inserts a placed photo as a tray duplicate; a same-run guard covers duplicated rows in one file.
- **Accepted consequence (documented):** once placed in a set, a `pm-` photo detaches from the continuous map-pick mirror — later un-pick / re-categorise / label / filename edits on the map no longer move it, and it drops out of `editor-picks.json`. Identical to the ownership transfer that already happens on manual slot promotion.
- Docs: new "Map-pick auto-routing" section in `docs/CANDIDATE_PHOTOS.md`. Changelog: `2.26.0`.

## Open design question (set1 vs set2 boundary)
The handoff only tags track vs turning, not which set. This PR uses `set1→set2→tray` spillover. A richer "define the TP / set boundary in map-corridors" flow is left as an additive follow-up (optional `set` field on the handoff schema) — see PR discussion.

## Test plan
- [x] `tsc --noEmit -p tsconfig.json` clean
- [x] Full photo-helper suite green (445 passed)
- [x] New unit tests: routing helper (set1→set2 spillover, both-full→tray, inactive-bucket placement + `url:''` + revoke, precision single-set, turning-point capacity 10)
- [x] New sync tests: `pick-track`→track / `pick-turning`→turning routing, `placedIds` dedup prevents re-insert, same-run duplicate guard
- [ ] Manual smoke: pick track+turning in map-corridors → open editor → track picks fill track sets, turning picks appear on mode switch; tab away/back does not duplicate; overflow past both sets lands in tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)