### PR TITLE
fix(photo-helper): accept candidate-tray drops onto an empty set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.1] - 2026-05-31
+
+### Fixed
+- **Photo Helper:** you can now drag a photo from the candidate tray onto an
+  **empty** set. Previously the drop only worked once the set already had at
+  least one photo — dropping onto an empty set did nothing. The empty-set drop
+  zone now accepts tray drops (landing in the first slot) and shows the same
+  highlight, while native file drops keep working as before. (#102)
+
 ## [2.26.0] - 2026-05-31
 
 ### Changed

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -1039,6 +1039,9 @@ function AppApi() {
                       maxPhotos={isPrecision && session?.mode === 'track' ? 10 : (layoutMode === 'portrait' ? 10 : 9)}
                       loading={loading}
                       error={error}
+                      setKey="set1"
+                      onCandidateDropped={(candidateId) => handleCandidateDropped('set1')(candidateId, 0)}
+                      onCrossSetDropRejected={() => setCrossSetHintOpen(true)}
                     />
                   </Paper>
                 ) : (
@@ -1090,6 +1093,9 @@ function AppApi() {
                       maxPhotos={layoutMode === 'portrait' ? 10 : 9}
                       loading={loading}
                       error={error}
+                      setKey="set2"
+                      onCandidateDropped={(candidateId) => handleCandidateDropped('set2')(candidateId, 0)}
+                      onCrossSetDropRejected={() => setCrossSetHintOpen(true)}
                     />
                   </Paper>
                 ) : (

--- a/frontend/photo-helper/src/__tests__/GridSizedDropZone.test.tsx
+++ b/frontend/photo-helper/src/__tests__/GridSizedDropZone.test.tsx
@@ -1,0 +1,112 @@
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { GridSizedDropZone } from '../components/GridSizedDropZone';
+import { serializeDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
+
+// Regression cover for the empty-set drag-drop bug: dropping a candidate-tray
+// thumb onto an EMPTY set (which renders GridSizedDropZone, not PhotoGridApi)
+// did nothing because the zone only handled native file drops. These pin the
+// internal `application/x-airq-photo` channel added to make tray drops work,
+// while keeping the native file-drop path (react-dropzone) untouched.
+
+// Echo-style t() so we can find rendered strings by their i18n key, and avoid
+// spinning up the real I18nContext.
+vi.mock('../contexts/I18nContext', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+// currentRatio.ratio is the only field read (grid aspect-ratio math).
+vi.mock('../contexts/AspectRatioContext', () => ({
+  useAspectRatio: () => ({ currentRatio: { ratio: 1.5 } }),
+}));
+
+// Electron import path disabled in tests → web dropzone behaviour.
+vi.mock('../hooks/useElectronPhotoImport', () => ({
+  useElectronPhotoImport: () => ({
+    isAvailable: false,
+    isImporting: false,
+    importError: null,
+    pickPhotos: vi.fn(),
+    clearImportError: vi.fn(),
+  }),
+}));
+
+/**
+ * Map-backed DataTransfer shim — jsdom doesn't implement the constructor.
+ * `types` is derived from the keys so `types.includes(MIME)` works.
+ */
+function makeDataTransfer(initial: Record<string, string> = {}): DataTransfer {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    types: [...store.keys()],
+    getData: (mime: string) => store.get(mime) ?? '',
+    setData: (mime: string, value: string) => { store.set(mime, value); },
+    dropEffect: 'move',
+    effectAllowed: 'move',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    clearData: () => store.clear(),
+    setDragImage: () => {},
+  } as unknown as DataTransfer;
+}
+
+function renderZone(overrides: Partial<React.ComponentProps<typeof GridSizedDropZone>> = {}) {
+  const props: React.ComponentProps<typeof GridSizedDropZone> = {
+    onFilesDropped: vi.fn(),
+    setName: 'Set 1',
+    maxPhotos: 9,
+    setKey: 'set1',
+    ...overrides,
+  };
+  const result = render(<GridSizedDropZone {...props} />);
+  // The dropzone Paper carries the handlers; locate it via the rest-state hint.
+  const dropTarget = screen.getByText('upload.clickOrDrop').closest('.MuiPaper-root') as HTMLElement;
+  return { ...result, props, dropTarget };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GridSizedDropZone — candidate-tray drop channel (empty-set fix)', () => {
+  it('fires onCandidateDropped with the photo id when a tray payload is dropped', () => {
+    const onCandidateDropped = vi.fn();
+    const { dropTarget } = renderZone({ onCandidateDropped });
+    fireEvent.drop(dropTarget, {
+      dataTransfer: makeDataTransfer({
+        [DRAG_PAYLOAD_MIME]: serializeDragPayload({ kind: 'tray', photoId: 'p1' }),
+      }),
+    });
+    expect(onCandidateDropped).toHaveBeenCalledTimes(1);
+    expect(onCandidateDropped).toHaveBeenCalledWith('p1');
+  });
+
+  it('routes a cross-set slot drop to onCrossSetDropRejected (not onCandidateDropped)', () => {
+    const onCandidateDropped = vi.fn();
+    const onCrossSetDropRejected = vi.fn();
+    const { dropTarget } = renderZone({ setKey: 'set1', onCandidateDropped, onCrossSetDropRejected });
+    fireEvent.drop(dropTarget, {
+      dataTransfer: makeDataTransfer({
+        // A slot photo dragged from the OTHER set (set2) onto this empty set1.
+        [DRAG_PAYLOAD_MIME]: serializeDragPayload({
+          kind: 'slot', setKey: 'set2', index: 0, photoId: 'slot-x',
+        }),
+      }),
+    });
+    expect(onCrossSetDropRejected).toHaveBeenCalledTimes(1);
+    expect(onCandidateDropped).not.toHaveBeenCalled();
+  });
+
+  it('does not hijack a native file drop (no internal payload → onCandidateDropped untouched)', () => {
+    const onCandidateDropped = vi.fn();
+    const { dropTarget } = renderZone({ onCandidateDropped });
+    // A plain drop with no internal MIME — react-dropzone owns this path; our
+    // handler must bail out and leave onCandidateDropped alone.
+    fireEvent.drop(dropTarget, { dataTransfer: makeDataTransfer() });
+    expect(onCandidateDropped).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/photo-helper/src/components/GridSizedDropZone.tsx
+++ b/frontend/photo-helper/src/components/GridSizedDropZone.tsx
@@ -1,21 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import { 
-  Box, 
-  Typography, 
-  Paper, 
+import {
+  Box,
+  Typography,
+  Paper,
   CircularProgress,
   Alert
 } from '@mui/material';
-import { 
-  CloudUpload, 
-  CheckCircle, 
-  Error as ErrorIcon 
+import {
+  CloudUpload,
+  CheckCircle,
+  Error as ErrorIcon
 } from '@mui/icons-material';
 import { isValidImageFile } from '../utils/imageProcessing';
 import { useI18n } from '../contexts/I18nContext';
 import { useAspectRatio } from '../contexts/AspectRatioContext';
 import { useElectronPhotoImport } from '../hooks/useElectronPhotoImport';
+import { parseDragPayload, DRAG_PAYLOAD_MIME } from '../utils/dragPayload';
+import { dispatchSlotDrop } from '../utils/slotDropDispatch';
 
 interface GridSizedDropZoneProps {
   onFilesDropped: (files: File[]) => void;
@@ -23,6 +25,20 @@ interface GridSizedDropZoneProps {
   maxPhotos: number;
   loading?: boolean;
   error?: string | null;
+  /**
+   * Which set this empty drop zone fills. Required to recognise a cross-set
+   * slot drag (a slot photo from the *other* set) so we can route it to the
+   * rejection hint instead of silently swallowing it. Defaults to 'set1'.
+   */
+  setKey?: 'set1' | 'set2';
+  /**
+   * Candidate-tray → set promotion. The set is empty here, so the dropped
+   * candidate always lands in slot 0. Mirrors `PhotoGridApi`'s prop of the
+   * same name so an empty set accepts tray drops just like a populated grid.
+   */
+  onCandidateDropped?: (candidateId: string) => void;
+  /** A slot photo from the other set was dropped here (v1 doesn't support cross-set). */
+  onCrossSetDropRejected?: () => void;
 }
 
 export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
@@ -30,7 +46,10 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
   setName,
   maxPhotos,
   loading = false,
-  error = null
+  error = null,
+  setKey = 'set1',
+  onCandidateDropped,
+  onCrossSetDropRejected
 }) => {
   const { t } = useI18n();
   const { currentRatio } = useAspectRatio();
@@ -76,6 +95,49 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
     await electronImport.pickPhotos(maxPhotos, onFilesDropped);
   };
 
+  // Internal candidate-tray drag channel. react-dropzone above owns the native
+  // file-drop path (`dataTransfer.files`); here we layer the app's
+  // `application/x-airq-photo` protocol on top so dropping a tray thumb onto an
+  // EMPTY set works just like dropping onto a populated `PhotoGridApi` grid.
+  // Same compose-through-getRootProps pattern as `CandidateTray` — our handlers
+  // only act when the internal MIME is present, leaving file drops to dropzone.
+  const [dropActive, setDropActive] = useState(false);
+
+  const handleInternalDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(DRAG_PAYLOAD_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDropActive(true);
+  };
+
+  const handleInternalDragLeave = () => setDropActive(false);
+
+  const handleInternalDrop = (e: React.DragEvent) => {
+    setDropActive(false);
+    // No internal payload → native file drop; let react-dropzone's composed
+    // onDrop handle it (don't preventDefault here, or we'd suppress it).
+    if (!e.dataTransfer.types.includes(DRAG_PAYLOAD_MIME)) return;
+    e.preventDefault();
+
+    // Reuse the same unit-tested dispatch the grid uses. The set is empty, so
+    // the only meaningful outcomes are `promote` (tray photo → slot 0) and
+    // `cross-set-rejected` (a slot photo dragged from the other set).
+    const action = dispatchSlotDrop({
+      payload: parseDragPayload(e.dataTransfer.getData(DRAG_PAYLOAD_MIME)),
+      textPlain: e.dataTransfer.getData('text/plain'),
+      files: [],
+      dropIndex: 0,
+      setKey,
+      isValidImageFile,
+    });
+
+    if (action.kind === 'promote') {
+      if (onCandidateDropped) onCandidateDropped(action.photoId);
+    } else if (action.kind === 'cross-set-rejected') {
+      if (onCrossSetDropRejected) onCrossSetDropRejected();
+    }
+  };
+
   // Determine styling based on state
   const getDropZoneStyles = () => {
     if (loading) {
@@ -103,14 +165,17 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
       };
     }
     
-    if (isDragActive) {
+    // `dropActive` = a candidate-tray thumb is being dragged over (internal
+    // payload, which react-dropzone's `isDragActive` doesn't pick up). Show the
+    // same active glow so the empty set reads as a valid drop target.
+    if (isDragActive || dropActive) {
       return {
         borderColor: 'primary.main',
         backgroundColor: 'primary.light',
         color: 'primary.dark'
       };
     }
-    
+
     return {
       borderColor: 'grey.400',
       backgroundColor: 'grey.50',
@@ -136,15 +201,15 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
       return t('upload.dropPhotosHere', { count: maxPhotos, photoText });
     }
     
-    if (isDragActive) {
+    if (isDragActive || dropActive) {
       return t('upload.dropImages');
     }
-    
+
     return t('upload.clickOrDrop');
   };
 
   const getSubText = () => {
-    if (loading || isDragActive) {
+    if (loading || isDragActive || dropActive) {
       return null;
     }
     
@@ -179,7 +244,14 @@ export const GridSizedDropZone: React.FC<GridSizedDropZoneProps> = ({
 
       {/* Grid-Sized Drop Zone */}
       <Paper
-        {...getRootProps({ onClick: useElectronDialog ? handleElectronClick : undefined })}
+        {...getRootProps({
+          onClick: useElectronDialog ? handleElectronClick : undefined,
+          // Chain our internal tray-drop handlers through react-dropzone so the
+          // native file-drop path stays intact (composeEventHandlers runs both).
+          onDragOver: handleInternalDragOver,
+          onDragLeave: handleInternalDragLeave,
+          onDrop: handleInternalDrop,
+        })}
         elevation={isDragActive ? 4 : 1}
         sx={{
           width: '100%',

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -96,6 +96,10 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
             maxPhotos={initialDropMax}
             loading={loading}
             error={error}
+            // The empty TP zone's file drops default to set1, so candidate-tray
+            // drops land there too (an empty set always fills slot 0).
+            setKey="set1"
+            onCandidateDropped={onCandidateDropped ? (id) => onCandidateDropped('set1', id, 0) : undefined}
           />
         </Paper>
       ) : (


### PR DESCRIPTION
## Summary
- Dragging a candidate-tray thumb onto an **empty** set did nothing — an empty set renders `GridSizedDropZone` (native file-drops only), which had no handler for the internal `application/x-airq-photo` payload tray thumbs carry. It only worked once the set had a photo and `PhotoGridApi` took over.
- Taught `GridSizedDropZone` the internal tray-drop channel, reusing the already-tested `dispatchSlotDrop` helper and the compose-through-`getRootProps` pattern from `CandidateTray`, so native file drops stay intact. Tray drops land in slot 0; cross-set slot drops route to the rejection hint.
- Wired the new props through `AppApi` (set1/set2 empty zones) and `TurningPointLayout`'s empty zone; added `GridSizedDropZone.test.tsx` covering tray promote, cross-set rejection, and the file-drop guard.

## Test plan
- [x] `pnpm vitest run` — full suite green (451 tests, incl. 3 new)
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [ ] Manual: with both sets empty, add candidates to the tray, drag a thumb onto the empty Set 1 zone → highlights on drag-over, lands in Set 1 (grid flips to `PhotoGridApi`)
- [ ] Manual: native file drop onto the empty zone still works
- [ ] Manual: repeat in turning-point mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)