### PR TITLE
fix: no-GPS photo flow, zoom anchoring, and editor label/tray polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.8] - 2026-06-19
+
+### Changed
+- **Map Corridors:** the side-panel photo list now splits selected photos into
+  two groups — **"Turning points – selected"** and **"Track photos – selected"** —
+  instead of one combined "Picks" group, so it's clear at a glance which picks are
+  turning-point photos and which are track photos. Dragging a row between the two
+  pick groups re-flags the photo (turning ↔ track). The Neutral / Rejected /
+  No-GPS groups and the "Send to editor" handoff are unchanged.
+
 ## [2.26.7] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ new desktop release.
   moment you click it, fixing a case where a photo placed just before pressing it
   (typically a no-GPS photo dragged onto the map — often the last one, the finish
   point) was counted in the button but didn't actually transfer to the editor.
+- **Photo Helper:** deleting a photo from a print set no longer deletes the
+  shared image file it came from, so re-sending those photos from Map Corridors
+  brings them ALL back. Previously, deleting placed photos and then re-sending
+  returned fewer than were picked (e.g. 9 picked → 7 returned), because the
+  set-delete stranded the map's image bytes (the same guard already protected the
+  candidate-tray delete; the set-delete path was missed).
 - **Map Corridors:** a placed photo no longer drifts from its spot while you
   zoom. Co-located ("fanned") photos kept a stale screen offset during a
   continuous zoom; the offset now updates every frame so the dot stays anchored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.5] - 2026-06-19
+
+### Changed
+- **Photo Helper:** the burned-in photo labels are now sized per discipline —
+  track-photo numbers are 20% smaller and turning-point labels 35% smaller than
+  before — in both the editor preview and the printed PDF.
+- **Photo Helper:** when a PDF export can't render some photos it now shows a
+  clear, actionable message (how many photos and how to recover them) instead of
+  a raw technical alert. Render failures usually mean a photo's image bytes were
+  lost — re-import those photos or remove the affected cells, then export again.
+
 ## [2.26.4] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.6] - 2026-06-19
+
+### Added
+- **Photo Helper:** turning-point sheets can now hold a **"no photo" placeholder**
+  for a genuinely missing photo. Click **"Insert 'no photo'"** on an empty slot to
+  reserve that position — the surrounding SP/TP/FP numbering stays correct, the
+  cell shows a blank frame with "No photo", and it prints the same blank labeled
+  cell in the PDF (no more padding the gap with a white image). Drag to reorder or
+  delete it like any photo.
+
 ## [2.26.5] - 2026-06-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.2] - 2026-06-19
+
+### Fixed
+- **Map Corridors:** a photo imported **without GPS** can now be re-categorised
+  after you place it on the map. Clicking its marker opens the full
+  Track / Turning-point / Skip / Reject + label popup — previously that popup
+  only appeared for photos that had EXIF GPS, so a placed no-GPS photo was stuck
+  on whatever category it was dropped with.
+- **Map Corridors:** the *Poslat do editoru* panel now warns when no-GPS photos
+  are still sitting in the tray (they only transfer once dropped on the map), and
+  a failed tray placement shows an error instead of silently dropping the photo —
+  addressing "one fewer photo reached the editor than I selected".
+- **Map Corridors:** a placed photo no longer drifts from its spot while you
+  zoom. Co-located ("fanned") photos kept a stale screen offset during a
+  continuous zoom; the offset now updates every frame so the dot stays anchored
+  to the map.
+- **Map Corridors:** the no-GPS photo tray auto-scrolls while you drag a
+  thumbnail — nudge the cursor to the strip's left/right edge and it rolls that
+  way, so thumbnails outside the visible window are reachable mid-drag.
+- **Photo Helper:** the TP / track-photo number labels are smaller; they had
+  grown oversized on both the on-screen previews and the printed sheets.
+
+### Added
+- **Photo Helper:** candidate-tray thumbnails now show the photo filename next to
+  the move/delete buttons, for easier orientation.
+- **Photo Helper:** the toolbar **Add photos** control is more prominent so the
+  manual-import entry point is easy to find.
+
 ## [2.26.1] - 2026-05-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ new desktop release.
   drop) is skipped instead of creating a duplicate, and the original (with its
   placement, flag, and edits) is left untouched. A short note reports how many
   duplicates were skipped.
+- **Photo Helper:** the editor's **Add photos** import also skips duplicates now —
+  re-adding a file already in the competition (the candidate tray or any print
+  set) is a no-op instead of creating a second copy, with a short note on what was
+  skipped.
 - **Photo Helper:** candidate-tray thumbnails now show the photo filename next to
   the move/delete buttons, for easier orientation.
 - **Photo Helper:** the toolbar **Add photos** control is more prominent so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [2.26.3] - 2026-06-19
+## [2.26.4] - 2026-06-19
 
 ### Fixed
 - **Map Corridors:** a photo imported **without GPS** can now be re-categorised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ new desktop release.
   are still sitting in the tray (they only transfer once dropped on the map), and
   a failed tray placement shows an error instead of silently dropping the photo —
   addressing "one fewer photo reached the editor than I selected".
+- **Map Corridors:** *Poslat do editoru* now writes the current selection at the
+  moment you click it, fixing a case where a photo placed just before pressing it
+  (typically a no-GPS photo dragged onto the map — often the last one, the finish
+  point) was counted in the button but didn't actually transfer to the editor.
 - **Map Corridors:** a placed photo no longer drifts from its spot while you
   zoom. Co-located ("fanned") photos kept a stale screen offset during a
   continuous zoom; the offset now updates every frame so the dot stays anchored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
+## [2.26.7] - 2026-06-19
+
+### Fixed
+- **Map Corridors:** a photo placed from the no-GPS tray is now covered by
+  re-import dedup too — its content hash carries onto the map marker, so
+  re-importing the same file no longer creates a duplicate.
+
 ## [2.26.6] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [2.26.2] - 2026-06-19
+## [2.26.3] - 2026-06-19
 
 ### Fixed
 - **Map Corridors:** a photo imported **without GPS** can now be re-categorised
@@ -37,6 +37,11 @@ new desktop release.
   grown oversized on both the on-screen previews and the printed sheets.
 
 ### Added
+- **Map Corridors:** importing the same photo twice is now a no-op — a file whose
+  contents match a photo already in the competition (or another file in the same
+  drop) is skipped instead of creating a duplicate, and the original (with its
+  placement, flag, and edits) is left untouched. A short note reports how many
+  duplicates were skipped.
 - **Photo Helper:** candidate-tray thumbnails now show the photo filename next to
   the move/delete buttons, for easier orientation.
 - **Photo Helper:** the toolbar **Add photos** control is more prominent so the

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.25.1",
+  "version": "2.26.2",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.3",
+  "version": "2.26.4",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.5",
+  "version": "2.26.6",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.7",
+  "version": "2.26.8",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.26.6",
+  "version": "2.26.7",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -786,12 +786,18 @@ function App() {
   // failure can no longer leave the photo duplicated in both lists.
   const handleNoGpsPhotoPlaced = useCallback(async (photoId: string, lng: number, lat: number) => {
     try {
-      await placeNoGpsPhoto(photoId, lng, lat)
+      // Honor the boolean return: a `false` means the entry was no longer in
+      // the tray (e.g. removed mid-drag), so NO marker was created. Without
+      // this the photo silently vanishes from both the tray and the map with
+      // no feedback — one of the "a photo didn't make it" paths (feedback
+      // 2026-06-19). Mirrors the provisional-commit handler's placeFailed snack.
+      const ok = await placeNoGpsPhoto(photoId, lng, lat)
+      if (!ok) setSnack({ severity: 'error', text: t('photo.tray.placeFailed') })
     } catch (err) {
       console.error('placeNoGpsPhoto failed:', err)
       setSnack({ severity: 'error', text: err instanceof Error ? err.message : String(err) })
     }
-  }, [placeNoGpsPhoto])
+  }, [placeNoGpsPhoto, t])
 
   // Phase 14 — drag-to-recategorize: a row dropped on another group sets its
   // flag. Reuses the same setter the popup buttons use.

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -569,9 +569,17 @@ function App() {
       return
     }
     setImportProgress({ done: 0, total: files.length })
+    // ADR-020 re-import dedup: collect the content hashes already in this
+    // competition (placed markers + no-GPS tray) so importPhotosToStorage skips
+    // re-importing the same photo and leaves the original (and its placement /
+    // flag / edits) untouched.
+    const existingContentHashes = new Set<string>()
+    for (const m of markers) if (m.contentHash) existingContentHashes.add(m.contentHash)
+    for (const p of (session?.noGpsPhotos ?? [])) if (p.contentHash) existingContentHashes.add(p.contentHash)
     try {
       const result = await importPhotosToStorage(storage, photosDir, files, {
         onProgress: (done, total) => setImportProgress({ done, total }),
+        existingContentHashes,
       })
       // Phase 4/6: surface imported photos. Photos WITH EXIF GPS become
       // PhotoMarkers and join the capture-dots layer (Phase 4). Photos
@@ -592,6 +600,7 @@ function App() {
                 lng: captured.lng,
                 lat: captured.lat,
                 name: p.file.name,
+                contentHash: p.contentHash,
                 capturedAt: {
                   lng: captured.lng,
                   lat: captured.lat,
@@ -610,6 +619,7 @@ function App() {
               next.push({
                 photoId: p.photoId,
                 filename: p.file.name,
+                contentHash: p.contentHash,
                 ...(p.exif.timestamp ? { timestamp: p.exif.timestamp } : {}),
               })
             }
@@ -617,12 +627,17 @@ function App() {
           })
         }
       }
-      if (result.failed.length === 0) {
+      const dupCount = result.duplicates?.length ?? 0
+      const dupSuffix = dupCount > 0 ? ` ${t('photo.import.duplicatesSkipped', { count: dupCount })}` : ''
+      if (result.ok.length === 0 && result.failed.length === 0 && dupCount > 0) {
+        // Every selected file was already imported — nothing new, nothing failed.
+        setSnack({ severity: 'info', text: t('photo.import.allDuplicates', { count: dupCount }) })
+      } else if (result.failed.length === 0) {
         setSnack({
           severity: 'success',
-          text: result.ok.length === 1
+          text: (result.ok.length === 1
             ? t('photo.import.successOne')
-            : t('photo.import.success', { count: result.ok.length }),
+            : t('photo.import.success', { count: result.ok.length })) + dupSuffix,
         })
       } else if (result.ok.length === 0) {
         setSnack(summarizeFailures(result.failed, t))
@@ -633,7 +648,7 @@ function App() {
             ok: result.ok.length,
             total: files.length,
             failed: result.failed.length,
-          }),
+          }) + dupSuffix,
         })
       }
     } catch (err) {
@@ -645,7 +660,7 @@ function App() {
     } finally {
       setImportProgress(null)
     }
-  }, [storage, photosDir, t, persistMarkers, persistNoGpsPhotos])
+  }, [storage, photosDir, t, persistMarkers, persistNoGpsPhotos, markers, session?.noGpsPhotos])
 
   // Phase 9 — Send-to-editor button handler. Flushes the pending
   // map-picks write FIRST (ADR-009 navigation-flush requirement) so a

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -656,6 +656,17 @@ function App() {
   // signal that the picks didn't make it.
   const handleSendToEditor = useCallback(async () => {
     try {
+      // Write the CURRENT picks synchronously at click time, THEN flush — don't
+      // rely on the debounced [markers] effect having already scheduled the
+      // latest snapshot. A photo placed immediately before clicking (typically a
+      // no-GPS photo just dragged from the tray, the last action before sending)
+      // can be one render behind the pending write, so the flushed file would
+      // miss it even though the footer counts it: the "18 selected, 17 arrived"
+      // bug. Re-scheduling here makes the handoff file authoritative over the
+      // visible count; flushPendingMapPicks immediately drains this write.
+      if (storage && competitionDir) {
+        scheduleWriteMapPicks(storage, competitionDir, buildMapPicks(markers))
+      }
       await flushPendingMapPicks()
     } catch (err) {
       console.error('flushPendingMapPicks failed before nav:', err)
@@ -669,7 +680,7 @@ function App() {
     } else {
       window.location.href = `/photo-helper/?competitionId=${competitionId}`
     }
-  }, [competitionId, t])
+  }, [competitionId, storage, competitionDir, markers, t])
 
   // Phase 8a — mirror the in-memory photo markers into map-picks.json
   // every time they change. The writer debounces (300ms) so rapid flag

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -640,7 +640,9 @@ function App() {
             : t('photo.import.success', { count: result.ok.length })) + dupSuffix,
         })
       } else if (result.ok.length === 0) {
-        setSnack(summarizeFailures(result.failed, t))
+        // Nothing imported — failures (and possibly some skipped duplicates).
+        const failSnack = summarizeFailures(result.failed, t)
+        setSnack(dupCount > 0 ? { ...failSnack, text: failSnack.text + dupSuffix } : failSnack)
       } else {
         setSnack({
           severity: 'warning',

--- a/frontend/map-corridors/src/__tests__/componentLogic.test.ts
+++ b/frontend/map-corridors/src/__tests__/componentLogic.test.ts
@@ -85,15 +85,16 @@ describe('labelButtonState — picker click rules', () => {
 })
 
 describe('PhotoListPanel — Send-to-editor disabled invariant', () => {
-  it('is disabled when picks.length === 0 (covered by groupPhotosByFlag tests)', () => {
-    // The actual `disabled={groups.picks.length === 0}` lives in the
+  it('is disabled when there are no picks (covered by groupPhotosByFlag tests)', () => {
+    // The actual `disabled={pickCount === 0}` (pickCount =
+    // groups.picksTurning.length + groups.picksTrack.length) lives in the
     // panel JSX. The grouping is fully tested by groupPhotosByFlag.test
     // — we just pin the rule here as a doc-test so a regression that
     // changes the predicate (e.g. `> 0` instead of `=== 0`) gets caught
     // by reviewers grepping for this file.
-    const picksEmpty: { length: number } = { length: 0 }
-    const picksNonempty: { length: number } = { length: 3 }
-    expect(picksEmpty.length === 0).toBe(true)
-    expect(picksNonempty.length === 0).toBe(false)
+    const pickCountEmpty: number = 0
+    const pickCountNonempty: number = 3
+    expect(pickCountEmpty === 0).toBe(true)
+    expect(pickCountNonempty === 0).toBe(false)
   })
 })

--- a/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupKeyForPhotoId.test.ts
@@ -5,8 +5,9 @@ import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 
 // Phase 13 (active-photo highlight). `groupKeyForPhotoId` drives the
 // auto-expand of the active photo's group when its marker is clicked on the
-// map — so it must map a photoId to picks/neutral/rejects, and return null for
-// anything that has no GPS marker (unknown id, or a no-GPS tray photo).
+// map — so it must map a photoId to turning/track picks, neutral or rejects,
+// and return null for anything that has no GPS marker (unknown id, or a no-GPS
+// tray photo).
 
 function pm(over: Partial<PhotoMarker>): PhotoMarker {
   return { id: 'pm', lng: 14, lat: 50, name: 'x.jpg', photoId: 'pm', ...over } as PhotoMarker
@@ -16,13 +17,18 @@ const markers: PhotoMarker[] = [
   pm({ id: 'a', photoId: 'a', name: 'a.jpg', flag: 'pick-track' }),
   pm({ id: 'b', photoId: 'b', name: 'b.jpg' }), // neutral (no flag)
   pm({ id: 'c', photoId: 'c', name: 'c.jpg', flag: 'reject' }),
+  pm({ id: 'd', photoId: 'd', name: 'd.jpg', flag: 'pick-turning' }),
 ]
 const noGps: NoGpsPhoto[] = [{ photoId: 'n', filename: 'n.jpg' } as NoGpsPhoto]
 const groups = groupPhotosByFlag(markers, noGps)
 
 describe('groupKeyForPhotoId', () => {
-  it('returns "picks" for a pick marker', () => {
-    expect(groupKeyForPhotoId(groups, 'a')).toBe('picks')
+  it('returns "picksTrack" for a track-pick marker', () => {
+    expect(groupKeyForPhotoId(groups, 'a')).toBe('picksTrack')
+  })
+
+  it('returns "picksTurning" for a turning-point-pick marker', () => {
+    expect(groupKeyForPhotoId(groups, 'd')).toBe('picksTurning')
   })
 
   it('returns "neutral" for an unflagged marker', () => {

--- a/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
+++ b/frontend/map-corridors/src/__tests__/groupPhotosByFlag.test.ts
@@ -11,16 +11,17 @@ function ng(photoId: string, filename = `${photoId}.jpg`): NoGpsPhoto {
 }
 
 describe('groupPhotosByFlag', () => {
-  it('returns four empty arrays + total=0 for no input', () => {
+  it('returns empty arrays + total=0 for no input', () => {
     const g = groupPhotosByFlag([], [])
-    expect(g.picks).toEqual([])
+    expect(g.picksTurning).toEqual([])
+    expect(g.picksTrack).toEqual([])
     expect(g.neutral).toEqual([])
     expect(g.rejects).toEqual([])
     expect(g.noGps).toEqual([])
     expect(g.total).toBe(0)
   })
 
-  it('puts photos in their flag groups — BOTH pick categories land in picks', () => {
+  it('splits picks by category — turning-point vs track — and keeps neutral/reject', () => {
     const markers: PhotoMarker[] = [
       pm({ id: 'a', photoId: 'pid-a' }),                        // neutral
       pm({ id: 'b', photoId: 'pid-b', flag: 'pick-track' }),    // pick (track)
@@ -28,9 +29,8 @@ describe('groupPhotosByFlag', () => {
       pm({ id: 'c', photoId: 'pid-c', flag: 'reject' }),        // reject
     ]
     const g = groupPhotosByFlag(markers, [])
-    // Track + turning-point picks both count as "picks"; the category only
-    // matters for the editor handoff, not the 4-group panel.
-    expect(g.picks.map(m => m.id)).toEqual(['b', 'd'])
+    expect(g.picksTurning.map(m => m.id)).toEqual(['d'])
+    expect(g.picksTrack.map(m => m.id)).toEqual(['b'])
     expect(g.neutral.map(m => m.id)).toEqual(['a'])
     expect(g.rejects.map(m => m.id)).toEqual(['c'])
   })
@@ -41,7 +41,7 @@ describe('groupPhotosByFlag', () => {
       pm({ id: 'photo', photoId: 'pid-1', flag: 'pick-track' }),
     ]
     const g = groupPhotosByFlag(markers, [])
-    expect(g.picks.map(m => m.id)).toEqual(['photo'])
+    expect(g.picksTrack.map(m => m.id)).toEqual(['photo'])
     expect(g.neutral).toEqual([])
     expect(g.total).toBe(1)
   })
@@ -52,7 +52,8 @@ describe('groupPhotosByFlag', () => {
     const markers = [pm({ id: 'a', photoId: 'pid-a', label: 'A' })]
     const g = groupPhotosByFlag(markers, [])
     expect(g.neutral.map(m => m.id)).toEqual(['a'])
-    expect(g.picks).toEqual([])
+    expect(g.picksTurning).toEqual([])
+    expect(g.picksTrack).toEqual([])
   })
 
   it('sorts noGpsPhotos by filename (numeric-aware) without mutating the input', () => {
@@ -70,17 +71,17 @@ describe('groupPhotosByFlag', () => {
       pm({ id: 'p100', photoId: 'c', flag: 'pick-track', name: 'DSC_0100.JPG' }),
     ]
     const g = groupPhotosByFlag(markers, [])
-    expect(g.picks.map(m => m.name)).toEqual(['DSC_0009.JPG', 'DSC_0010.JPG', 'DSC_0100.JPG'])
+    expect(g.picksTrack.map(m => m.name)).toEqual(['DSC_0009.JPG', 'DSC_0010.JPG', 'DSC_0100.JPG'])
   })
 
   it('orders by original filename, NOT by a custom displayName', () => {
     const markers: PhotoMarker[] = [
       pm({ id: 'z', photoId: 'a', flag: 'pick-track', name: 'DSC_0002.JPG', displayName: 'AAA' }),
-      pm({ id: 'a', photoId: 'b', flag: 'pick-turning', name: 'DSC_0001.JPG', displayName: 'ZZZ' }),
+      pm({ id: 'a', photoId: 'b', flag: 'pick-track', name: 'DSC_0001.JPG', displayName: 'ZZZ' }),
     ]
     const g = groupPhotosByFlag(markers, [])
     // 0001 before 0002 (filename order) — a rename to ZZZ/AAA must not reorder.
-    expect(g.picks.map(m => m.name)).toEqual(['DSC_0001.JPG', 'DSC_0002.JPG'])
+    expect(g.picksTrack.map(m => m.name)).toEqual(['DSC_0001.JPG', 'DSC_0002.JPG'])
   })
 
   it('total is the sum across all four groups', () => {

--- a/frontend/map-corridors/src/__tests__/importPhotosToStorage.test.ts
+++ b/frontend/map-corridors/src/__tests__/importPhotosToStorage.test.ts
@@ -18,14 +18,16 @@ function makeFile(name: string): File {
   return new File([new Uint8Array(8)], name, { type: 'image/jpeg' })
 }
 
-function makePhoto(name: string): ImportedPhoto {
+// Default to a per-name hash so multi-photo fixtures aren't treated as
+// duplicates of each other; pass an explicit hash to exercise dedup.
+function makePhoto(name: string, contentHash: string = `hash-${name}`): ImportedPhoto {
   const file = makeFile(name)
   return {
     photoId: `pm-${name}`,
     file,
     thumbnail: new Blob([new Uint8Array(32)], { type: 'image/jpeg' }),
     exif: {},
-    contentHash: '0'.repeat(40),
+    contentHash,
   }
 }
 
@@ -232,6 +234,78 @@ describe('importPhotosToStorage — storage failures', () => {
       [photo.file],
     )
     expect(result.failed[0].message).toBe('plain string thrown')
+  })
+})
+
+describe('importPhotosToStorage — re-import dedup (ADR-020)', () => {
+  it('skips a file whose hash already exists in the session and never saves it', async () => {
+    const photo = makePhoto('again.jpg', 'dup-hash')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+      { existingContentHashes: new Set(['dup-hash']) },
+    )
+
+    expect(result.ok).toEqual([])
+    expect(result.duplicates).toEqual([{ filename: 'again.jpg', contentHash: 'dup-hash' }])
+    // Original preserved: no blob/thumb written for the duplicate.
+    expect(storage.savePhotoFile).not.toHaveBeenCalled()
+    expect(storage.savePhotoThumb).not.toHaveBeenCalled()
+  })
+
+  it('keeps the first of an intra-batch duplicate pair and skips the rest', async () => {
+    const first = makePhoto('a.jpg', 'same')
+    const second = makePhoto('b.jpg', 'same')
+    importPhotoFilesMock.mockResolvedValue({ ok: [first, second], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [first.file, second.file],
+    )
+
+    expect(result.ok).toEqual([first])
+    expect(result.duplicates).toEqual([{ filename: 'b.jpg', contentHash: 'same' }])
+    expect(storage.savePhotoFile).toHaveBeenCalledTimes(1)
+    expect(storage.savePhotoFile).toHaveBeenCalledWith(photosDir, 'pm-a.jpg', first.file)
+  })
+
+  it('imports normally when the existing set holds only other hashes', async () => {
+    const photo = makePhoto('new.jpg', 'fresh-hash')
+    importPhotoFilesMock.mockResolvedValue({ ok: [photo], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [photo.file],
+      { existingContentHashes: new Set(['unrelated']) },
+    )
+
+    expect(result.ok).toEqual([photo])
+    expect(result.duplicates).toBeUndefined()
+    expect(storage.savePhotoFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs intra-batch dedup even without an existingContentHashes set', async () => {
+    const a = makePhoto('x.jpg', 'h')
+    const b = makePhoto('y.jpg', 'h')
+    importPhotoFilesMock.mockResolvedValue({ ok: [a, b], failed: [] } as ImportResult)
+    const storage = fakeStorage()
+
+    const result = await importPhotosToStorage(
+      storage as unknown as StorageInterface,
+      photosDir,
+      [a.file, b.file],
+    )
+
+    expect(result.ok).toHaveLength(1)
+    expect(result.duplicates).toHaveLength(1)
   })
 })
 

--- a/frontend/map-corridors/src/__tests__/recategorize.test.ts
+++ b/frontend/map-corridors/src/__tests__/recategorize.test.ts
@@ -3,19 +3,26 @@ import { flagForGroup, canRecategorize } from '../recategorize/recategorize'
 
 // Phase 14 (drag-to-recategorize). Dropping a row onto a group must map to the
 // right flag, and invalid drops (same group, or the no-GPS tray) must be
-// rejected so the drop handler can no-op cleanly.
+// rejected so the drop handler can no-op cleanly. The two pick groups
+// (turning-point vs track) each set their own flag, so dragging a row between
+// them re-flags the photo (pick-turning ↔ pick-track) with no popup round-trip.
 
 describe('flagForGroup', () => {
-  it('picks → pick-track (default category; re-categorize to turning via popup)', () => expect(flagForGroup('picks')).toBe('pick-track'))
+  it('picksTurning → pick-turning', () => expect(flagForGroup('picksTurning')).toBe('pick-turning'))
+  it('picksTrack → pick-track', () => expect(flagForGroup('picksTrack')).toBe('pick-track'))
   it('rejects → reject', () => expect(flagForGroup('rejects')).toBe('reject'))
   it('neutral → null (flag cleared)', () => expect(flagForGroup('neutral')).toBeNull())
   it('noGps → undefined (not a recategorize target)', () => expect(flagForGroup('noGps')).toBeUndefined())
 })
 
 describe('canRecategorize', () => {
-  it('allows pick → reject', () => expect(canRecategorize('picks', 'rejects')).toBe(true))
-  it('allows neutral → picks', () => expect(canRecategorize('neutral', 'picks')).toBe(true))
-  it('rejects same-group drop (no-op)', () => expect(canRecategorize('picks', 'picks')).toBe(false))
-  it('rejects dropping onto the no-GPS tray', () => expect(canRecategorize('picks', 'noGps')).toBe(false))
-  it('rejects dragging a no-GPS photo (no flag to change)', () => expect(canRecategorize('noGps', 'picks')).toBe(false))
+  it('allows track-pick → reject', () => expect(canRecategorize('picksTrack', 'rejects')).toBe(true))
+  it('allows neutral → track-pick', () => expect(canRecategorize('neutral', 'picksTrack')).toBe(true))
+  it('allows turning-pick ↔ track-pick re-flag (drag between the two pick groups)', () => {
+    expect(canRecategorize('picksTurning', 'picksTrack')).toBe(true)
+    expect(canRecategorize('picksTrack', 'picksTurning')).toBe(true)
+  })
+  it('rejects same-group drop (no-op)', () => expect(canRecategorize('picksTrack', 'picksTrack')).toBe(false))
+  it('rejects dropping onto the no-GPS tray', () => expect(canRecategorize('picksTrack', 'noGps')).toBe(false))
+  it('rejects dragging a no-GPS photo (no flag to change)', () => expect(canRecategorize('noGps', 'picksTrack')).toBe(false))
 })

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -71,7 +71,7 @@ export function NoGpsTray(props: NoGpsTrayProps) {
   }, [])
 
   // Cancel any in-flight loop if the tray unmounts mid-drag (no leaked rAF).
-  useEffect(() => stopAutoScroll, [stopAutoScroll])
+  useEffect(() => () => stopAutoScroll(), [stopAutoScroll])
 
   const tick = useCallback(() => {
     const el = scrollRef.current
@@ -141,10 +141,11 @@ export function NoGpsTray(props: NoGpsTrayProps) {
           ref={scrollRef}
           onDragOver={handleStripDragOver}
           onDragLeave={handleStripDragLeave}
-          // Stop the loop when the drag finishes anywhere (dragend bubbles up
-          // from the thumb) or drops onto the strip itself.
+          // Stop the loop when the drag ends: dragend bubbles up from the thumb.
+          // (The strip is never itself a drop target — dragover never calls
+          // preventDefault — so the drop lands on the map canvas, and a
+          // dragleave/dragend always fires here first.)
           onDragEnd={stopAutoScroll}
-          onDrop={stopAutoScroll}
           sx={{
             height: TRAY_HEIGHT_PX - 32, // minus header chrome
             overflowX: 'auto',

--- a/frontend/map-corridors/src/components/NoGpsTray.tsx
+++ b/frontend/map-corridors/src/components/NoGpsTray.tsx
@@ -4,7 +4,7 @@
 // HTML5-draggable; drop onto the map places it as a `'pick'` PhotoMarker
 // at the drop coordinates.
 
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Box, IconButton, Paper, Tooltip, Typography } from '@mui/material'
 import { Close, ExpandLess, ExpandMore } from '@mui/icons-material'
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
@@ -12,6 +12,9 @@ import type { NoGpsPhoto } from '../types/markers'
 import { compareNoGpsPhotos, noGpsPhotoDisplayName } from '../types/markers'
 import { useI18n } from '../contexts/I18nContext'
 import { usePhotoThumbUrl } from './usePhotoThumbUrl'
+// Reuse the marker edge-pan's eased velocity ramp so the tray's drag-scroll
+// feels identical to the map's, and the easing stays tested in one place.
+import { edgeVelocity } from '../map/useEdgePanDrag'
 
 /** Drag type the map drop handler watches for. Public — MapProviderView imports this. */
 export const NO_GPS_PHOTO_DRAG_TYPE = 'application/x-airq-no-gps-photo'
@@ -50,6 +53,61 @@ export function NoGpsTray(props: NoGpsTrayProps) {
 
   const sorted = useMemo(() => [...photos].sort(compareNoGpsPhotos), [photos])
 
+  // --- Auto-scroll the strip while a thumbnail is being dragged onto the map ---
+  // Thumbs use native HTML5 drag, so the user can't also operate the scrollbar
+  // mid-drag — a thumb outside the 20vw window (ADR-012) would be unreachable.
+  // When the drag cursor nears the strip's left/right edge, roll the strip that
+  // way each frame (only scrollLeft changes, so the ADR-012 width cap holds).
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const velRef = useRef(0)
+
+  const stopAutoScroll = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+    velRef.current = 0
+  }, [])
+
+  // Cancel any in-flight loop if the tray unmounts mid-drag (no leaked rAF).
+  useEffect(() => stopAutoScroll, [stopAutoScroll])
+
+  const tick = useCallback(() => {
+    const el = scrollRef.current
+    if (el && velRef.current !== 0) {
+      el.scrollLeft += velRef.current
+      rafRef.current = requestAnimationFrame(tick)
+    } else {
+      rafRef.current = null
+    }
+  }, [])
+
+  const handleStripDragOver = useCallback((e: React.DragEvent) => {
+    // Only our own thumb drags drive the scroll — ignore unrelated drags.
+    if (!e.dataTransfer.types.includes(NO_GPS_PHOTO_DRAG_TYPE)) return
+    const el = scrollRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    // edgeVelocity: negative near the left edge, positive near the right, 0 in
+    // the middle — exactly scrollLeft's sign convention, so add it directly.
+    velRef.current = edgeVelocity(e.clientX - rect.left, rect.width)
+    if (velRef.current !== 0 && rafRef.current == null) {
+      rafRef.current = requestAnimationFrame(tick)
+    } else if (velRef.current === 0) {
+      stopAutoScroll()
+    }
+  }, [tick, stopAutoScroll])
+
+  const handleStripDragLeave = useCallback((e: React.DragEvent) => {
+    // dragleave also fires when moving onto a child thumb; only stop when the
+    // pointer truly exits the strip, else dragover restarts it next frame.
+    const el = scrollRef.current
+    const related = e.relatedTarget as Node | null
+    if (el && related && el.contains(related)) return
+    stopAutoScroll()
+  }, [stopAutoScroll])
+
   // Auto-hide when nothing to show. Phase 6 acceptance: "Tray empty → collapses".
   // We hide entirely (vs. show empty chrome) — simpler, no chevron-with-nothing.
   if (sorted.length === 0) return null
@@ -80,6 +138,13 @@ export function NoGpsTray(props: NoGpsTrayProps) {
       </Box>
       {open && (
         <Box
+          ref={scrollRef}
+          onDragOver={handleStripDragOver}
+          onDragLeave={handleStripDragLeave}
+          // Stop the loop when the drag finishes anywhere (dragend bubbles up
+          // from the thumb) or drops onto the strip itself.
+          onDragEnd={stopAutoScroll}
+          onDrop={stopAutoScroll}
           sx={{
             height: TRAY_HEIGHT_PX - 32, // minus header chrome
             overflowX: 'auto',

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -115,16 +115,17 @@ export interface PhotoListPanelProps {
  */
 export const MAX_COMPARE_VARIANTS = 3
 
-type GroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
+type GroupKey = 'picksTurning' | 'picksTrack' | 'neutral' | 'rejects' | 'noGps'
 
-const GROUP_ORDER: readonly GroupKey[] = ['picks', 'neutral', 'rejects', 'noGps']
+const GROUP_ORDER: readonly GroupKey[] = ['picksTurning', 'picksTrack', 'neutral', 'rejects', 'noGps']
 
 export function PhotoListPanel(props: PhotoListPanelProps) {
   const { t } = useI18n()
   const { markers, noGpsPhotos, storage, photosDir, onMarkerClick, onSendToEditor, onPhotoDelete, onPhotoRename, onCompareVariants, activePhotoId, onPhotoSetFlag, onNoGpsPhotoClick, onPreviewPhoto } = props
   const [collapsedPanel, setCollapsedPanel] = useState(false)
   const [collapsedGroups, setCollapsedGroups] = useState<Record<GroupKey, boolean>>({
-    picks: false,
+    picksTurning: false,
+    picksTrack: false,
     neutral: false,
     rejects: true, // default-collapsed — usually fewer items the user revisits less often
     noGps: false,
@@ -141,12 +142,17 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
   const [dragSourceGroup, setDragSourceGroup] = useState<GroupKey | null>(null)
 
   const groups = useMemo(() => groupPhotosByFlag(markers, noGpsPhotos), [markers, noGpsPhotos])
+  // All picks (turning-point + track) — the send button counts/enables on this,
+  // since "Poslat do editoru" sends every pick regardless of category.
+  const pickCount = groups.picksTurning.length + groups.picksTrack.length
 
   // Visible-order index of every selectable row (GPS markers only — noGps
   // rows have no marker to compare). Drives Shift+click range expansion.
   const orderedSelectableIds = useMemo(() => {
     const ids: string[] = []
-    for (const m of groups.picks) if (m.photoId) ids.push(m.photoId)
+    // Visual order matches GROUP_ORDER (turning picks, then track picks, …).
+    for (const m of groups.picksTurning) if (m.photoId) ids.push(m.photoId)
+    for (const m of groups.picksTrack) if (m.photoId) ids.push(m.photoId)
     for (const m of groups.neutral) if (m.photoId) ids.push(m.photoId)
     for (const m of groups.rejects) if (m.photoId) ids.push(m.photoId)
     return ids
@@ -350,10 +356,10 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
             variant="contained"
             size="small"
             startIcon={<SendOutlined fontSize="small" />}
-            disabled={groups.picks.length === 0}
+            disabled={pickCount === 0}
             onClick={() => { void onSendToEditor() }}
           >
-            {t('photo.list.sendToEditor', { count: groups.picks.length })}
+            {t('photo.list.sendToEditor', { count: pickCount })}
           </Button>
           {/* No-GPS photos still sitting in the tray are not picks and will NOT
               transfer to the editor until dropped on the map. Surfacing the
@@ -425,16 +431,17 @@ function groupCount(g: ReturnType<typeof groupPhotosByFlag>, key: GroupKey): num
 }
 
 /**
- * Which marker group (picks/neutral/rejects) a photoId lives in, or `null` if
- * it isn't a GPS marker (unknown id, or a no-GPS tray photo — those have no
- * marker and can't be the active photo). Exported for unit testing; drives the
- * Phase-13 auto-expand of the active photo's group.
+ * Which marker group (turning/track picks, neutral, rejects) a photoId lives
+ * in, or `null` if it isn't a GPS marker (unknown id, or a no-GPS tray photo —
+ * those have no marker and can't be the active photo). Exported for unit
+ * testing; drives the Phase-13 auto-expand of the active photo's group.
  */
 export function groupKeyForPhotoId(
   g: ReturnType<typeof groupPhotosByFlag>,
   photoId: string,
 ): Exclude<GroupKey, 'noGps'> | null {
-  if (g.picks.some(m => m.photoId === photoId)) return 'picks'
+  if (g.picksTurning.some(m => m.photoId === photoId)) return 'picksTurning'
+  if (g.picksTrack.some(m => m.photoId === photoId)) return 'picksTrack'
   if (g.neutral.some(m => m.photoId === photoId)) return 'neutral'
   if (g.rejects.some(m => m.photoId === photoId)) return 'rejects'
   return null

--- a/frontend/map-corridors/src/components/PhotoListPanel.tsx
+++ b/frontend/map-corridors/src/components/PhotoListPanel.tsx
@@ -355,6 +355,19 @@ export function PhotoListPanel(props: PhotoListPanelProps) {
           >
             {t('photo.list.sendToEditor', { count: groups.picks.length })}
           </Button>
+          {/* No-GPS photos still sitting in the tray are not picks and will NOT
+              transfer to the editor until dropped on the map. Surfacing the
+              count here stops the export from looking "one fewer than expected"
+              with no explanation (feedback 2026-06-19). */}
+          {groups.noGps.length > 0 && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: 'block', mt: 0.75, lineHeight: 1.3 }}
+            >
+              {t('photo.list.noGpsNotPlaced', { count: groups.noGps.length })}
+            </Typography>
+          )}
         </Box>
       )}
     </Paper>

--- a/frontend/map-corridors/src/components/groupPhotosByFlag.ts
+++ b/frontend/map-corridors/src/components/groupPhotosByFlag.ts
@@ -7,15 +7,17 @@ import type { NoGpsPhoto, PhotoMarker } from '../types/markers'
 import { compareFilenames, compareNoGpsPhotos } from '../types/markers'
 
 export interface GroupedPhotos {
-  /** Photo markers picked as track OR turning-point. Includes label-less picks. */
-  picks: readonly PhotoMarker[]
+  /** Photo markers picked as a TURNING-POINT (`flag === 'pick-turning'`). */
+  picksTurning: readonly PhotoMarker[]
+  /** Photo markers picked as a TRACK photo (`flag === 'pick-track'`, incl. legacy bare `pick`). */
+  picksTrack: readonly PhotoMarker[]
   /** Photo markers with no flag and no label. */
   neutral: readonly PhotoMarker[]
   /** Photo markers with `flag === 'reject'`. */
   rejects: readonly PhotoMarker[]
   /** Photos imported without GPS that haven't been placed yet (live in NoGpsTray). */
   noGps: readonly NoGpsPhoto[]
-  /** Total count across all four groups — useful for the empty-panel test. */
+  /** Total count across all groups — useful for the empty-panel test. */
   total: number
 }
 
@@ -28,21 +30,26 @@ export function groupPhotosByFlag(
   markers: readonly PhotoMarker[],
   noGpsPhotos: readonly NoGpsPhoto[],
 ): GroupedPhotos {
-  const picks: PhotoMarker[] = []
+  const picksTurning: PhotoMarker[] = []
+  const picksTrack: PhotoMarker[] = []
   const neutral: PhotoMarker[] = []
   const rejects: PhotoMarker[] = []
   for (const m of markers) {
     if (!m.photoId) continue // KML markers don't belong in the photo list
-    // Both pick categories (track + turning-point) count as "picks" — the
-    // 4-group panel stays; the category only matters for the editor handoff.
-    if (isPickFlag(m.flag)) picks.push(m)
+    // Split picks by category so the panel shows "turning-point picks" vs
+    // "track picks" separately. Turning-point first; every other pick
+    // (pick-track + any legacy bare `pick`, migrated to track on load) goes to
+    // the track group — matching the editor's per-flag print-set routing.
+    if (m.flag === 'pick-turning') picksTurning.push(m)
+    else if (isPickFlag(m.flag)) picksTrack.push(m)
     else if (m.flag === 'reject') rejects.push(m)
     else neutral.push(m)
   }
   // Order every group by the ORIGINAL camera filename (numeric-aware), so the
   // list mirrors the shooting sequence regardless of any custom `displayName`.
   // Sorting by the immutable `name` means renaming a photo never moves it.
-  picks.sort((a, b) => compareFilenames(a.name, b.name))
+  picksTurning.sort((a, b) => compareFilenames(a.name, b.name))
+  picksTrack.sort((a, b) => compareFilenames(a.name, b.name))
   neutral.sort((a, b) => compareFilenames(a.name, b.name))
   rejects.sort((a, b) => compareFilenames(a.name, b.name))
   // Reuse the tray's comparator so the no-GPS group and the NoGpsTray agree on
@@ -50,10 +57,11 @@ export function groupPhotosByFlag(
   // filenames — not just on the primary filename sort.
   const noGps = [...noGpsPhotos].sort(compareNoGpsPhotos)
   return {
-    picks,
+    picksTurning,
+    picksTrack,
     neutral,
     rejects,
     noGps,
-    total: picks.length + neutral.length + rejects.length + noGps.length,
+    total: picksTurning.length + picksTrack.length + neutral.length + rejects.length + noGps.length,
   }
 }

--- a/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
+++ b/frontend/map-corridors/src/hooks/useCorridorSessionOPFS.ts
@@ -405,6 +405,10 @@ export function useCorridorSessionOPFS(competitionId?: string | null) {
       // Carry the custom name across so dragging a renamed tray photo onto
       // the map keeps its label (and still preserves the original filename).
       ...(entry.displayName ? { displayName: entry.displayName } : {}),
+      // Carry the import-time content hash across so a placed no-GPS photo stays
+      // covered by re-import dedup (ADR-020) — otherwise re-importing the same
+      // file would create a duplicate marker (matches markers.ts contentHash doc).
+      ...(entry.contentHash ? { contentHash: entry.contentHash } : {}),
       // Phase 14 — caller may commit straight to a chosen category (provisional
       // placement). `null` = neutral, so omit the flag field. Tray drag-drop
       // defaults to 'pick-track' (the common case; re-categorize via the popup).

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -34,7 +34,9 @@
       "failureStorage": "{{count}} fotek nelze uložit (úložiště)",
       "failureStorageOne": "1 fotku nelze uložit (úložiště)",
       "unsupported": "Nepodporovaný soubor: {{name}}",
-      "noCompetition": "Před importem fotek otevři soutěž z hlavního menu"
+      "noCompetition": "Před importem fotek otevři soutěž z hlavního menu",
+      "duplicatesSkipped": "(přeskočeno duplikátů: {{count}})",
+      "allDuplicates": "Všechny vybrané fotky už byly importované – přeskočeno ({{count}})."
     },
     "popup": {
       "include": "Vybrané",

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -77,7 +77,8 @@
       "sendToEditor": "Poslat do editoru ({{count}})",
       "compareSelected": "Srovnat varianty ({{count}})",
       "compareLimitTip": "Najednou lze srovnávat nejvýše {{max}} varianty",
-      "clearSelection": "Zrušit výběr"
+      "clearSelection": "Zrušit výběr",
+      "noGpsNotPlaced": "Fotky bez GPS ({{count}}) zatím nejsou na mapě – přetáhněte je na ni, jinak se do editoru nepřenesou."
     },
     "compare": {
       "title": "Srovnání variant",

--- a/frontend/map-corridors/src/locales/cs.json
+++ b/frontend/map-corridors/src/locales/cs.json
@@ -70,7 +70,8 @@
     },
     "list": {
       "title": "Fotky",
-      "picks": "Vybrané",
+      "picksTurning": "Otočné body – vybrané",
+      "picksTrack": "Traťové foto – vybrané",
       "neutral": "Neutrální",
       "rejects": "Odmítnuté",
       "noGps": "Bez GPS",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -34,7 +34,9 @@
       "failureStorage": "{{count}} photos could not be saved (storage)",
       "failureStorageOne": "1 photo could not be saved (storage)",
       "unsupported": "Unsupported file: {{name}}",
-      "noCompetition": "Open a competition from the launcher before importing photos"
+      "noCompetition": "Open a competition from the launcher before importing photos",
+      "duplicatesSkipped": "({{count}} duplicate(s) skipped)",
+      "allDuplicates": "All selected photos are already imported — skipped ({{count}})."
     },
     "popup": {
       "include": "Picked",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -70,7 +70,8 @@
     },
     "list": {
       "title": "Photos",
-      "picks": "Picks",
+      "picksTurning": "Turning points – selected",
+      "picksTrack": "Track photos – selected",
       "neutral": "Neutral",
       "rejects": "Rejects",
       "noGps": "No GPS",

--- a/frontend/map-corridors/src/locales/en.json
+++ b/frontend/map-corridors/src/locales/en.json
@@ -77,7 +77,8 @@
       "sendToEditor": "Send to editor ({{count}})",
       "compareSelected": "Compare variants ({{count}})",
       "compareLimitTip": "At most {{max}} variants can be compared at once",
-      "clearSelection": "Clear selection"
+      "clearSelection": "Clear selection",
+      "noGpsNotPlaced": "No-GPS photos ({{count}}) aren't on the map yet — drag them onto the map or they won't transfer to the editor."
     },
     "compare": {
       "title": "Compare variants",

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -468,8 +468,9 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       map.flyTo({ center, zoom: Math.max(map.getZoom(), 14), duration: 700 })
       // Also open the photo popup so the panel click is a one-step
       // action (fly + preview + actions). KML/click markers don't have
-      // a photo popup — guarded by photoId + capturedAt.
-      if (marker.photoId && marker.capturedAt) {
+      // a photo popup — gated on photoId (NOT capturedAt) so a no-GPS
+      // photo placed from the tray still opens its flag popup from the list.
+      if (marker.photoId) {
         setActivePhotoMarkerId(markerId)
       }
     },
@@ -1062,14 +1063,18 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
           </React.Fragment>
         )
       })}
-      {/* Phase 5 photo-marker popup. Mounted only when a capture dot is
-          clicked AND the parent provides photo storage + handlers. */}
+      {/* Phase 5 photo-marker popup. Mounted when ANY photo marker is active
+          (an EXIF capture dot OR a no-GPS photo placed from the tray) and the
+          parent provides photo storage + handlers. Gated on photoId — NOT
+          capturedAt — so no-GPS placements (which never carry capturedAt) still
+          get the Track/TP/Skip/Reject + label UI. The retained photoId clause
+          keeps KML/click-placed markers (no photoId) popup-free. */}
       {(() => {
         if (!activePhotoMarkerId) return null
         if (!props.photoStorage || !props.photoDir) return null
         if (!props.onPhotoIncludeTrack || !props.onPhotoIncludeTurning || !props.onPhotoSkip || !props.onPhotoReject) return null
         const marker = props.markers?.find(m => m.id === activePhotoMarkerId)
-        if (!marker || !marker.capturedAt || !marker.photoId) return null
+        if (!marker || !marker.photoId) return null
         const popupId = activePhotoMarkerId
         // When the active marker is fanned, shift the popup by the same pixel
         // offset so its tail points at the fanned dot the user clicked rather
@@ -1098,7 +1103,7 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
               photoId={marker.photoId}
               filename={marker.displayName ?? marker.name}
               originalFilename={marker.displayName ? marker.name : undefined}
-              timestamp={marker.capturedAt.timestamp}
+              timestamp={marker.capturedAt?.timestamp}
               flag={marker.flag}
               storage={props.photoStorage}
               photosDir={props.photoDir}

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFan.ts
@@ -10,10 +10,14 @@
 //                  place. Endpoints are unprojected back to lng/lat so the GL
 //                  layer tracks the map natively between recomputes.
 //
-// Overlap depends on zoom, so the fan recomputes on `moveend`/`zoomend` (the
-// settle events — not `move`/`zoom`, which fire every frame). It also
-// recomputes when the marker set changes or when a marker enters/leaves drag
-// (the dragged marker is excluded so its dot snaps cleanly to the cursor).
+// Overlap depends on zoom, so the fan recomputes on `moveend`/`zoomend` AND on
+// the per-frame `zoom` event — the offset is a SCREEN-PIXEL vector, valid only
+// at the zoom it was projected at, so it must keep up with a zoom in flight or
+// the dot rides a stale offset and slides off its true point until the gesture
+// settles. A pure pan (`move`) is deliberately NOT subscribed: translation
+// preserves the markers' relative screen positions, so the offsets stay valid.
+// It also recomputes when the marker set changes or when a marker enters/leaves
+// drag (the dragged marker is excluded so its dot snaps cleanly to the cursor).
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
@@ -169,11 +173,21 @@ export function useMarkerFan(params: {
     const bump = () => { if (draggingRef.current == null) setSettleTick(t => t + 1) }
     map.on('moveend', bump)
     map.on('zoomend', bump)
+    // Per-frame during a continuous/animated zoom (wheel, pinch, +/- buttons,
+    // flyTo/fitBounds). Without this the fanned dot keeps its pre-zoom pixel
+    // offset layered on the (correctly re-projected) geo-anchor and visibly
+    // drifts relative to the basemap until the gesture settles — the "placed
+    // photo doesn't stay put on zoom" report. The `draggingRef` guard keeps it a
+    // no-op during an edge-pan marker drag, preserving the ~60fps optimisation
+    // that motivated the settle-only choice. Pan (`move`) stays unsubscribed
+    // because translation doesn't change markers' relative screen positions.
+    map.on('zoom', bump)
     // Initial compute once the map is ready (no settle event fires on load).
     bump()
     return () => {
       map.off('moveend', bump)
       map.off('zoomend', bump)
+      map.off('zoom', bump)
     }
   }, [isMapLoaded, mapRef])
 

--- a/frontend/map-corridors/src/map/photoLayers/useMarkerFanZoom.test.tsx
+++ b/frontend/map-corridors/src/map/photoLayers/useMarkerFanZoom.test.tsx
@@ -1,0 +1,54 @@
+// Regression test for the bug #6 fix (2.26.2): the marker-fan recompute must
+// subscribe to the per-frame `zoom` event — not only the `moveend`/`zoomend`
+// settle events — so a fanned dot's screen-pixel offset stays valid *during* a
+// continuous zoom instead of drifting until the gesture settles. It must also
+// unsubscribe every listener it added on unmount (no leak). The pure projection
+// boundary (`buildMarkerFan`) is covered separately in `useMarkerFan.test.ts`;
+// this file pins the effect's event wiring, which had no coverage.
+
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { RefObject } from 'react'
+import type { MapRef } from 'react-map-gl/mapbox'
+import { useMarkerFan } from './useMarkerFan'
+
+function fakeMapRef() {
+  const on = vi.fn()
+  const off = vi.fn()
+  const map = { on, off }
+  // Only `getMap().on/off` are exercised here: with `markers: undefined` the
+  // projection memo returns EMPTY without ever calling project/unproject, so a
+  // minimal fake map is enough.
+  const ref = { current: { getMap: () => map } } as unknown as RefObject<MapRef | null>
+  return { ref, on, off }
+}
+
+describe('useMarkerFan — viewport event subscriptions', () => {
+  it('subscribes to the per-frame `zoom` event plus the settle events', () => {
+    const { ref, on } = fakeMapRef()
+    renderHook(() =>
+      useMarkerFan({ mapRef: ref, isMapLoaded: true, markers: undefined, draggingMarkerId: null }),
+    )
+    const events = on.mock.calls.map((c) => c[0])
+    expect(events).toContain('zoom') // the bug #6 fix — keeps fanned dots anchored mid-zoom
+    expect(events).toContain('moveend')
+    expect(events).toContain('zoomend')
+  })
+
+  it('unsubscribes every listener it added on unmount (no leak)', () => {
+    const { ref, on, off } = fakeMapRef()
+    const { unmount } = renderHook(() =>
+      useMarkerFan({ mapRef: ref, isMapLoaded: true, markers: undefined, draggingMarkerId: null }),
+    )
+    unmount()
+    // Symmetry: every (event, handler) pair handed to on() is handed to off()
+    // with the SAME handler reference, not merely the same event name.
+    for (const call of on.mock.calls) {
+      expect(off.mock.calls).toContainEqual(call)
+    }
+    const offEvents = off.mock.calls.map((c) => c[0])
+    expect(offEvents).toContain('zoom')
+    expect(offEvents).toContain('moveend')
+    expect(offEvents).toContain('zoomend')
+  })
+})

--- a/frontend/map-corridors/src/photoImport/importPhotosToStorage.ts
+++ b/frontend/map-corridors/src/photoImport/importPhotosToStorage.ts
@@ -8,9 +8,19 @@
 import type { StorageInterface, DirectoryHandle } from '@airq/shared-storage'
 import { importPhotoFiles } from './importPhotoFiles'
 import type { ImportPhotoFilesOpts } from './importPhotoFiles'
-import type { ImportResult } from './types'
+import type { ImportDuplicate, ImportResult } from './types'
 
-export type ImportPhotosToStorageOpts = ImportPhotoFilesOpts
+export interface ImportPhotosToStorageOpts extends ImportPhotoFilesOpts {
+  /**
+   * SHA-1 hashes already present in the session (markers + no-GPS tray). A
+   * freshly-read file whose hash matches one of these — or an earlier file in
+   * the SAME batch — is reported in `result.duplicates` and NOT saved, so the
+   * existing photo (and its placement / flag / edits) is preserved and no orphan
+   * blob is written. ADR-020 re-import dedup. Omit to disable cross-session
+   * dedup; intra-batch dedup always runs.
+   */
+  existingContentHashes?: ReadonlySet<string>
+}
 
 /**
  * Run the Phase 1 import pipeline, then persist each successful import
@@ -32,6 +42,26 @@ export async function importPhotosToStorage(
   opts: ImportPhotosToStorageOpts = {},
 ): Promise<ImportResult> {
   const result = await importPhotoFiles(files, opts)
+
+  // ADR-020 re-import dedup. Drop any read whose content hash already exists in
+  // the session, or repeats within this batch, BEFORE saving — so a duplicate
+  // never writes a second blob and never produces a second marker / tray entry.
+  // `seen` is seeded with the session's hashes; each kept file adds its own so a
+  // file dropped twice in one batch only lands once.
+  const seen = new Set<string>(opts.existingContentHashes ?? [])
+  const duplicates: ImportDuplicate[] = []
+  const fresh: ImportResult['ok'] = []
+  for (const photo of result.ok) {
+    if (seen.has(photo.contentHash)) {
+      duplicates.push({ filename: photo.file.name, contentHash: photo.contentHash })
+    } else {
+      seen.add(photo.contentHash)
+      fresh.push(photo)
+    }
+  }
+  result.ok = fresh
+  if (duplicates.length > 0) result.duplicates = duplicates
+
   if (result.ok.length === 0) return result
 
   const persisted = await Promise.all(result.ok.map(async (photo) => {

--- a/frontend/map-corridors/src/photoImport/types.ts
+++ b/frontend/map-corridors/src/photoImport/types.ts
@@ -40,7 +40,21 @@ export interface ImportFailure {
   message: string
 }
 
+/** A file skipped because its bytes match an already-imported photo (ADR-020). */
+export interface ImportDuplicate {
+  filename: string
+  /** SHA-1 hex that matched an existing photo (or an earlier file in the batch). */
+  contentHash: string
+}
+
 export interface ImportResult {
   ok: ImportedPhoto[]
   failed: ImportFailure[]
+  /**
+   * Files dropped as re-imports of a photo already in the session, or duplicated
+   * within the same batch. Populated by `importPhotosToStorage` (which has the
+   * existing-hash set); `importPhotoFiles` alone never dedups, so it omits this.
+   * Duplicates are NOT saved — the original photo is preserved untouched.
+   */
+  duplicates?: ImportDuplicate[]
 }

--- a/frontend/map-corridors/src/recategorize/recategorize.ts
+++ b/frontend/map-corridors/src/recategorize/recategorize.ts
@@ -5,7 +5,7 @@
 
 import type { PhotoFlag } from '../types/markers'
 
-export type PanelGroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
+export type PanelGroupKey = 'picksTurning' | 'picksTrack' | 'neutral' | 'rejects' | 'noGps'
 
 /**
  * The flag a photo takes when dropped into a group. `null` = neutral (flag
@@ -14,9 +14,12 @@ export type PanelGroupKey = 'picks' | 'neutral' | 'rejects' | 'noGps'
  */
 export function flagForGroup(key: PanelGroupKey): PhotoFlag | null | undefined {
   switch (key) {
-    // Dropping into the picks section defaults to track; the user re-categorizes
-    // to turning-point via the marker popup. (A neutral pick category isn't a thing.)
-    case 'picks': return 'pick-track'
+    // The two pick sections set their category directly — dropping a photo onto
+    // "turning-point picks" sets pick-turning, onto "track picks" sets
+    // pick-track. So the user can re-flag turning↔track just by dragging the row
+    // between the two groups (no marker-popup round-trip needed).
+    case 'picksTurning': return 'pick-turning'
+    case 'picksTrack': return 'pick-track'
     case 'neutral': return null
     case 'rejects': return 'reject'
     default: return undefined // noGps — not a recategorize target

--- a/frontend/map-corridors/src/types/markers.ts
+++ b/frontend/map-corridors/src/types/markers.ts
@@ -55,6 +55,13 @@ export type PhotoMarker = Readonly<{
   // Drives the "newer wins" conflict resolution in `useEditorPicksSync`
   // and `useMapPicksSync` (label may be set in either app now).
   labelUpdatedAt?: string
+  /**
+   * SHA-1 hex of the original file bytes (ADR-020). Assigned at import and
+   * carried across `placeNoGpsPhoto`. Lets a re-import of the same photo be
+   * rejected so a duplicate never overwrites the original. Optional — absent on
+   * pre-ADR-020 sessions and on KML/click-placed markers.
+   */
+  contentHash?: string
 }>
 
 // Ground marker types — FAI precision flying canvas shapes (12 letters + 14 symbols).
@@ -138,7 +145,8 @@ export function isPhotoMarker(value: unknown): value is PhotoMarker {
     isValidCapturedAt(v.capturedAt) &&
     (v.photoId === undefined || (typeof v.photoId === 'string' && v.photoId.length > 0)) &&
     (v.flag === undefined || (typeof v.flag === 'string' && PHOTO_FLAG_SET.has(v.flag))) &&
-    (v.labelUpdatedAt === undefined || typeof v.labelUpdatedAt === 'string')
+    (v.labelUpdatedAt === undefined || typeof v.labelUpdatedAt === 'string') &&
+    (v.contentHash === undefined || typeof v.contentHash === 'string')
   )
 }
 
@@ -181,6 +189,8 @@ export type NoGpsPhoto = Readonly<{
   displayName?: string
   /** ISO 8601 EXIF DateTimeOriginal; used for tray sort order. Optional — some cameras don't set it. */
   timestamp?: string
+  /** SHA-1 hex of the original file bytes (ADR-020) — re-import dedup. See `PhotoMarker.contentHash`. */
+  contentHash?: string
 }>
 
 export function isNoGpsPhoto(value: unknown): value is NoGpsPhoto {
@@ -190,7 +200,8 @@ export function isNoGpsPhoto(value: unknown): value is NoGpsPhoto {
     typeof v.photoId === 'string' && v.photoId.length > 0 &&
     typeof v.filename === 'string' && v.filename.length > 0 &&
     (v.displayName === undefined || typeof v.displayName === 'string') &&
-    (v.timestamp === undefined || typeof v.timestamp === 'string')
+    (v.timestamp === undefined || typeof v.timestamp === 'string') &&
+    (v.contentHash === undefined || typeof v.contentHash === 'string')
   )
 }
 

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -280,6 +280,11 @@ function AppApi() {
   // appearing isn't a mystery.
   const [dupToast, setDupToast] = useState<{ count: number } | null>(null);
 
+  // Friendly, actionable surface for a PDF export failure (replaces a raw
+  // native alert showing the technical message). Most failures are "a photo
+  // lost its image bytes"; the message tells the user how to recover.
+  const [pdfError, setPdfError] = useState<string | null>(null);
+
   // Hint snackbar for cross-set slot→slot drags (out of scope in v1 per
   // docs/CANDIDATE_PHOTOS.md). Previously a silent no-op (PR #62 review I4).
   const [crossSetHintOpen, setCrossSetHintOpen] = useState(false);
@@ -678,8 +683,17 @@ function AppApi() {
       // user needs to know the export was aborted (or partial), not be left
       // wondering why the dialog never opened.
       console.error('PDF generation failed:', error);
-      const message = error instanceof Error ? error.message : String(error);
-      alert(message);
+      // The hi-res render path attaches `renderFailures` (one entry per
+      // un-renderable photo — usually missing image bytes from a photo that was
+      // deleted earlier). Turn that into a plain-language, actionable message
+      // instead of dumping the raw technical string into a native alert().
+      const failures = (error as { renderFailures?: unknown[] } | null)?.renderFailures;
+      const failedCount = Array.isArray(failures) ? failures.length : 0;
+      setPdfError(
+        failedCount > 0
+          ? t('pdf.error.renderFailed', { count: failedCount })
+          : t('pdf.error.generic'),
+      );
     }
   };
 
@@ -1364,6 +1378,7 @@ function AppApi() {
                         setKey={selectedPhoto.setKey}
                         showOriginal={showOriginal}
                         circleMode={circleMode}
+                        mode={session?.mode}
                       />
                       {/* Filename caption under the photo — screen only. */}
                       {selectedPhoto.photo.filename && (
@@ -1585,6 +1600,20 @@ function AppApi() {
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         message={dupToast ? t('candidates.duplicatesSkipped', { count: dupToast.count }) : ''}
       />
+
+      {/* PDF export failure — friendly, actionable surface that replaces the raw
+          native alert. Stays up longer and is dismissible because the message
+          tells the user how to recover (re-import / remove the affected cells). */}
+      <Snackbar
+        open={Boolean(pdfError)}
+        autoHideDuration={14000}
+        onClose={() => setPdfError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity="error" variant="filled" onClose={() => setPdfError(null)} sx={{ maxWidth: 560 }}>
+          {pdfError}
+        </Alert>
+      </Snackbar>
 
       {/* Hint when the user tries an unsupported cross-set slot drag (PR #62
           review I4). The two-step via the tray works; this just tells them. */}

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -110,6 +110,7 @@ function AppApi() {
     importPickToSets,
     removeCandidate,
     promoteCandidateToSlot,
+    addPlaceholderToSet,
     demoteSlotToCandidate,
     setCandidateFlag,
     setCandidateLabel,
@@ -1038,6 +1039,7 @@ function AppApi() {
             onCandidateDropped={(setKey, candidateId, slotIndex) =>
               handleCandidateDropped(setKey)(candidateId, slotIndex)
             }
+            onAddPlaceholder={addPlaceholderToSet ? (setKey, slotIndex) => { void addPlaceholderToSet(setKey, slotIndex); } : undefined}
             totalPhotoCount={stats.set1Photos + stats.set2Photos}
             isPrecision={isPrecision}
           />

--- a/frontend/photo-helper/src/AppApi.tsx
+++ b/frontend/photo-helper/src/AppApi.tsx
@@ -275,6 +275,11 @@ function AppApi() {
   // like the photos "disappeared" from the user's perspective.
   const [dropToast, setDropToast] = useState<{ count: number } | null>(null);
 
+  // Snackbar shown when "Add photos" skips files already in the session
+  // (content-hash re-import dedup, ADR-020) — so fewer-than-selected photos
+  // appearing isn't a mystery.
+  const [dupToast, setDupToast] = useState<{ count: number } | null>(null);
+
   // Hint snackbar for cross-set slot→slot drags (out of scope in v1 per
   // docs/CANDIDATE_PHOTOS.md). Previously a silent no-op (PR #62 review I4).
   const [crossSetHintOpen, setCrossSetHintOpen] = useState(false);
@@ -296,6 +301,15 @@ function AppApi() {
     }
   };
 
+  // Wrapper around the hook's `addPhotosToCandidates` that surfaces the re-import
+  // dedup (ADR-020). The dedup happens hook-side for every caller; this only adds
+  // the toast at the user-facing import sites so a skipped duplicate isn't silent.
+  const handleAddCandidates = async (files: File[]) => {
+    if (!addPhotosToCandidates) return;
+    const r = await addPhotosToCandidates(files);
+    if (r && r.duplicates > 0) setDupToast({ count: r.duplicates });
+  };
+
   // Initial drop for rally turning-point distributes across set1+set2; on total
   // overflow the hook routes everything to the candidate tray. Surface the toast
   // the same way `handleAddToSet` does (PR #62 review I1).
@@ -314,7 +328,7 @@ function AppApi() {
   // loaded so a pre-mount paste can't race the session bootstrap.
   const { pasteError, clearPasteError } = useClipboardPaste({
     addFiles: (files) => {
-      if (addPhotosToCandidates) void addPhotosToCandidates(files);
+      void handleAddCandidates(files);
     },
     disabled: !session || !addPhotosToCandidates,
   });
@@ -854,7 +868,7 @@ function AppApi() {
                   </Typography>
                   <ImportPhotosControl
                     onFilesPicked={(files) => {
-                      if (addPhotosToCandidates) void addPhotosToCandidates(files);
+                      void handleAddCandidates(files);
                     }}
                     disabled={!session || !addPhotosToCandidates}
                   />
@@ -975,7 +989,7 @@ function AppApi() {
         {(candidatePhotos.length > 0 || stats.totalPhotos > 0) && (
           <CandidateTray
             photos={candidatePhotos}
-            onAddFiles={(files) => { if (addPhotosToCandidates) void addPhotosToCandidates(files); }}
+            onAddFiles={(files) => { void handleAddCandidates(files); }}
             onPhotoClick={handleCandidateClick}
             onSetFlag={(photoId, flag) => { if (setCandidateFlag) void setCandidateFlag(photoId, flag); }}
             onDelete={(photoId) => { if (removeCandidate) void removeCandidate(photoId); }}
@@ -1560,6 +1574,16 @@ function AppApi() {
         onClose={() => setDropToast(null)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
         message={dropToast ? t('candidates.smartDropToast', { count: dropToast.count }) : ''}
+      />
+
+      {/* Re-import dedup notification — "Add photos" skipped files already in the
+          session, so the user doesn't think their pick silently vanished. */}
+      <Snackbar
+        open={Boolean(dupToast)}
+        autoHideDuration={6000}
+        onClose={() => setDupToast(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        message={dupToast ? t('candidates.duplicatesSkipped', { count: dupToast.count }) : ''}
       />
 
       {/* Hint when the user tries an unsupported cross-set slot drag (PR #62

--- a/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
+++ b/frontend/photo-helper/src/__tests__/buildPdfSets.test.ts
@@ -43,6 +43,24 @@ describe('buildPdfSets — turningpoint mode', () => {
     ]);
   });
 
+  it('rally: a "no photo" placeholder holds its slot number; surrounding labels are unaffected', () => {
+    const placeholder: ApiPhoto = { ...makePhoto('ph'), isPlaceholder: true, url: '' };
+    const result = buildPdfSets({
+      mode: 'turningpoint',
+      layoutMode: 'landscape',
+      isPrecision: false,
+      // The 2nd photo is missing — a placeholder holds the TP1 position so the
+      // following photos keep TP2/TP3 (numbering not shifted).
+      set1: { title: 'SP - TP3', photos: [makePhoto('a'), placeholder, makePhoto('c'), makePhoto('d')] },
+      set2: makeSet('FP', ['f']),
+      generateLabel: letterLabel,
+    });
+    expect(result.set1WithLabels.photos.map(p => p.label)).toEqual(['SP', 'TP1', 'TP2', 'TP3']);
+    // The placeholder IS the TP1 cell and keeps its flag for the PDF render branch.
+    expect(result.set1WithLabels.photos[1].isPlaceholder).toBe(true);
+    expect(result.set2WithLabels.photos.map(p => p.label)).toEqual(['FP']);
+  });
+
   it('precision: set2 photos dropped, set1 labeled SP + TP1..TP7 + FP (9 photos)', () => {
     const result = buildPdfSets({
       mode: 'turningpoint',

--- a/frontend/photo-helper/src/__tests__/placeholderPhoto.test.ts
+++ b/frontend/photo-helper/src/__tests__/placeholderPhoto.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { insertPlaceholderIntoSet } from '../utils/candidateTransitions';
+import { insertPlaceholderIntoSet, demoteSlotToCandidate } from '../utils/candidateTransitions';
 import { createPlaceholderPhoto, PLACEHOLDER_ID_PREFIX, isPlaceholderId } from '../utils/placeholderPhoto';
 import type { ApiPhoto, ApiPhotoSession } from '../types/api';
 
@@ -75,5 +75,16 @@ describe('insertPlaceholderIntoSet', () => {
     const session = makeTurningSession([makePhoto('a'), makePhoto('b')]);
     insertPlaceholderIntoSet(session, 'set1', 1, createPlaceholderPhoto('s', 'x'));
     expect(session.sets.set1.photos.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+});
+
+describe('placeholders never enter the candidate tray', () => {
+  it('demoteSlotToCandidate is a no-op on a placeholder (would create a dead-url tray entry)', () => {
+    const ph = createPlaceholderPhoto('sess-1', 'Bez fotky');
+    const session = makeTurningSession([ph]);
+    const next = demoteSlotToCandidate(session, 'set1', ph.id);
+    expect(next).toBe(session); // unchanged reference — the guard returns early
+    expect(next.candidates?.photos).toEqual([]);
+    expect(next.sets.set1.photos.map((p) => p.id)).toEqual([ph.id]);
   });
 });

--- a/frontend/photo-helper/src/__tests__/placeholderPhoto.test.ts
+++ b/frontend/photo-helper/src/__tests__/placeholderPhoto.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { insertPlaceholderIntoSet } from '../utils/candidateTransitions';
+import { createPlaceholderPhoto, PLACEHOLDER_ID_PREFIX, isPlaceholderId } from '../utils/placeholderPhoto';
+import type { ApiPhoto, ApiPhotoSession } from '../types/api';
+
+function makePhoto(id: string): ApiPhoto {
+  return {
+    id,
+    sessionId: 'sess-1',
+    url: `blob:${id}`,
+    filename: `${id}.jpg`,
+    canvasState: {
+      position: { x: 0, y: 0 }, scale: 1, brightness: 0, contrast: 1, sharpness: 0,
+      whiteBalance: { temperature: 0, tint: 0, auto: false }, labelPosition: 'bottom-left',
+    } as ApiPhoto['canvasState'],
+    label: '',
+  };
+}
+
+function makeTurningSession(set1: ApiPhoto[], set2: ApiPhoto[] = []): ApiPhotoSession {
+  return {
+    id: 'sess-1', version: 1, createdAt: 'x', updatedAt: 'x', mode: 'turningpoint',
+    competition_name: 'Test',
+    sets: { set1: { title: '', photos: set1 }, set2: { title: '', photos: set2 } },
+    candidates: { photos: [] },
+  } as ApiPhotoSession;
+}
+
+describe('createPlaceholderPhoto', () => {
+  it('builds a blank, image-less placeholder photo', () => {
+    const p = createPlaceholderPhoto('sess-1', 'Bez fotky');
+    expect(p.isPlaceholder).toBe(true);
+    expect(p.url).toBe('');
+    expect(p.filename).toBe('Bez fotky');
+    expect(p.label).toBe('');
+    expect(p.id.startsWith(PLACEHOLDER_ID_PREFIX)).toBe(true);
+    expect(isPlaceholderId(p.id)).toBe(true);
+    expect(p.canvasState).toBeTruthy();
+  });
+
+  it('gives each placeholder a unique id', () => {
+    expect(createPlaceholderPhoto('s', 'x').id).not.toBe(createPlaceholderPhoto('s', 'x').id);
+  });
+});
+
+describe('insertPlaceholderIntoSet', () => {
+  it('inserts at the slot index, pushing later photos down (numbering preserved)', () => {
+    const session = makeTurningSession([makePhoto('a'), makePhoto('b'), makePhoto('c')]);
+    const ph = createPlaceholderPhoto('sess-1', 'Bez fotky');
+    const next = insertPlaceholderIntoSet(session, 'set1', 1, ph);
+    expect(next.sets.set1.photos.map((p) => p.id)).toEqual(['a', ph.id, 'b', 'c']);
+    expect(next.sets.set1.photos[1].isPlaceholder).toBe(true);
+    expect(next.version).toBe(session.version + 1);
+  });
+
+  it('clamps an out-of-range index (past end → append, negative → 0)', () => {
+    const session = makeTurningSession([makePhoto('a'), makePhoto('b')]);
+    const ph1 = createPlaceholderPhoto('s', 'x');
+    expect(insertPlaceholderIntoSet(session, 'set1', 99, ph1).sets.set1.photos.map((p) => p.id))
+      .toEqual(['a', 'b', ph1.id]);
+    const ph2 = createPlaceholderPhoto('s', 'x');
+    expect(insertPlaceholderIntoSet(session, 'set1', -5, ph2).sets.set1.photos.map((p) => p.id))
+      .toEqual([ph2.id, 'a', 'b']);
+  });
+
+  it('mirrors into the active mode bucket (setsTurning === sets)', () => {
+    const session = makeTurningSession([makePhoto('a')]);
+    const next = insertPlaceholderIntoSet(session, 'set1', 0, createPlaceholderPhoto('s', 'x')) as unknown as {
+      setsTurning: unknown; sets: unknown;
+    };
+    expect(next.setsTurning).toEqual(next.sets);
+  });
+
+  it('does not mutate the input session', () => {
+    const session = makeTurningSession([makePhoto('a'), makePhoto('b')]);
+    insertPlaceholderIntoSet(session, 'set1', 1, createPlaceholderPhoto('s', 'x'));
+    expect(session.sets.set1.photos.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+});

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -728,6 +728,47 @@ describe('useCompetitionSystem — addExistingCandidate sequential race (handoff
     expect((await storageMock.listDirectory(photosDir)).map(e => e.name)).toContain(pmId);
   });
 
+  // Regression: feedback 2026-06-19. Same shared-blob hazard as removeCandidate,
+  // but via the SET delete path — the user deleted PLACED turning photos in the
+  // editor, re-sent 9 from corridors, and only 7 returned because `removePhoto`
+  // lacked the pm- guard its sibling delete paths already had, so it stranded the
+  // shared bytes for the deleted photos.
+  it('removePhoto KEEPS the OPFS file for a pm-prefixed photo placed in a set', async () => {
+    const result = await setup();
+    const compId = result.current.currentCompetition!.id;
+    const photosDir = { path: `/competitions/${compId}/photos` } as DirectoryHandle;
+    const pmId = 'pm-set-photo-1';
+    await storageMock.savePhotoFile(photosDir, pmId, makeFile('pm.jpg'));
+
+    // Get the pm- photo into a set via the candidate → slot promotion path.
+    await act(async () => {
+      await result.current.addExistingCandidate({
+        id: pmId,
+        sessionId: result.current.session!.id,
+        url: 'blob:test/pm-set',
+        filename: 'pm.jpg',
+        canvasState: {
+          position: { x: 0, y: 0 }, scale: 1, brightness: 0, contrast: 1,
+          sharpness: 0, whiteBalance: { temperature: 0, tint: 0, auto: false },
+          labelPosition: 'bottom-left' as const,
+        },
+        label: '',
+        flag: 'pick',
+      });
+      await result.current.promoteCandidateToSlot(pmId, 'set1', 0);
+    });
+    expect(result.current.session!.sets.set1.photos.map(p => p.id)).toContain(pmId);
+
+    await act(async () => {
+      await result.current.removePhoto('set1', pmId);
+    });
+
+    // Removed from the set (what the user wanted)...
+    expect(result.current.session!.sets.set1.photos.map(p => p.id)).not.toContain(pmId);
+    // ...but the shared OPFS bytes survive so the next handoff re-inserts it.
+    expect((await storageMock.listDirectory(photosDir)).map(e => e.name)).toContain(pmId);
+  });
+
   it('deleteCandidates KEEPS OPFS files for pm-prefixed photos but deletes non-pm', async () => {
     const result = await setup();
     const compId = result.current.currentCompetition!.id;

--- a/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
+++ b/frontend/photo-helper/src/__tests__/useCompetitionSystem.candidates.test.tsx
@@ -170,7 +170,11 @@ beforeEach(async () => {
 afterEach(() => { vi.restoreAllMocks(); });
 
 function makeFile(name = 'photo.jpg'): File {
-  return new File([new Uint8Array([0xFF, 0xD8, 0xFF])], name, { type: 'image/jpeg' });
+  // Unique content per name so the content-hash re-import dedup doesn't collapse
+  // distinct fixtures; keep the JPEG magic-byte prefix. Two calls with the SAME
+  // name produce identical bytes — used to exercise dedup.
+  const nameBytes = Array.from(name, (c) => c.charCodeAt(0) & 0xff);
+  return new File([new Uint8Array([0xFF, 0xD8, 0xFF, ...nameBytes])], name, { type: 'image/jpeg' });
 }
 
 async function setup() {
@@ -296,6 +300,45 @@ describe('useCompetitionSystem — promoteCandidateToSlot capacity clamp (PR #62
     const session = result.current.session!;
     expect(session.sets.set1.photos.map(p => p.id)).toEqual([candidateId]);
     expect(session.setsTrack?.set1.photos.map(p => p.id)).toEqual([candidateId]);
+  });
+});
+
+describe('useCompetitionSystem — addPhotosToCandidates re-import dedup (ADR-020)', () => {
+  it('adds distinct files and reports zero duplicates', async () => {
+    const result = await setup();
+    let r: { added: number; duplicates: number } | undefined;
+    await act(async () => {
+      r = await result.current.addPhotosToCandidates([makeFile('a.jpg'), makeFile('b.jpg')]);
+    });
+    expect(r).toEqual({ added: 2, duplicates: 0 });
+    expect(result.current.session!.candidates!.photos).toHaveLength(2);
+  });
+
+  it('skips a file already in the candidate tray on a later import', async () => {
+    const result = await setup();
+    await act(async () => {
+      await result.current.addPhotosToCandidates([makeFile('dup.jpg')]);
+    });
+    let r: { added: number; duplicates: number } | undefined;
+    await act(async () => {
+      r = await result.current.addPhotosToCandidates([makeFile('dup.jpg'), makeFile('new.jpg')]);
+    });
+    expect(r).toEqual({ added: 1, duplicates: 1 });
+    // 1 original + 1 genuinely-new = 2; the re-import of dup.jpg was dropped.
+    expect(result.current.session!.candidates!.photos.map(p => p.filename).sort())
+      .toEqual(['dup.jpg', 'new.jpg']);
+  });
+
+  it('dedups within a single batch and stamps a SHA-1 contentHash on the kept photo', async () => {
+    const result = await setup();
+    let r: { added: number; duplicates: number } | undefined;
+    await act(async () => {
+      r = await result.current.addPhotosToCandidates([makeFile('x.jpg'), makeFile('x.jpg')]);
+    });
+    expect(r).toEqual({ added: 1, duplicates: 1 });
+    const photos = result.current.session!.candidates!.photos;
+    expect(photos).toHaveLength(1);
+    expect(photos[0].contentHash).toMatch(/^[0-9a-f]{40}$/);
   });
 });
 

--- a/frontend/photo-helper/src/components/CandidateTray.tsx
+++ b/frontend/photo-helper/src/components/CandidateTray.tsx
@@ -479,6 +479,33 @@ const CandidateThumb: React.FC<CandidateThumbProps> = ({
         </Box>
       </Box>
 
+      {/* Filename caption — screen-only orientation aid shown above the move/
+          delete controls (feedback 2026-06-19). Mirrors the print-set slot tiles
+          (PhotoGridApi). The ellipsis clamp is mandatory: the thumb is a fixed
+          width, so an unclamped name would wrap and break the flex-wrap grid.
+          Full name on hover via the title attribute. */}
+      {photo.filename && (
+        <Typography
+          variant="caption"
+          title={photo.filename}
+          sx={{
+            display: 'block',
+            px: 0.5,
+            pt: 0.25,
+            fontFamily: 'monospace',
+            fontSize: '0.65rem',
+            color: 'text.secondary',
+            textAlign: 'center',
+            lineHeight: 1.2,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {photo.filename}
+        </Typography>
+      )}
+
       {/* Always-visible control toolbar. Left-click only — no right-click menu
           (first dev-test feedback 2026-05-12). Flag toggles act radio-like:
           clicking the active flag clears it back to neutral. */}

--- a/frontend/photo-helper/src/components/ImportPhotosControl.tsx
+++ b/frontend/photo-helper/src/components/ImportPhotosControl.tsx
@@ -86,10 +86,12 @@ export const ImportPhotosControl: React.FC<ImportPhotosControlProps> = ({
     ? 'success.main'
     : isDragActive
     ? 'primary.main'
-    // Idle: primary-tinted (was grey) so the always-visible add-photos entry
-    // point reads as an action and is easy to find, including on an empty
-    // competition where it sits beside the hero drop zone (feedback 2026-06-19).
-    : 'primary.main';
+    // Idle: a lighter primary tint (was grey) so the always-visible add-photos
+    // entry point reads as an action and is easy to find, including on an empty
+    // competition beside the hero drop zone — while staying visually distinct
+    // from the solid primary.main border that marks the drag-active state
+    // (feedback 2026-06-19).
+    : 'primary.light';
 
   const bgColor = isDragReject
     ? 'error.light'

--- a/frontend/photo-helper/src/components/ImportPhotosControl.tsx
+++ b/frontend/photo-helper/src/components/ImportPhotosControl.tsx
@@ -86,7 +86,10 @@ export const ImportPhotosControl: React.FC<ImportPhotosControlProps> = ({
     ? 'success.main'
     : isDragActive
     ? 'primary.main'
-    : 'grey.400';
+    // Idle: primary-tinted (was grey) so the always-visible add-photos entry
+    // point reads as an action and is easy to find, including on an empty
+    // competition where it sits beside the hero drop zone (feedback 2026-06-19).
+    : 'primary.main';
 
   const bgColor = isDragReject
     ? 'error.light'
@@ -126,7 +129,7 @@ export const ImportPhotosControl: React.FC<ImportPhotosControlProps> = ({
         ) : (
           <CloudUpload sx={{ fontSize: 20, color: 'primary.main' }} />
         )}
-        <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 500, whiteSpace: 'nowrap' }}>
+        <Typography variant="body2" sx={{ fontSize: '0.8rem', fontWeight: 600, color: 'primary.main', whiteSpace: 'nowrap' }}>
           {label}
         </Typography>
       </Box>

--- a/frontend/photo-helper/src/components/PhotoEditorApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoEditorApi.tsx
@@ -26,6 +26,10 @@ interface PhotoEditorApiProps {
   setKey?: 'set1' | 'set2' | 'candidates'; // For PDF generation canvas identification
   showOriginal?: boolean; // Whether to show original (no effects) or edited version
   circleMode?: boolean; // Whether circle mode is enabled
+  // Discipline of the set this photo belongs to — sizes the burned-in label per
+  // the user's per-mode preference (track −20%, turning −35%). Optional; absent
+  // (e.g. candidate-tray thumbs, which pass label="") keeps the default size.
+  mode?: 'track' | 'turningpoint';
 }
 
 // UNIFIED RENDERING SYSTEM - Same logic for grid and modal
@@ -109,7 +113,11 @@ export const renderPhotoOnCanvas = async (
   aspectRatio = 4/3,
   baseHeight = 225,
   showOriginal = false,
-  useHighQuality = false
+  useHighQuality = false,
+  // Discipline of the photo being rendered — drives the per-mode label font
+  // size in drawLabel (track −20%, turning −35%; feedback 2026-06-19). Optional
+  // so callers that don't care (or pre-date it) keep the default size.
+  mode?: 'track' | 'turningpoint'
 ) => {
   const ctx = getCanvasContext(canvas);
   if (!ctx) {
@@ -253,7 +261,7 @@ export const renderPhotoOnCanvas = async (
         ctx.drawImage(processedCanvas, x, y);
         // Draw label on main canvas
         const labelPos = isDragging && localLabelPosition ? localLabelPosition : canvasState.labelPosition;
-        drawLabel(canvas, label, labelPos);
+        drawLabel(canvas, label, labelPos, mode);
         return;
       }
     } catch (error) {
@@ -410,7 +418,7 @@ export const renderPhotoOnCanvas = async (
   // Draw label only when not dragging to save work while moving
   if (!isDragging) {
     const labelPos = isDragging && localLabelPosition ? localLabelPosition : canvasState.labelPosition;
-    drawLabel(canvas, label, labelPos);
+    drawLabel(canvas, label, labelPos, mode);
   }
 };
 
@@ -480,7 +488,8 @@ export const PhotoEditorApi: React.FC<PhotoEditorApiProps> = ({
   size = 'grid',
   setKey,
   showOriginal = false,
-  circleMode: externalCircleMode = false
+  circleMode: externalCircleMode = false,
+  mode
 }) => {
   const { currentRatio, getCanvasSize } = useAspectRatio();
   
@@ -721,7 +730,8 @@ export const PhotoEditorApi: React.FC<PhotoEditorApiProps> = ({
       currentRatio.ratio,
       BASE_WIDTH / currentRatio.ratio,
       (showOriginal || isDragging),
-      useHighQuality
+      useHighQuality,
+      mode
     );
 
     // Draw circle overlay if it exists
@@ -757,7 +767,7 @@ export const PhotoEditorApi: React.FC<PhotoEditorApiProps> = ({
       }
       ctx.drawImage(tempCanvas, 0, 0, canvasSize.width, canvasSize.height);
     }
-  }, [loadedImage, photo?.canvasState, photo?.canvasState?.brightness, photo?.canvasState?.contrast, photo?.canvasState?.scale, photo?.canvasState?.circle, label, canvasSize, localPosition, localLabelPosition, isDragging, isDraggingCircle, localCirclePosition, webglManager, currentRatio, showOriginal, circleMode, circlePreview, dragScaleFactor, size, isIdleHQ]);
+  }, [loadedImage, photo?.canvasState, photo?.canvasState?.brightness, photo?.canvasState?.contrast, photo?.canvasState?.scale, photo?.canvasState?.circle, label, canvasSize, localPosition, localLabelPosition, isDragging, isDraggingCircle, localCirclePosition, webglManager, currentRatio, showOriginal, circleMode, circlePreview, dragScaleFactor, size, isIdleHQ, mode]);
 
   useEffect(() => {
     renderCanvas().catch(error => {

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -89,7 +89,12 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   const { currentRatio, isTransitioning } = useAspectRatio();
   const { generateLabel } = useLabeling();
   const { t } = useI18n();
-  
+
+  // Turning-point sets supply customLabels (SP/TP1../FP); track sets don't.
+  // Reuse that existing signal to size the burned-in photo label per discipline
+  // (track −20%, turning −35%; feedback 2026-06-19).
+  const labelMode: 'track' | 'turningpoint' = customLabels ? 'turningpoint' : 'track';
+
   // Drag and drop state
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
@@ -321,6 +326,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                   onRemove={() => onPhotoRemove(slot.photo!.id)}
                   size="grid" // Small size for grid view
                   setKey={setKey} // Pass setKey for PDF generation
+                  mode={labelMode}
                 />
 
                 {/* Delete button — kept OUTSIDE the dark hover-overlay so it

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Typography, Paper, CircularProgress, IconButton, Tooltip } from '@mui/material';
+import { Box, Button, Typography, Paper, CircularProgress, IconButton, Tooltip } from '@mui/material';
 import { useTheme, alpha } from '@mui/material/styles';
 import { Image as ImageIcon, CloudUpload, Close } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
@@ -54,6 +54,12 @@ interface PhotoGridApiProps {
    */
   slotsOverride?: number;
   columnsOverride?: number;
+  /**
+   * Insert a "no photo" placeholder at the given slot index. Provided only in
+   * turning-point mode (the affordance is hidden on track sheets). Wired to the
+   * hook's `addPlaceholderToSet`.
+   */
+  onAddPlaceholder?: (slotIndex: number) => void;
 }
 
 interface GridSlot {
@@ -68,6 +74,8 @@ interface PhotoGridSlotEmptyProps {
   position: number;
   onFilesDropped?: (files: File[]) => void;
   maxFilesRemaining?: number;
+  /** When set (turning-point only), shows a "No photo" button that inserts a placeholder in this slot. */
+  onAddNoPhoto?: () => void;
 }
 
 export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
@@ -85,6 +93,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
   maxPhotosOverride,
   slotsOverride,
   columnsOverride,
+  onAddPlaceholder,
 }) => {
   const { currentRatio, isTransitioning } = useAspectRatio();
   const { generateLabel } = useLabeling();
@@ -303,9 +312,9 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
             >
             {slot.photo ? (
               <Box
-                onClick={() => onPhotoClick && onPhotoClick(slot.photo!)}
+                onClick={slot.photo.isPlaceholder ? undefined : () => onPhotoClick && onPhotoClick(slot.photo!)}
                 sx={{
-                  cursor: 'pointer',
+                  cursor: slot.photo.isPlaceholder ? 'default' : 'pointer',
                   width: '100%',
                   height: '100%',
                   position: 'relative',
@@ -318,16 +327,33 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                   }
                 }}
               >
-                <PhotoEditorApi
-                  key={slot.photo.id} // Stable key based on photo ID to prevent remounting
-                  photo={slot.photo}
-                  label={slot.label}
-                  onUpdate={(canvasState) => onPhotoUpdate(slot.photo!.id, canvasState)}
-                  onRemove={() => onPhotoRemove(slot.photo!.id)}
-                  size="grid" // Small size for grid view
-                  setKey={setKey} // Pass setKey for PDF generation
-                  mode={labelMode}
-                />
+                {slot.photo.isPlaceholder ? (
+                  // "No photo" placeholder cell: a blank frame holding the slot
+                  // position, with its TP/SP/FP label (bottom-left, mirroring
+                  // drawLabel) and a centered "No photo" caption. No PhotoEditorApi
+                  // (it has no image; routing it there would spin "Loading…" forever).
+                  <Box sx={{ width: '100%', height: '100%', position: 'relative', bgcolor: 'grey.100', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <Typography variant="body2" sx={{ color: 'text.disabled', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, userSelect: 'none' }}>
+                      {t('photo.noPhotoCell')}
+                    </Typography>
+                    {slot.label && (
+                      <Box sx={{ position: 'absolute', bottom: 4, left: 4, bgcolor: 'rgba(0, 0, 0, 0.7)', color: 'white', fontSize: '0.75rem', fontWeight: 600, px: 1, py: 0.25, borderRadius: 1, pointerEvents: 'none' }}>
+                        {slot.label}
+                      </Box>
+                    )}
+                  </Box>
+                ) : (
+                  <PhotoEditorApi
+                    key={slot.photo.id} // Stable key based on photo ID to prevent remounting
+                    photo={slot.photo}
+                    label={slot.label}
+                    onUpdate={(canvasState) => onPhotoUpdate(slot.photo!.id, canvasState)}
+                    onRemove={() => onPhotoRemove(slot.photo!.id)}
+                    size="grid" // Small size for grid view
+                    setKey={setKey} // Pass setKey for PDF generation
+                    mode={labelMode}
+                  />
+                )}
 
                 {/* Delete button — kept OUTSIDE the dark hover-overlay so it
                     has its own visibility. Previously embedded inside the
@@ -369,7 +395,9 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
 
                 {/* Hover overlay — dim + "click to edit" hint. Delete button
                     is now a sibling above, not a child, so its visibility no
-                    longer depends on the overlay opacity. */}
+                    longer depends on the overlay opacity. Hidden for placeholders
+                    (they aren't editable). */}
+                {!slot.photo.isPlaceholder && (
                 <Box
                   className="hover-overlay"
                   sx={{
@@ -398,6 +426,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                     {t('photo.clickToEdit')}
                   </Typography>
                 </Box>
+                )}
               </Box>
             ) : (
               <PhotoGridSlotEmpty
@@ -405,6 +434,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                 position={slot.index + 1}
                 onFilesDropped={onFilesDropped}
                 maxFilesRemaining={maxFilesRemaining}
+                onAddNoPhoto={labelMode === 'turningpoint' && onAddPlaceholder ? () => onAddPlaceholder(slot.index) : undefined}
               />
             )}
             </Paper>
@@ -412,7 +442,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                 canvases by data-photo-id, so this DOM text is never emitted
                 to print. Keeps the photo itself undisturbed for the
                 competitor's view (feedback 2026-04-23). */}
-            {slot.photo?.filename && (
+            {slot.photo?.filename && !slot.photo.isPlaceholder && (
               <Typography
                 variant="caption"
                 title={slot.photo.filename}
@@ -447,7 +477,8 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
   label,
   position: _position,
   onFilesDropped,
-  maxFilesRemaining
+  maxFilesRemaining,
+  onAddNoPhoto
 }) => {
   const theme = useTheme();
   const { t } = useI18n();
@@ -564,6 +595,20 @@ const PhotoGridSlotEmpty: React.FC<PhotoGridSlotEmptyProps> = ({
           <Typography variant="caption" sx={{ opacity: 0.7, textAlign: 'center', px: 1 }}>
             {t('upload.clickOrDrop')}
           </Typography>
+          {onAddNoPhoto && (
+            // Turning-point only: reserve this slot as a "no photo" placeholder
+            // so the surrounding TP numbering stays correct. stopPropagation +
+            // preventDefault so it doesn't trigger the dropzone's file picker.
+            <Button
+              size="small"
+              variant="text"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); e.preventDefault(); onAddNoPhoto(); }}
+              sx={{ mt: 0.75, fontSize: '0.7rem', textTransform: 'none', color: 'text.secondary', minWidth: 0, px: 1, '&:hover': { color: 'primary.main' } }}
+            >
+              {t('photo.addNoPhoto')}
+            </Button>
+          )}
         </>
       )}
     </Box>

--- a/frontend/photo-helper/src/components/PhotoGridApi.tsx
+++ b/frontend/photo-helper/src/components/PhotoGridApi.tsx
@@ -434,7 +434,7 @@ export const PhotoGridApi: React.FC<PhotoGridApiProps> = ({
                 position={slot.index + 1}
                 onFilesDropped={onFilesDropped}
                 maxFilesRemaining={maxFilesRemaining}
-                onAddNoPhoto={labelMode === 'turningpoint' && onAddPlaceholder ? () => onAddPlaceholder(slot.index) : undefined}
+                onAddNoPhoto={labelMode === 'turningpoint' && onAddPlaceholder && slot.index === photoSet.photos.length ? () => onAddPlaceholder(slot.index) : undefined}
               />
             )}
             </Paper>

--- a/frontend/photo-helper/src/components/TurningPointLayout.tsx
+++ b/frontend/photo-helper/src/components/TurningPointLayout.tsx
@@ -29,6 +29,8 @@ interface TurningPointLayoutProps {
    * omitted, candidate drops on a slot are ignored (back-compat).
    */
   onCandidateDropped?: (setKey: 'set1' | 'set2', candidateId: string, slotIndex: number) => void;
+  /** Insert a "no photo" placeholder at a slot in the given set (turning-point only). */
+  onAddPlaceholder?: (setKey: 'set1' | 'set2', slotIndex: number) => void;
   totalPhotoCount: number;
   /**
    * Precision discipline only uses a single set of up to 9 photos
@@ -54,6 +56,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
   onFilesDropped,
   onInitialFilesDropped,
   onCandidateDropped,
+  onAddPlaceholder,
   onPhotoClick,
   onPhotoUpdate,
   onPhotoRemove,
@@ -121,6 +124,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set1', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set1', files)}
                 onCandidateDropped={onCandidateDropped ? (id, idx) => onCandidateDropped('set1', id, idx) : undefined}
+                onAddPlaceholder={onAddPlaceholder ? (idx) => onAddPlaceholder('set1', idx) : undefined}
                 customLabels={turningPointLabels.set1}
                 maxPhotosOverride={rallyMaxPerSet}
                 slotsOverride={set1Grid?.slots}
@@ -145,6 +149,7 @@ export const TurningPointLayout: React.FC<TurningPointLayoutProps> = ({
                 onPhotoMove={(fromIndex, toIndex) => onPhotoMove('set2', fromIndex, toIndex)}
                 onFilesDropped={(files) => onFilesDropped('set2', files)}
                 onCandidateDropped={onCandidateDropped ? (id, idx) => onCandidateDropped('set2', id, idx) : undefined}
+                onAddPlaceholder={onAddPlaceholder ? (idx) => onAddPlaceholder('set2', idx) : undefined}
                 customLabels={turningPointLabels.set2}
                 maxPhotosOverride={rallyMaxPerSet}
                 slotsOverride={set2Grid?.slots}

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -828,7 +828,17 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       referencedElsewhere = isPhotoReferencedInSession(next, photoId);
       return next;
     }, { updatePhotos: true });
-    if (compId && !referencedElsewhere) {
+    // EXCEPTION: pm-prefixed photos are owned by map-corridors (shared
+    // `competitions/{compId}/photos/` dir). Deleting the file here strands the
+    // map marker — `getPhotoBlob` then NotFoundErrors on the next
+    // `useMapPicksSync` pass and the entry is silently skipped, so a re-Send
+    // brings back FEWER photos than were picked. Mirrors the guard in
+    // `removeCandidate` / `deleteCandidates` (user feedback 2026-05-17 added it
+    // there but THIS set-deletion path was missed — feedback 2026-06-19:
+    // "deleted in editor, re-sent 9, only 7 returned"). map-corridors' own
+    // hard-delete is the canonical place to free pm- bytes.
+    const isMapOwned = photoId.startsWith('pm-');
+    if (compId && !referencedElsewhere && !isMapOwned) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -28,7 +28,9 @@ import {
   clearAllCandidates as clearAllCandidatesPure,
   updateCandidateCanvasState as updateCandidateCanvasStatePure,
   routeImportedPickIntoSets,
+  insertPlaceholderIntoSet,
 } from '../utils/candidateTransitions';
+import { createPlaceholderPhoto, PLACEHOLDER_ID_PREFIX } from '../utils/placeholderPhoto';
 import { collectSessionContentHashes, partitionFilesByContentHash } from '../utils/contentHash';
 import {
   defaultTrackSetTitles,
@@ -89,6 +91,12 @@ export interface UseCompetitionSystemResult {
   importPickToSets: (photo: ApiPhoto, targetMode: 'track' | 'turningpoint') => Promise<void>;
   removeCandidate: (photoId: string) => Promise<void>;
   promoteCandidateToSlot: (candidateId: string, setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
+  /**
+   * Insert a "no photo" placeholder at `slotIndex` (turning-point mode), holding
+   * the slot position so the SP/TP/FP numbering of surrounding photos stays
+   * correct when a photo is missing. No-op if the set is already at capacity.
+   */
+  addPlaceholderToSet: (setKey: 'set1' | 'set2', slotIndex: number) => Promise<void>;
   demoteSlotToCandidate: (setKey: 'set1' | 'set2', photoId: string) => Promise<void>;
   setCandidateFlag: (photoId: string, flag: CandidateFlag) => Promise<void>;
   /**
@@ -838,7 +846,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // "deleted in editor, re-sent 9, only 7 returned"). map-corridors' own
     // hard-delete is the canonical place to free pm- bytes.
     const isMapOwned = photoId.startsWith('pm-');
-    if (compId && !referencedElsewhere && !isMapOwned) {
+    // Placeholders carry no OPFS file (url=''); a delete would throw a swallowed
+    // NotFoundError. Skip the file-delete for them too.
+    const isPlaceholder = photoId.startsWith(PLACEHOLDER_ID_PREFIX);
+    if (compId && !referencedElsewhere && !isMapOwned && !isPlaceholder) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {
@@ -887,7 +898,10 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     // canonical place to delete pm- bytes, and it cleans up both the
     // marker and the file in one shot. User feedback 2026-05-17.
     const isMapOwned = photoId.startsWith('pm-');
-    if (compId && !referencedElsewhere && !isMapOwned) {
+    // Placeholders carry no OPFS file (url=''); a delete would throw a swallowed
+    // NotFoundError. Skip the file-delete for them too.
+    const isPlaceholder = photoId.startsWith(PLACEHOLDER_ID_PREFIX);
+    if (compId && !referencedElsewhere && !isMapOwned && !isPlaceholder) {
       try {
         await competitionService.deletePhotosByIds(compId, [photoId]);
       } catch (err) {
@@ -922,6 +936,25 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
       return next;
     }, { updatePhotos: true });
   }, [updateCurrentCompetition]);
+
+  // Insert a "no photo" placeholder at a slot (turning-point only). Holds the
+  // position so SP/TP/FP numbering stays correct. The pure helper splices +
+  // mirrors into the active mode bucket; here we just gate on capacity and build
+  // the localized placeholder. updatePhotos:true persists; the placeholder has
+  // url='' so saveSessionPhotos skips it (no OPFS write).
+  const addPlaceholderToSet = useCallback(async (
+    setKey: 'set1' | 'set2',
+    slotIndex: number,
+  ) => {
+    const sess = currentCompetition?.session;
+    if (!sess) return;
+    const capacity = getGridCapacity(sess as any);
+    if ((sess.sets?.[setKey]?.photos?.length ?? 0) >= capacity) return;
+    await updateCurrentCompetition(session => {
+      const placeholder = createPlaceholderPhoto(session.id, t('photo.noPhotoFilename'));
+      return insertPlaceholderIntoSet(session, setKey, slotIndex, placeholder);
+    }, { updatePhotos: true });
+  }, [updateCurrentCompetition, currentCompetition, t]);
 
   const demoteSlotToCandidate = useCallback(async (
     setKey: 'set1' | 'set2',
@@ -1498,6 +1531,7 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     importPickToSets,
     removeCandidate,
     promoteCandidateToSlot,
+    addPlaceholderToSet,
     demoteSlotToCandidate,
     setCandidateFlag,
     setCandidateLabel,

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -947,7 +947,9 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
     slotIndex: number,
   ) => {
     const sess = currentCompetition?.session;
-    if (!sess) return;
+    // Turning-point only (the UI button is hidden on track sheets); guard here
+    // too so a stray call can't insert a placeholder into a track set.
+    if (!sess || sess.mode !== 'turningpoint') return;
     const capacity = getGridCapacity(sess as any);
     if ((sess.sets?.[setKey]?.photos?.length ?? 0) >= capacity) return;
     await updateCurrentCompetition(session => {

--- a/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
+++ b/frontend/photo-helper/src/hooks/useCompetitionSystem.ts
@@ -29,6 +29,7 @@ import {
   updateCandidateCanvasState as updateCandidateCanvasStatePure,
   routeImportedPickIntoSets,
 } from '../utils/candidateTransitions';
+import { collectSessionContentHashes, partitionFilesByContentHash } from '../utils/contentHash';
 import {
   defaultTrackSetTitles,
   DEFAULT_TRACK_SET1_TITLE_RALLY,
@@ -68,7 +69,7 @@ export interface UseCompetitionSystemResult {
   updateSessionCompetitionName: (competitionName: string) => Promise<void>;
 
   // Candidate pool operations (see docs/CANDIDATE_PHOTOS.md)
-  addPhotosToCandidates: (files: File[]) => Promise<void>;
+  addPhotosToCandidates: (files: File[]) => Promise<{ added: number; duplicates: number }>;
   /**
    * Insert a pre-built `ApiPhoto` (bytes + thumb already on disk).
    * Used by `useMapPicksSync` (Phase 8b of photo-map-culling) to
@@ -617,23 +618,33 @@ export function useCompetitionSystem(): UseCompetitionSystemResult {
    * and indirectly by `addPhotosToSet` via the smart-drop heuristic when a
    * slot batch exceeds remaining capacity. New candidates start as `neutral`.
    */
-  const addPhotosToCandidates = useCallback(async (files: File[]) => {
+  const addPhotosToCandidates = useCallback(async (files: File[]): Promise<{ added: number; duplicates: number }> => {
     if (!currentCompetition?.session) {
       setError(t('errors.noActiveCompetition'));
-      return;
+      return { added: 0, duplicates: 0 };
     }
-    if (files.length === 0) return;
-    await updateCurrentCompetition(session => {
-      const sessionId = session.id;
-      const newPhotos = filesToPhotos(files, sessionId, 'neutral');
-      const existing = session.candidates?.photos ?? [];
-      return {
-        ...session,
-        version: session.version + 1,
-        updatedAt: new Date().toISOString(),
-        candidates: { photos: [...existing, ...newPhotos] },
-      };
-    }, { updatePhotos: true });
+    if (files.length === 0) return { added: 0, duplicates: 0 };
+    // ADR-020 re-import dedup: skip any file whose bytes match a photo already
+    // anywhere in the session (tray or any set) or repeat within this batch, so a
+    // duplicate never creates a second candidate. The original is left untouched.
+    const existingHashes = collectSessionContentHashes(currentCompetition.session);
+    const { fresh, duplicates } = await partitionFilesByContentHash(files, existingHashes);
+    if (fresh.length > 0) {
+      await updateCurrentCompetition(session => {
+        const sessionId = session.id;
+        // filesToPhotos preserves order, so zip the precomputed hashes back on.
+        const newPhotos = filesToPhotos(fresh.map(f => f.file), sessionId, 'neutral')
+          .map((p, i) => ({ ...p, contentHash: fresh[i].contentHash }));
+        const existing = session.candidates?.photos ?? [];
+        return {
+          ...session,
+          version: session.version + 1,
+          updatedAt: new Date().toISOString(),
+          candidates: { photos: [...existing, ...newPhotos] },
+        };
+      }, { updatePhotos: true });
+    }
+    return { added: fresh.length, duplicates: duplicates.length };
   }, [updateCurrentCompetition, currentCompetition, filesToPhotos, t]);
 
   /**

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -332,6 +332,10 @@
       "trackSet1": "Traťové foto – 1. sada",
       "trackSet2": "Traťové foto – 2. sada",
       "turningPoint": "Foto otočných bodů"
+    },
+    "error": {
+      "renderFailed": "PDF se nepodařilo vytvořit. Některé fotky ({{count}}) nemají obrazová data a nelze je vykreslit – pravděpodobně byly dříve smazány. Naimportujte je znovu v Koridorech a pošlete do editoru, nebo je v editoru odeberte, a export zopakujte.",
+      "generic": "PDF se nepodařilo vytvořit. Zkuste to prosím znovu."
     }
   }
 }

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -166,7 +166,10 @@
     "position": "Pozice {{position}}",
     "loadingFailed": "Nepodařilo se načíst obrázek.",
     "tryAgain": "Zkuste to znovu nebo nahrajte jiný soubor.",
-    "deleteTooltip": "Smazat fotografii"
+    "deleteTooltip": "Smazat fotografii",
+    "noPhotoCell": "Bez fotky",
+    "addNoPhoto": "Vložit „bez fotky“",
+    "noPhotoFilename": "Bez fotky"
   },
   "controls": {
     "imageAdjustments": "Úpravy obrázku",

--- a/frontend/photo-helper/src/locales/cs.json
+++ b/frontend/photo-helper/src/locales/cs.json
@@ -300,6 +300,7 @@
     "emptyHint": "Sem přetáhněte další fotografie — kteroukoli pak přetáhněte do políčka, aby se dostala do tisku",
     "dragHint": "Přetáhněte miniaturu na prázdné políčko, nebo použijte tlačítka pod každou fotografií.",
     "smartDropToast": "Přidáno {{count}} fotografií do Kandidátů — přetáhněte kteroukoli do políčka, aby se dostala do tisku.",
+    "duplicatesSkipped": "Přeskočeno již importovaných fotografií: {{count}}.",
     "crossSetHint": "Přesun mezi sadami jde přes Kandidáty. Přetáhněte fotografii nejprve sem a pak do druhé sady.",
     "allFiltered": "Všichni kandidáti jsou skryti filtrem.",
     "flag": {

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -301,6 +301,7 @@
     "emptyHint": "Drop extra photos here — drag any onto a slot to use it in the print set",
     "dragHint": "Drag a thumbnail onto an empty slot to add it to the print set, or use the toolbar buttons below each photo.",
     "smartDropToast": "Added {{count}} photos to Candidates — drag any onto a slot to use them.",
+    "duplicatesSkipped": "Skipped {{count}} photo(s) already imported.",
     "crossSetHint": "Cross-set moves go via the Candidates tray. Drag the photo there, then drag it into the other set.",
     "allFiltered": "All candidates are hidden by the filter.",
     "flag": {

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -333,6 +333,10 @@
       "trackSet1": "enroute photos first set",
       "trackSet2": "enroute photos second set",
       "turningPoint": "TP photos"
+    },
+    "error": {
+      "renderFailed": "Couldn't create the PDF. Some photos ({{count}}) have no image data and can't be rendered — they were probably deleted earlier. Re-import them in Map Corridors and send them to the editor, or remove those cells in the editor, then export again.",
+      "generic": "Couldn't create the PDF. Please try again."
     }
   }
 }

--- a/frontend/photo-helper/src/locales/en.json
+++ b/frontend/photo-helper/src/locales/en.json
@@ -166,7 +166,10 @@
     "position": "Position {{position}}",
     "loadingFailed": "Failed to load image.",
     "tryAgain": "Please try again or upload a different file.",
-    "deleteTooltip": "Delete photo"
+    "deleteTooltip": "Delete photo",
+    "noPhotoCell": "No photo",
+    "addNoPhoto": "Insert \"no photo\"",
+    "noPhotoFilename": "No photo"
   },
   "controls": {
     "imageAdjustments": "Image Adjustments",

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -53,6 +53,13 @@ export interface ApiPhoto {
    * side). Absent on legacy data.
    */
   labelUpdatedAt?: string;
+  /**
+   * SHA-1 hex of the original file bytes (ADR-020). Set when a photo is
+   * imported via the editor's "Add photos" path so re-importing the same file
+   * is skipped instead of creating a duplicate. Absent on map-handoff (`pm-`)
+   * photos — the handoff doesn't carry a hash — and on legacy data.
+   */
+  contentHash?: string;
 }
 
 export interface ApiPhotoSet {

--- a/frontend/photo-helper/src/types/api.ts
+++ b/frontend/photo-helper/src/types/api.ts
@@ -60,6 +60,14 @@ export interface ApiPhoto {
    * photos — the handoff doesn't carry a hash — and on legacy data.
    */
   contentHash?: string;
+  /**
+   * True for a synthetic "no photo" cell that occupies a turning-point slot so
+   * the SP/TP/FP numbering of the surrounding photos stays correct when a photo
+   * is genuinely missing. Has NO image bytes (`url: ''`, no OPFS file). Rendered
+   * as a blank labeled frame in the editor and as a blank labeled cell in the
+   * PDF (never aborts the export). Absent/false on every real photo.
+   */
+  isPlaceholder?: boolean;
 }
 
 export interface ApiPhotoSet {

--- a/frontend/photo-helper/src/utils/candidateTransitions.ts
+++ b/frontend/photo-helper/src/utils/candidateTransitions.ts
@@ -83,6 +83,30 @@ export function promoteCandidateToSlot(
 }
 
 /**
+ * Insert a "no photo" placeholder into a set at `slotIndex`, pushing later
+ * photos down so a missing turning-point photo can hold its position and keep
+ * the SP/TP/FP numbering correct. Index is clamped to [0, length]. Mirrors the
+ * new `sets` into the active mode bucket (`setsTrack`/`setsTurning`) like the
+ * other slot mutations, so a mode-switch round-trip preserves it. Pure — the
+ * caller persists the result. The placeholder is built by `createPlaceholderPhoto`.
+ */
+export function insertPlaceholderIntoSet(
+  session: ApiPhotoSession,
+  setKey: SetKey,
+  slotIndex: number,
+  placeholder: ApiPhoto,
+): ApiPhotoSession {
+  const set = session.sets[setKey];
+  const photos = [...set.photos];
+  photos.splice(Math.max(0, Math.min(slotIndex, photos.length)), 0, placeholder);
+  const nextSets = { ...session.sets, [setKey]: { ...set, photos } };
+  const next = bumpVersion({ ...session, sets: nextSets });
+  const modeKey = session.mode === 'track' ? 'setsTrack' : 'setsTurning';
+  (next as unknown as Record<string, unknown>)[modeKey] = nextSets;
+  return next;
+}
+
+/**
  * Demote a slot photo back to the tray. Default flag is 'pick' — the photo
  * was committed to a slot once, so it's likely a strong candidate the user
  * is reconsidering rather than a fresh neutral upload.
@@ -96,6 +120,10 @@ export function demoteSlotToCandidate(
   const set = session.sets[setKey];
   const photo = set.photos.find((p) => p.id === photoId);
   if (!photo) return session;
+  // Placeholders never enter the candidate tray — they have no image bytes and
+  // exist only to hold a turning-point slot position. Demoting one would create
+  // a tray entry with a dead url. Ignore the request.
+  if (photo.isPlaceholder) return session;
 
   const remainingSlotPhotos = set.photos.filter((p) => p.id !== photoId);
   const demoted: ApiPhoto = { ...photo, flag };

--- a/frontend/photo-helper/src/utils/canvasUtils.ts
+++ b/frontend/photo-helper/src/utils/canvasUtils.ts
@@ -97,10 +97,12 @@ export const drawLabel = (
   
   // Scale font size based on canvas size to maintain consistent visual appearance.
   // Base font size for the 300px-wide on-screen canvas; scales proportionally for
-  // hi-res PDF renders. Bumped 34 → 68 (feedback 2026-05-12) so jury graders can
-  // read the photo number at arm's length on the printed sheet; `bold` removed
-  // at the same time — the heavier stroke at this size felt obtrusive.
-  const baseFontSize = 68;
+  // hi-res PDF renders. History: 34 → 68 (feedback 2026-05-12, jury legibility) →
+  // 48 (feedback 2026-06-19): 68 read as oversized on both the editor previews and
+  // the printed TP/track-number labels; 48 stays comfortably above the original 34
+  // and legible at arm's length while no longer dominating the photo. This constant
+  // is the single source for BOTH the on-screen preview and the PDF label.
+  const baseFontSize = 48;
   const baseCanvasWidth = 300;
   const scaleFactor = canvas.width / baseCanvasWidth;
   const fontSize = Math.round(baseFontSize * scaleFactor);

--- a/frontend/photo-helper/src/utils/canvasUtils.ts
+++ b/frontend/photo-helper/src/utils/canvasUtils.ts
@@ -87,22 +87,26 @@ export const drawImageOnCanvas = (
 export const drawLabel = (
   canvas: HTMLCanvasElement,
   label: string,
-  position: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right' = 'bottom-left'
+  position: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right' = 'bottom-left',
+  mode?: 'track' | 'turningpoint'
 ): void => {
   const ctx = getCanvasContext(canvas);
   if (!ctx) {
     console.warn('Cannot draw label on invalid canvas');
     return;
   }
-  
+
   // Scale font size based on canvas size to maintain consistent visual appearance.
   // Base font size for the 300px-wide on-screen canvas; scales proportionally for
   // hi-res PDF renders. History: 34 → 68 (feedback 2026-05-12, jury legibility) →
-  // 48 (feedback 2026-06-19): 68 read as oversized on both the editor previews and
-  // the printed TP/track-number labels; 48 stays comfortably above the original 34
-  // and legible at arm's length while no longer dominating the photo. This constant
-  // is the single source for BOTH the on-screen preview and the PDF label.
-  const baseFontSize = 48;
+  // 48 (feedback 2026-06-19) → per-discipline (feedback 2026-06-19): track numbers
+  // −20% and turning-point labels −35% from the 48 baseline, chosen by the caller's
+  // `mode`. No mode → the 48 default (candidate tray draws no label; legacy callers
+  // keep the old size). Single source for BOTH the on-screen preview and the PDF.
+  const baseFontSize =
+    mode === 'track' ? 48 * 0.80 :
+    mode === 'turningpoint' ? 48 * 0.65 :
+    48;
   const baseCanvasWidth = 300;
   const scaleFactor = canvas.width / baseCanvasWidth;
   const fontSize = Math.round(baseFontSize * scaleFactor);

--- a/frontend/photo-helper/src/utils/contentHash.ts
+++ b/frontend/photo-helper/src/utils/contentHash.ts
@@ -1,0 +1,80 @@
+// Re-import dedup for the editor's "Add photos" path (ADR-020). Mirrors
+// map-corridors' import-side content hashing (SHA-1 of the file bytes) so the
+// behaviour is consistent across the two apps, but operates on the editor's
+// ApiPhoto session rather than the map's markers/tray. The two hash spaces are
+// independent — the map→editor handoff does not carry a hash — so editor dedup
+// only matches photos imported through the editor itself.
+
+import type { ApiPhoto } from '../types/api';
+
+/** SHA-1 hex of a file's bytes. Same algorithm as map-corridors' computeContentHash. */
+export async function computeFileContentHash(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const hash = await crypto.subtle.digest('SHA-1', buf);
+  const bytes = new Uint8Array(hash);
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) hex += bytes[i].toString(16).padStart(2, '0');
+  return hex;
+}
+
+/** The minimal slice of a session the dedup needs — every place a photo can live. */
+interface HashSourceSets {
+  set1?: { photos?: ApiPhoto[] };
+  set2?: { photos?: ApiPhoto[] };
+}
+export interface ContentHashSession {
+  candidates?: { photos?: ApiPhoto[] };
+  sets?: HashSourceSets;
+  setsTrack?: HashSourceSets;
+  setsTurning?: HashSourceSets;
+}
+
+/**
+ * Every content hash already present in the session: the candidate tray plus
+ * both slots of the active sets AND the inactive discipline buckets — so a
+ * re-import is rejected no matter where the original currently lives.
+ */
+export function collectSessionContentHashes(session: ContentHashSession | null | undefined): Set<string> {
+  const hashes = new Set<string>();
+  if (!session) return hashes;
+  const addFrom = (photos?: ApiPhoto[]) => {
+    for (const p of photos ?? []) if (p.contentHash) hashes.add(p.contentHash);
+  };
+  addFrom(session.candidates?.photos);
+  for (const sets of [session.sets, session.setsTrack, session.setsTurning]) {
+    addFrom(sets?.set1?.photos);
+    addFrom(sets?.set2?.photos);
+  }
+  return hashes;
+}
+
+export interface FileWithHash {
+  file: File;
+  contentHash: string;
+}
+
+/**
+ * Split incoming files into the ones to keep and the duplicates to drop. A file
+ * is a duplicate when its content hash matches one already in the session
+ * (`existingHashes`) OR an earlier file in this same batch — first occurrence
+ * wins, mirroring importPhotosToStorage. Hashing is sequential to keep that
+ * "first wins" order deterministic; batches are small.
+ */
+export async function partitionFilesByContentHash(
+  files: File[],
+  existingHashes: ReadonlySet<string>,
+): Promise<{ fresh: FileWithHash[]; duplicates: File[] }> {
+  const seen = new Set<string>(existingHashes);
+  const fresh: FileWithHash[] = [];
+  const duplicates: File[] = [];
+  for (const file of files) {
+    const contentHash = await computeFileContentHash(file);
+    if (seen.has(contentHash)) {
+      duplicates.push(file);
+    } else {
+      seen.add(contentHash);
+      fresh.push({ file, contentHash });
+    }
+  }
+  return { fresh, duplicates };
+}

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -5,6 +5,7 @@ import { dirnameOf, slugifyForFilename } from '@airq/shared-storage';
 import { calculateLandscapeGrid } from './pdfLandscapeGrid';
 import { getImageCache } from './imageCache';
 import { BASE_WIDTH, drawCircle, renderPhotoOnCanvas } from '../components/PhotoEditorApi';
+import { drawLabel } from './canvasUtils';
 
 // Hi-res target width for photos embedded in the PDF.
 // At 1600 px wide, a 280 pt landscape A4 cell prints at >400 DPI —
@@ -229,6 +230,34 @@ export const generatePDF = async (
   // photo cell from the printed sheet — for a competition answer-sheet
   // workflow that's a correctness bug, not cosmetic (feedback 2026-05-12).
   const getPhotoDataUrl = async (photo: ApiPhoto): Promise<PhotoRenderResult> => {
+    // "No photo" placeholder: draw a blank white cell with a thin border, a
+    // centered "no photo" caption, and the slot's TP/SP/FP label — no image.
+    // Returns kind:'ok' so it lands at its grid position and never counts as a
+    // render failure (a genuinely missing image still flows to the catch below
+    // and aborts the export — placeholders never mask real failures).
+    if (photo.isPlaceholder) {
+      const canvas = document.createElement('canvas');
+      canvas.width = PDF_PHOTO_TARGET_WIDTH;
+      canvas.height = Math.round(PDF_PHOTO_TARGET_WIDTH / aspectRatio);
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        const scale = canvas.width / BASE_WIDTH;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.strokeStyle = '#cccccc';
+        ctx.lineWidth = Math.max(1, Math.round(scale));
+        ctx.strokeRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = '#9e9e9e';
+        ctx.font = `${Math.round(28 * scale)}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(t ? t('photo.noPhotoCell') : 'No photo', canvas.width / 2, canvas.height / 2);
+        ctx.textAlign = 'start';
+        ctx.textBaseline = 'alphabetic';
+      }
+      drawLabel(canvas, photo.label, photo.canvasState.labelPosition ?? 'bottom-left', mode);
+      return { kind: 'ok', dataUrl: canvas.toDataURL('image/jpeg', PDF_PHOTO_JPEG_QUALITY) };
+    }
     try {
       // Loaded images are normally already cached by the editor grid; this
       // reuses them and falls back to a load if missing (e.g., off-screen).

--- a/frontend/photo-helper/src/utils/pdfGenerator.ts
+++ b/frontend/photo-helper/src/utils/pdfGenerator.ts
@@ -256,6 +256,7 @@ export const generatePDF = async (
         BASE_WIDTH / aspectRatio,
         false,
         true,
+        mode,
       );
 
       // Circle overlay (drawn after the photo, same as the live editor).

--- a/frontend/photo-helper/src/utils/placeholderPhoto.ts
+++ b/frontend/photo-helper/src/utils/placeholderPhoto.ts
@@ -1,0 +1,38 @@
+// Synthetic "no photo" placeholder cell for a missing turning-point photo.
+//
+// A placeholder is a normal ApiPhoto kept IN the slot array at its index, so the
+// SP/TP/FP numbering of the surrounding photos stays correct (labels are
+// index-based — see buildPdfSets / generateTurningPointLabels). It carries no
+// image bytes: url='' so it's never written to OPFS (saveSessionPhotos is
+// blob-gated) and never loaded into the image cache. The editor renders it as a
+// blank labeled frame; the PDF draws a blank labeled cell instead of aborting.
+// See types/api.ts ApiPhoto.isPlaceholder.
+
+import type { ApiPhoto } from '../types/api';
+import { createDefaultCanvasState } from '../hooks/usePhotoSessionOPFS';
+
+/** Marks a synthetic placeholder id. Mirrors the `pm-` map-origin convention. */
+export const PLACEHOLDER_ID_PREFIX = 'placeholder-';
+
+/** True when an id belongs to a no-photo placeholder. */
+export function isPlaceholderId(id: string): boolean {
+  return id.startsWith(PLACEHOLDER_ID_PREFIX);
+}
+
+/**
+ * Build a "no photo" placeholder ApiPhoto. `filename` is a localized display
+ * string ("Bez fotky" / "No photo") — screen-only, never used for matching.
+ * `label` starts empty; it's overwritten by the by-index labeling in
+ * buildPdfSets and the grid (so the placeholder shows its TP/SP/FP number).
+ */
+export function createPlaceholderPhoto(sessionId: string, filename: string): ApiPhoto {
+  return {
+    id: `${PLACEHOLDER_ID_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    sessionId,
+    url: '',
+    filename,
+    canvasState: createDefaultCanvasState(),
+    label: '',
+    isPlaceholder: true,
+  };
+}


### PR DESCRIPTION
## Summary
Fixes a 7-item user bug report covering the Map Corridors → Photo Helper workflow. Each item is its own focused commit.

**No-GPS photos (report #1–#3)**
- **#3** A photo placed from the no-GPS tray can now be re-categorised: its marker popup (Track / Turning / Skip / Reject + label) was gated on EXIF `capturedAt`, which placed no-GPS markers never have — now gated on `photoId` (`MapProviderView.tsx`).
- **#1** The *Poslat do editoru* panel warns when no-GPS photos are still in the tray (they don't transfer until dropped on the map), and a failed tray placement now shows a snackbar instead of silently dropping the photo.
- **#2** The always-on **Add photos** toolbar control is more prominent so the manual-import entry point is easy to find.

**Editor previews (report #4–#5)**
- **#4** Candidate-tray thumbnails now show the filename next to the move/delete buttons.
- **#5** `drawLabel` font 68 → 48 — TP/track-number labels were oversized on previews **and** the printed PDF (one shared constant).

**Map interaction (report #6–#7)**
- **#6** Fanned (co-located) photos stay anchored during a continuous zoom — the fan now recomputes on the per-frame `zoom` event, not just on settle. *Caveat: only co-located photos ever drifted; a solitary marker has a stable `[0,0]` offset.*
- **#7** The no-GPS tray auto-scrolls while dragging a thumbnail (edge-pan reusing the map's `edgeVelocity`), kept **within** the ADR-012 20vw cap (only `scrollLeft` changes).

## Test plan
- [x] map-corridors: 703 tests pass; `tsc -b` clean
- [x] photo-helper: 451 tests pass; `tsc --noEmit` clean
- [ ] Place a no-GPS photo → click its marker → flag popup opens; Skip/Reject work (#3)
- [ ] Leave a no-GPS photo in the tray → send-button hint appears; count matches editor (#1)
- [ ] Zoom (wheel/pinch) with several photos at one spot → dots stay on their points (#6)
- [ ] Drag a tray thumb to the strip's edge → strip rolls; release stops it (#7)
- [ ] Candidate thumbnails show filename (#4); labels visibly smaller on screen + PDF (#5); Add-photos chip stands out (#2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)