### PR TITLE
docs: spec TP-break set1/set2 split (follow-up to #100)

### DIFF
--- a/docs/photo-map-culling/set-split-suggestion-plan.md
+++ b/docs/photo-map-culling/set-split-suggestion-plan.md
@@ -1,135 +1,150 @@
-# Plan (DRAFT): Suggested set1↔set2 split for rally imports
+# Plan (DRAFT): set1↔set2 split at a user-chosen turning point
 
 **Status:** DRAFT — awaiting sign-off. Not implemented.
-**Depends on:** PR #100 (`feat/map-picks-auto-route-sets`), which ships the
-baseline `set1 → set2 → tray` capacity fill. This doc designs the *next* layer:
-making the set1/set2 boundary land on a **meaningful route point** instead of
-"wherever set1 filled up."
+**Builds on:** PR #100 (`feat/map-picks-auto-route-sets`, merged), which auto-routes
+imported picks into their discipline's sets with a `set1 → set2 → tray`
+capacity fill.
 **Owner decisions (2026-05-31, this session):**
-- Split owner: **C — the editor suggests + draggable divider.** The map sends
-  order (+ optional markers); the editor owns capacity and proposes the cut.
-- Default cut: **largest route gap, TP-aware.**
+- The set1/set2 boundary is **a turning point the user designates** — not a
+  guessed/heuristic cut. (This replaces the earlier "largest-gap heuristic +
+  draggable divider" draft, which was scrapped: there is nothing to *guess* and
+  nothing to *drag* when the break is an explicit TP.)
+- The break is chosen **in map-corridors** (that's where the route + TPs live).
+- Overflow (one side of the break has more photos than a sheet holds) →
+  **the surplus goes to the candidate tray**, never silently dropped, never
+  cross-spilled into the other set.
+- Moving the break **re-flows already-placed photos** — the editor *reconciles*
+  to the map's per-photo `set` every sync (decision **(b)**), not just at first
+  import. **The map owns set membership** (pure reconcile): the editor user
+  reorders within a sheet and crops freely, but cross-sheet membership is the
+  corridors break's call.
 
 ---
 
-## Why
+## The model, in one line
 
-set1/set2 are two **sheets** of the answer PDF; the photos on them are in route
-order (filename, then EXIF time). The natural sheet boundary is *where one leg of
-the route ends and the next begins* — a turning point, or a big jump in
-distance/time between consecutive shots. PR #100's capacity fill cuts at photo
-#9/#10 regardless, so the user re-drags photos to move the boundary to a real
-point on every import. This feature picks a sensible boundary automatically and
-lets the user nudge it.
+> The user marks one turning point as the **set break** in map-corridors;
+> photos before it go to **set1**, photos from it onward go to **set2**, per
+> discipline. The editor just obeys the per-photo set the map sends, capping
+> each sheet and sending the surplus to the tray.
 
-**Scope: rally only.** Precision is single-sheet (set2 unused), so there is no
-boundary to choose — this feature is inert for precision. Applies independently
-within each rally discipline: track photos split across track set1/set2, turning
-photos across turning set1/set2.
+Rally only — precision is single-sheet, so it ignores the break.
 
-## Knowledge boundary (why C, not B)
+## Division of labour
 
-- **The editor owns capacity** (9 / 10 per sheet, layout- and mode-dependent via
-  `getGridCapacity`). A rally discipline holds up to ~2×cap; "everything in
-  set1" is physically impossible, so the split must be capacity-aware → editor.
-- **The map owns route semantics** (order, GPS, where TPs are). It can *hint*
-  the meaningful cut but must not assert a hard set assignment, or set-capacity
-  rules leak into the map app (and would have to be suppressed for precision).
+| App | Owns | Why |
+|---|---|---|
+| **map-corridors** | the break choice + computing each photo's set | the route order, GPS, and TP markers all live here |
+| **photo-helper** | capacity + overflow→tray | the sheet size (`getGridCapacity`) is an editor concept |
 
-So: **map hints where the cut is meaningful; editor decides where it's legal and
-applies it.** Degrades gracefully — with zero map changes, the editor already
-has per-photo `gps` on each `pm-` candidate and can run the gap heuristic alone.
+The map sends a **per-photo set assignment**; the editor never needs to know
+what a TP is or how route order is computed. That keeps the editor dumb and
+avoids cross-app ordering drift.
 
-## The suggested-cut heuristic (TP-aware largest gap)
+## Handoff change (`frontend/shared-handoff/src/types.ts`)
 
-Input: the discipline's fresh picks in route order `P[0..n-1]`, each with
-`gps.capturedAt {lng,lat}` and/or `gps.timestamp`. Let `cap = getGridCapacity`
-for that mode.
+Add an optional field to `MapPickEntry` (additive, versioned — old files just
+omit it and fall back to PR #100 behavior):
 
-1. **No split needed** when `n ≤ cap` → all into set1.
-2. **Legal window for the cut index `k`** (photos `[0..k-1]` → set1, `[k..n-1]`
-   → set2): `max(1, n - cap) ≤ k ≤ min(cap, n-1)`. Outside this, a sheet would
-   overflow. If `n > 2·cap`, the surplus beyond `2·cap` spills to the tray
-   (PR #100 behavior) before the split is computed.
-3. **Score each adjacent gap** `g(i)` between `P[i-1]` and `P[i]` for `i` in the
-   legal window:
-   - primary: **haversine distance** between the two coords (subjectAt
-     preferred, else capturedAt);
-   - fallback when either coord is missing: **EXIF time delta**;
-   - **TP-aware boost:** if a route marker / turning point sits at this boundary
-     (see "Optional map hint" below), multiply the score so a real leg-end wins
-     ties against an incidental gap.
-4. **Pick `k` = argmax g(i)** within the window. Ties → the `k` closest to the
-   window midpoint (most balanced sheets).
-5. **Fallback** when all gaps are missing/equal (no GPS, no times): even split,
-   `k = clamp(round(n/2), window)`.
+```ts
+set?: 'set1' | 'set2'   // target sheet within the photo's discipline.
+                        // Absent → editor uses set1→set2→tray spillover (PR #100).
+```
 
-Pure, unit-testable: `suggestSetSplit(orderedPicks, cap, markers?) → k`.
+map-corridors computes `set` from `(break TP position, photo's route order)` and
+writes it on every `pick-track` / `pick-turning` entry once a break is chosen.
 
-## Optional map hint (additive, later)
+## map-corridors side (the bulk of the work)
 
-To make "TP-aware" explicit rather than gap-inferred, extend `MapPickEntry`
-(versioned, additive — `frontend/shared-handoff/src/types.ts`) with an optional
-boundary marker, e.g. `legBreakBefore?: boolean` or `legIndex?: number`, set by
-map-corridors where the route crosses a turning point. The editor prefers these
-as cut points and falls back to the gap heuristic when absent. **Not required
-for v1** — the gap heuristic works on the `gps` the picks already carry.
+1. **Designate the break.** A toggle/context action on a turning-point marker:
+   "Set break here." Exactly one break per route (we only have set1+set2 → one
+   cut). Visualize which TP is the break.
+2. **Compute per-photo `set`.** In route order (the existing shooting-order
+   comparator — filename, then EXIF time), every photo *before* the break TP →
+   `set1`; the break TP and everything *after* → `set2`. (Convention: the break
+   TP's own turning photo lands in **set1**, i.e. it closes the first leg —
+   confirm.)
+3. **Apply per discipline.** The single break position partitions **track**
+   photos across track set1/set2 **and** **turning** photos across turning
+   set1/set2. (Turning photos often fit one sheet, so the break may only matter
+   for track in practice — but the rule is consistent.)
+4. Write `set` into `map-picks.json` entries; re-write when the break moves.
 
-## UI: draggable divider
+## photo-helper side — reconcile, not imperative insert (decision **(b)**, locked)
 
-In the rally two-sheet view, render a boundary control between set1 and set2
-positioned at the suggested `k`, labelled e.g. *"Suggested split — drag to
-adjust."* Dragging it re-partitions the ordered list (clamped to the legal
-window; it can't push a sheet over capacity).
+PR #100 places picks **imperatively, one at a time** and then **detaches** them
+(placed photos ignore later map edits). To let a *break move* re-flow the sheets,
+the editor instead **reconciles** — every sync, it makes each discipline's two
+sheets match the map's per-photo `set`. Import is just the first reconcile
+(empty sheets → filled); a later break change is another reconcile. One code
+path. This **supersedes** PR #100's import-time-only routing for `pm-` photos.
 
-**Lifecycle / the hard constraint:** the divider only makes sense while the two
-sheets still hold the imported photos *in import order*. Once the user manually
-reorders, swaps, or deletes within a sheet, "slide the boundary" is ill-defined.
-So:
-- The divider is **live only in a pristine, import-ordered state** (track a
-  `splitDirty` flag per discipline; set it on any manual slot mutation).
-- Once dirty, the divider locks/hides and placement is just normal drag-drop.
+**Ownership (locked decision, 2026-05-31):** the **map owns set membership**
+(pure reconcile). In the editor the user reorders *within* a sheet and crops
+freely; to move a photo *across* sheets they change the break in corridors. No
+per-photo dirty flag, always converges. (The rejected alternative was
+"manual editor cross-sheet move detaches the photo.")
 
-**MVP fallback** if the live divider is too much for a first cut: apply the
-suggested split at import and show a one-time hint *"Split placed after photo N —
-drag photos to adjust"*, reusing existing drag-drop. Ship the heuristic value
-first, add the interactive divider second.
+### Reconcile algorithm (pure, per discipline, per sync)
 
-## Where it plugs into the shipped code
+Inputs: the discipline's `pm-` photos wherever they currently are (set1 / set2 /
+tray), each with its current `ApiPhoto` state and its desired `entry.set`; plus
+the non-`pm-` photos already in the sheets; plus `cap = getGridCapacity`.
 
-PR #100 places picks **one at a time** in `syncMapPicksOnce` via
-`routeImportedPickIntoSets` (set1→set2→tray). The split needs the **whole
-discipline batch** to choose `k`, so:
+1. Desired set1 = `pm-` photos with `entry.set === 'set1'`, in **route order**;
+   desired set2 likewise. (`entry.set` absent → fall back to PR #100
+   `set1→set2→tray` spillover for that photo — back-compat while the map doesn't
+   emit `set` yet.)
+2. For each sheet: keep its **non-`pm-` (manual) photos in place**, then append
+   the desired `pm-` photos in route order up to `cap`. **Surplus `pm-` photos →
+   tray.** Never cross-spill into the other sheet.
+3. **Preserve editor-owned state on every move:** a moved photo carries its
+   existing `canvasState` (crop/zoom/brightness) and `label` — reconcile moves
+   the *existing object*, it never recreates it. (Regression trap: a careless
+   re-flow would wipe the user's crops when the break moves.)
+4. **No-op when already satisfied:** if the computed sheets+tray equal the
+   current state, return the session unchanged (don't bump `version`) — prevents
+   sync churn and write loops. Deterministic ⇒ converges in one pass.
 
-- In `syncMapPicksOnce`, before the per-photo loop, group the **fresh** inserts
-  (not in `placedIds`/candidates) by discipline, in route order, and compute
-  `k = suggestSetSplit(...)` per discipline.
-- Replace per-photo spillover with a batch placement that fills set1 with
-  `[0..k-1]` and set2 with `[k..]` (tray for surplus past `2·cap`). Keep the
-  single-photo path as the fallback for incremental, post-batch arrivals
-  (one new pick after the initial import just appends per current rules).
-- `routeImportedPickIntoSets` stays the primitive; add
-  `applySuggestedSplit(session, mode, orderedPhotos, k)` alongside it, both pure.
+`reconcileDisciplineSets(session, mode, capacity) → ApiPhotoSession`, alongside
+the existing pure helpers in `candidateTransitions.ts`. Active vs inactive
+mode-bucket handling and blob-URL rules are exactly as PR #100
+(`url: ''` for the inactive bucket, revoke orphans).
 
-Ordering source of truth: reuse the existing **filename-then-EXIF** comparator
-(the same one the map-compare "shooting order" fix uses, commit `b8af505` /
-#99 era) so editor and map agree.
+`useMapPicksSync` stops calling per-photo `importPickToSets` for category picks
+and instead, after upserting the candidate/photo objects, runs the reconcile
+per affected discipline. `placedIds` is no longer a "skip" guard but feeds the
+reconcile's "where is each photo now" input.
+
+## Conventions (locked)
+
+- **Break TP → set1.** The break TP's own photo closes leg 1.
+- **Break applies to both disciplines** (track *and* turning), same cut — turning
+  may rarely need it, but the rule is uniform.
+- **No break chosen → exactly today's behavior** (PR #100 spillover). Safe default.
 
 ## Test plan (when built)
 
-- `suggestSetSplit`: no-split (`n≤cap`); legal-window clamping; largest-gap
-  pick; TP-marker boost beats a larger incidental gap; even-split fallback (no
-  GPS); `n>2·cap` surplus → tray then split the rest.
-- Batch placement: pristine import fills both sheets at `k`; precision ignores
-  (single sheet); idempotent re-sync (placedIds) doesn't re-split.
-- Divider (if built): drag clamps to legal window; `splitDirty` locks it after a
-  manual mutation.
+- map-corridors: break selection persists; per-photo `set` computed correctly
+  from route order around the break; re-write on break move; precision never
+  emits `set`.
+- shared-handoff: `set` round-trips; `isMapPickEntry` accepts/validates it;
+  absent `set` still valid (back-compat).
+- photo-helper `reconcileDisciplineSets`: desired partition by `entry.set` in
+  route order; manual (non-`pm-`) photos stay put; surplus → tray (no
+  cross-spill); **moved photo keeps its `canvasState` + `label`**; no-op when
+  already satisfied (no `version` bump); absent `set` → PR #100 spillover;
+  converges in one pass on re-sync; **break move re-flows placed photos**,
+  including pulling a tray-overflow photo back into a now-roomy sheet and
+  pushing a now-over-capacity photo out to the tray.
 
-## Open questions for sign-off
+## Phasing
 
-1. **Divider now or MVP hint first?** (Recommend MVP hint → divider as a
-   fast-follow.)
-2. **Ship the gap-only heuristic (zero map changes) first, add the explicit
-   `legIndex` map hint later?** (Recommend yes.)
-3. **Distance vs time weighting** when both exist — pure distance, or a blend?
-   (Recommend distance-primary; time only as fallback.)
+1. **shared-handoff:** add optional `set` (+ validator). No behavior change.
+2. **photo-helper:** introduce `reconcileDisciplineSets` and switch
+   `useMapPicksSync` from per-photo `importPickToSets` to per-discipline
+   reconcile. Falls back to PR #100 spillover while the map emits no `set`, so
+   it's shippable before the map side exists.
+3. **map-corridors:** break-selection UI on TP markers + per-photo `set`
+   computation from route order + visualization. Lights the feature up end to
+   end and exercises the re-flow path.


### PR DESCRIPTION
## Summary
Design draft (no code) for the follow-up to #100 — choosing the rally set1↔set2 boundary at a **user-designated turning point** instead of a capacity cut.

- **Break = a TP the user marks in map-corridors.** Photos before it → set1, from it onward → set2, per discipline. Carried on an additive `MapPickEntry.set?: 'set1' | 'set2'` field (absent → today's #100 spillover, back-compat).
- **Editor reconciles** each discipline's sheets to the map's per-photo `set` every sync (decision **(b)**): import is the first reconcile, and **moving the break re-flows already-placed photos**. Reconcile preserves each moved photo's `canvasState` + `label` (regression trap called out).
- **Map owns set membership** (pure reconcile): editor reorders within a sheet and crops freely; cross-sheet membership is the corridors break's call.
- **Overflow → tray**, never cross-spill. **No break → exactly #100 behavior.**
- Supersedes the earlier largest-gap-heuristic + draggable-divider draft.

Also annotated `track-turning-categorization-plan.md` decision #3 as superseded by #100.

## Status
DRAFT design — **awaiting sign-off**, not implemented. Phasing (shared-handoff field → photo-helper reconcile → map-corridors break UI) is in the doc.

## Test plan
- [ ] N/A — documentation only. Implementation test plan is in the doc for when it's built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)