### PR TITLE
fix(map-corridors): Print map failed with 'Image data too large' on high-DPI displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ new desktop release.
 
 ## [Unreleased]
 
+### Fixed
+- **Map Corridors:** fixed **Print map** failing with *"Image data too large"*
+  on machines with Windows display scaling above 100 %. The A4 print capture
+  rendered at the display's pixel ratio (up to 4× the pixels at 200 % scaling)
+  and the resulting PNG blew past the desktop app's transfer limit. The
+  exported image is now always exactly A4 at 300 DPI regardless of display
+  scaling, and it travels to the save dialog as raw bytes instead of an
+  inflated base64 string.
+
 ### Added
 - **Guided onboarding tour.** The launcher, Map Corridors and the Photo Editor
   now walk new organizers through the whole workflow — starting with the basics

--- a/frontend/desktop/main.js
+++ b/frontend/desktop/main.js
@@ -1100,11 +1100,19 @@ safeHandle('competition-delete', async (event, id) => {
 // Save map print image via native save dialog. Prefers the directory the
 // source KML was imported from (feedback 2026-04-23: every export dialog
 // should land in the user's race folder, not our internal storage).
-safeHandle('save-map-image', async (event, base64Data, defaultDir, fileNameArg) => {
-  if (typeof base64Data !== 'string' || base64Data.length === 0) {
+safeHandle('save-map-image', async (event, imageData, defaultDir, fileNameArg) => {
+  // Binary transport (Uint8Array of raw PNG bytes) — was a base64 string.
+  // The 33% base64 inflation pushed legitimate A4 captures from high-DPI
+  // machines over the old 50 MB string cap ("Image data too large" reported
+  // 2026-07 by a client on Windows display scaling >100%). Structured-clone
+  // IPC hands us the bytes directly, so the cap is now on real byte length.
+  // Buffer passes the instanceof check too (it subclasses Uint8Array).
+  if (!(imageData instanceof Uint8Array) || imageData.byteLength === 0) {
     throw new Error('Invalid image data');
   }
-  if (base64Data.length > 50 * 1024 * 1024) {
+  // A normalized A4-at-300DPI PNG tops out ≈35 MB even for incompressible
+  // satellite imagery; 64 MB bounds a malicious renderer with ~2× headroom.
+  if (imageData.byteLength > 64 * 1024 * 1024) {
     throw new Error('Image data too large');
   }
   // Apply the same UNC + length + existence checks as `save-kml`. A
@@ -1127,8 +1135,7 @@ safeHandle('save-map-image', async (event, base64Data, defaultDir, fileNameArg) 
     filters: [{ name: 'PNG Images', extensions: ['png'] }]
   });
   if (!filePath) return null;
-  const buffer = Buffer.from(base64Data, 'base64');
-  fs.writeFileSync(filePath, buffer);
+  fs.writeFileSync(filePath, imageData);
   return filePath;
 });
 

--- a/frontend/desktop/preload.js
+++ b/frontend/desktop/preload.js
@@ -60,11 +60,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   //   • { canceled: false, path: '<abs>' }                  — picked and validated
   pickDirectory: (defaultDir, title) => ipcRenderer.invoke('pick-directory', defaultDir, title),
 
-  // Save map print image via native save dialog. `fileName` is optional —
-  // when provided the renderer's slug-based name (e.g. map-print-plzen-2026-…)
+  // Save map print image via native save dialog. `imageData` is a Uint8Array
+  // of raw PNG bytes — binary IPC avoids the 33% base64 inflation that pushed
+  // high-DPI A4 captures over the old 50 MB string cap. `fileName` is optional
+  // — when provided the renderer's slug-based name (e.g. map-print-plzen-2026-…)
   // is used; otherwise the main-process handler falls back to the legacy
   // date-only default.
-  saveMapImage: (base64Data, defaultDir, fileName) => ipcRenderer.invoke('save-map-image', base64Data, defaultDir, fileName),
+  saveMapImage: (imageData, defaultDir, fileName) => ipcRenderer.invoke('save-map-image', imageData, defaultDir, fileName),
 
   // Save a photo-sheet PDF via native save dialog. defaultDir is the
   // competition's working folder (set when the user imports a KML).

--- a/frontend/map-corridors/src/App.tsx
+++ b/frontend/map-corridors/src/App.tsx
@@ -1219,18 +1219,13 @@ function App() {
         : `map-print-${printDate}.png`
 
       if (electronAPI?.saveMapImage) {
-        // Electron: save via native dialog
-        const base64 = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader()
-          reader.onload = () => {
-            const result = reader.result as string
-            resolve(result.split(',')[1]) // strip data:image/png;base64, prefix
-          }
-          reader.onerror = () => reject(reader.error)
-          reader.readAsDataURL(blob)
-        })
+        // Electron: save via native dialog. Raw bytes over structured-clone
+        // IPC — the previous FileReader→base64 path inflated the payload by
+        // 33% and materialized a giant string, tripping the main-process
+        // size cap on high-DPI machines ("Image data too large").
+        const imageData = new Uint8Array(await blob.arrayBuffer())
         // Round-5: chosen folder is no longer auto-promoted to workingDir.
-        await electronAPI.saveMapImage(base64, importedKmlDir || undefined, printFileName)
+        await electronAPI.saveMapImage(imageData, importedKmlDir || undefined, printFileName)
       } else {
         // Browser: download via anchor
         const url = URL.createObjectURL(blob)

--- a/frontend/map-corridors/src/types/electron.d.ts
+++ b/frontend/map-corridors/src/types/electron.d.ts
@@ -16,7 +16,9 @@ declare module '@airq/shared-storage' {
     goHome?: () => void
     navigateToApp?: (app: string, competitionId: string) => void
     openMapboxSettings?: () => void
-    saveMapImage?: (base64: string, defaultDir?: string, fileName?: string) => Promise<string | null>
+    // Raw PNG bytes — binary IPC (base64 string transport was retired after
+    // its 33% inflation pushed high-DPI captures over the main-process cap).
+    saveMapImage?: (imageData: Uint8Array, defaultDir?: string, fileName?: string) => Promise<string | null>
     savePdf?: (base64: string, fileName: string, defaultDir?: string) => Promise<string | null>
     getConfig?: (key: string) => Promise<string | undefined>
     setConfig?: (key: string, value: string) => Promise<void>

--- a/frontend/map-corridors/src/utils/mapCapture.ts
+++ b/frontend/map-corridors/src/utils/mapCapture.ts
@@ -81,6 +81,11 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     mapboxgl.accessToken = accessToken
   }
 
+  // NOTE: mapbox-gl has no `pixelRatio` MapOption (that's MapLibre-only), so
+  // the WebGL canvas backing store is always `dims × window.devicePixelRatio`.
+  // On Windows display scaling >100% that's up to 2× per axis. We can't stop
+  // the oversized render, but the capture below normalizes the exported PNG
+  // back to exactly `dims`, so the output size is machine-independent.
   const map = new mapboxgl.Map({
     container,
     style,
@@ -88,8 +93,7 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
     interactive: false,
     fadeDuration: 0,
     attributionControl: false,
-    pixelRatio: 1,
-  } as mapboxgl.MapOptions)
+  })
 
   try {
     // Wait for style to load
@@ -160,18 +164,27 @@ export async function captureMapForPrint(options: PrintOptions): Promise<PrintCa
       'Map tile rendering timed out'
     )
 
-    // Capture the WebGL canvas
+    // Capture the WebGL canvas, normalized to exactly `dims` (A4 @ 300 DPI).
+    // The backing store may be devicePixelRatio× larger (see the Map options
+    // note above); drawing it scaled into a dims-sized canvas keeps the PNG
+    // byte size machine-independent. The old canvas-sized export produced a
+    // 4× -pixel PNG on 200% Windows scaling, blowing past the desktop app's
+    // IPC size cap ("Image data too large") — and when the store IS larger,
+    // this is supersampling, so print quality doesn't suffer.
     const mapCanvas = map.getCanvas()
     const offscreen = document.createElement('canvas')
-    offscreen.width = mapCanvas.width
-    offscreen.height = mapCanvas.height
+    offscreen.width = dims.width
+    offscreen.height = dims.height
     const ctx = offscreen.getContext('2d')
     if (!ctx) throw new Error('Failed to create 2D canvas context — image may be too large for this device')
-    ctx.drawImage(mapCanvas, 0, 0)
+    ctx.drawImage(mapCanvas, 0, 0, dims.width, dims.height)
 
-    // Scale factor: canvas pixels may differ from CSS pixels
-    const scaleX = mapCanvas.width / dims.width
-    const scaleY = mapCanvas.height / dims.height
+    // With the output normalized to `dims`, `map.project()` CSS-pixel coords
+    // map 1:1 onto the offscreen canvas. Kept as named constants because the
+    // marker/label math below was originally written against a variable
+    // canvas-to-CSS ratio and reads better with the factor visible.
+    const scaleX = 1
+    const scaleY = 1
 
     // Composite photo markers. Screen now uses 12px diameter (was 8); print
     // was originally tuned to 20px (10px radius) after the 2026-04-18 round


### PR DESCRIPTION
## Problem

Client report: printing the map fails with **"Error invoking remote method 'save-map-image': Error: Image data too large"**.

## Root cause

`captureMapForPrint` passed `pixelRatio: 1` to `new mapboxgl.Map(...)` — but that option is **MapLibre-only**; mapbox-gl v3 has no such MapOption (the `as mapboxgl.MapOptions` cast was hiding the type error) and always renders at `window.devicePixelRatio`.

On Windows display scaling >100 % (client machines commonly run 125–200 %), the A4 print canvas backing store grows to up to 7016×4960 px (4× the pixels at 200 %). The resulting PNG exceeds ~37.5 MB, and after the renderer's FileReader→base64 conversion (+33 % inflation) the payload blows past the 50 MB string cap in the `save-map-image` IPC handler. At 100 % scaling the same capture stays under the cap — which is why it never reproduced on dev machines.

## Fix

1. **Normalize the capture** (`mapCapture.ts`): draw the (possibly DPR-scaled) WebGL canvas into an offscreen canvas of exactly A4 @ 300 DPI (3508×2480). Output size is now machine-independent; when the backing store is larger this is supersampling, so print quality does not suffer. The ineffective `pixelRatio` option and the misleading cast are removed.
2. **Binary IPC transport**: `save-map-image` now receives raw PNG bytes (`Uint8Array`) over structured-clone IPC instead of a base64 string — no 33 % inflation, no giant string materialized in the renderer. The cap is now 64 MB of real bytes (worst-case incompressible A4 PNG ≈ 35 MB, so ~2× headroom while still bounding a malicious renderer).
3. Preload bridge, renderer caller, and `electron.d.ts` updated to match. Main + renderer always ship together in one .exe, so no compat shim needed.

## Testing

- `map-corridors`: 762 tests pass, `tsc --noEmit` clean
- `desktop`: 63 tests pass
- Manual verification on a >100 % display-scaling machine recommended before release (print on satellite style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)