### PR TITLE
feat(map-corridors): Google Earth-style keyboard navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ new desktop release.
 ## [Unreleased]
 
 ### Added
+- **Map Corridors:** the map now answers **Google Earth keyboard controls**
+  regardless of where you last clicked — arrow keys pan, **Shift+←/→** rotates,
+  **Shift+↑/↓** tilts, **Page Up/Page Down** and **+/−** zoom, **N** faces
+  north, **U** looks straight down, **R** resets the view. Hold a key to keep
+  moving.
 - **Guided onboarding tour.** The launcher, Map Corridors and the Photo Editor
   now walk new organizers through the whole workflow — starting with the basics
   (load route & photos → sort track/turning → split the sets → send → lay out &

--- a/docs/USER_MANUAL.cs.md
+++ b/docs/USER_MANUAL.cs.md
@@ -102,7 +102,26 @@ Fotky jsou seskupené podle rozhodnutí: **Otočné body – vybrané**,
   doprovází do editoru, aniž by se měnil původní název souboru.
 - **Smazat** fotku ze soutěže (✕).
 
-### 3.5 Volba, kde se sady rozdělí (Rally)
+### 3.5 Ovládání mapy klávesnicí
+
+Mapa reaguje na stejné klávesy jako Google Earth, ať jste naposledy klikli
+kamkoli (přednost má jen psaní do textového pole):
+
+| Klávesa | Akce |
+|---------|------|
+| **← ↑ ↓ →** | Posun mapy |
+| **Shift + ← / →** | Otáčení (kompas se otáčí s mapou) |
+| **Shift + ↑ / ↓** | Naklonění pohledu |
+| **Page Up / Page Down** | Přiblížení / oddálení |
+| **+ / −** | Přiblížení / oddálení |
+| **N** | Natočit na sever |
+| **U** | Pohled kolmo dolů |
+| **R** | Obnovit pohled (sever + kolmo dolů) |
+
+Podržením klávesy se pohyb opakuje. Kompas v levém horním rohu také vrátí
+mapu na sever, kdykoli je otočená.
+
+### 3.6 Volba, kde se sady rozdělí (Rally)
 
 Použijte výběr **„Sada 2 začíná od"** v horní části seznamu a zvolte otočný bod
 trati (TP1, TP2, …):
@@ -118,7 +137,7 @@ Otočné body pocházejí z **trati**, takže to funguje, i když žádná z va�
 není fotkou otočného bodu. Soutěže v přesném létání mají jednu sadu a tento
 ovládací prvek nezobrazují.
 
-### 3.6 Odeslání do editoru
+### 3.7 Odeslání do editoru
 
 Klikněte na **Poslat do editoru (N)** — N je počet vybraných fotek. Výběr
 (i rozdělení) přejde do Photo Helperu, který se otevře s předvyplněnými sadami.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -101,7 +101,26 @@ selected**, **Neutral**, **Rejected**, **No GPS**. You can:
   follows it into the editor without touching the original filename.
 - **Delete** a photo from the competition (✕).
 
-### 3.5 Choose where the sheets split (Rally)
+### 3.5 Map keyboard controls
+
+The map answers the same keys as Google Earth, no matter where you last
+clicked (only typing in a text field takes priority):
+
+| Key | Action |
+|-----|--------|
+| **← ↑ ↓ →** | Pan the map |
+| **Shift + ← / →** | Rotate (compass turns with the map) |
+| **Shift + ↑ / ↓** | Tilt the view |
+| **Page Up / Page Down** | Zoom in / out |
+| **+ / −** | Zoom in / out |
+| **N** | Face north |
+| **U** | Look straight down |
+| **R** | Reset the view (north + straight down) |
+
+Hold a key to keep moving. The compass button in the top-left corner also
+resets to north whenever the map is rotated.
+
+### 3.6 Choose where the sheets split (Rally)
 
 Use the **"Set 2 starts at"** selector at the top of the list and pick a route
 turning point (TP1, TP2, …):
@@ -116,7 +135,7 @@ The turning points come from the **route**, so this works even if none of your
 photos are turning-point photos. Precision competitions are single-set and don't
 show this control.
 
-### 3.6 Send to the editor
+### 3.7 Send to the editor
 
 Click **Send to editor (N)** — N is the number of picked photos. The selections
 (and the split) cross to Photo Helper, which opens with the sets pre-filled. If

--- a/frontend/map-corridors/src/__tests__/keyboardNav.test.ts
+++ b/frontend/map-corridors/src/__tests__/keyboardNav.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { interpretMapKey, applyMapKeyAction } from '../map/keyboardNav'
+import { interpretMapKey, applyMapKeyAction, shouldIgnoreMapKey } from '../map/keyboardNav'
 import type { MapCamera, MapKeyAction } from '../map/keyboardNav'
 
 // ---------------------------------------------------------------------------
@@ -50,6 +50,63 @@ describe('interpretMapKey', () => {
     for (const k of ['a', 'Escape', 'Enter', ' ', 'Tab', 'Home', 'End', '1', 'F5']) {
       expect(key(k)).toBeNull()
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldIgnoreMapKey — the gate that keeps the map from stealing keys that
+// belong to another interaction (PR #111 review findings F1/F2)
+// ---------------------------------------------------------------------------
+describe('shouldIgnoreMapKey', () => {
+  // Build a realistic event-shaped object around a DOM target (jsdom).
+  const evt = (target: EventTarget | null, over: Partial<KeyboardEvent> = {}) => ({
+    defaultPrevented: false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    target,
+    ...over,
+  })
+
+  it('ignores keys another component already claimed (defaultPrevented)', () => {
+    // MUI Select/MenuList preventDefault arrows without stopPropagation —
+    // the event still bubbles to window and must be dropped there.
+    expect(shouldIgnoreMapKey(evt(document.body, { defaultPrevented: true }))).toBe(true)
+  })
+
+  it('ignores browser/system shortcut modifiers', () => {
+    expect(shouldIgnoreMapKey(evt(document.body, { ctrlKey: true }))).toBe(true)
+    expect(shouldIgnoreMapKey(evt(document.body, { metaKey: true }))).toBe(true)
+    expect(shouldIgnoreMapKey(evt(document.body, { altKey: true }))).toBe(true)
+  })
+
+  it('ignores typing targets', () => {
+    for (const tag of ['input', 'textarea', 'select']) {
+      expect(shouldIgnoreMapKey(evt(document.createElement(tag)))).toBe(true)
+    }
+    const editable = document.createElement('div')
+    // jsdom doesn't compute isContentEditable from the attribute; set the
+    // property the code reads.
+    Object.defineProperty(editable, 'isContentEditable', { value: true })
+    expect(shouldIgnoreMapKey(evt(editable))).toBe(true)
+  })
+
+  it('ignores targets inside open MUI popups (dialog / menu / listbox / combobox)', () => {
+    for (const role of ['dialog', 'menu', 'listbox', 'combobox']) {
+      const popup = document.createElement('div')
+      popup.setAttribute('role', role)
+      const button = document.createElement('button')
+      popup.appendChild(button)
+      // Target is a descendant, not the role element itself — closest() case.
+      expect(shouldIgnoreMapKey(evt(button))).toBe(true)
+    }
+  })
+
+  it('allows plain targets: body, buttons, and non-element targets', () => {
+    expect(shouldIgnoreMapKey(evt(document.body))).toBe(false)
+    expect(shouldIgnoreMapKey(evt(document.createElement('button')))).toBe(false)
+    // window/document targets (not HTMLElement) must not crash and not block
+    expect(shouldIgnoreMapKey(evt(null))).toBe(false)
   })
 })
 

--- a/frontend/map-corridors/src/__tests__/keyboardNav.test.ts
+++ b/frontend/map-corridors/src/__tests__/keyboardNav.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest'
+import { interpretMapKey, applyMapKeyAction } from '../map/keyboardNav'
+import type { MapCamera, MapKeyAction } from '../map/keyboardNav'
+
+// ---------------------------------------------------------------------------
+// interpretMapKey — the Google-Earth key map (see keyboardNav.ts header)
+// ---------------------------------------------------------------------------
+describe('interpretMapKey', () => {
+  const key = (k: string, shift = false) => interpretMapKey({ key: k, shiftKey: shift })
+
+  it('plain arrows pan by 100px in screen space', () => {
+    expect(key('ArrowUp')).toEqual({ type: 'pan', dx: 0, dy: -100 })
+    expect(key('ArrowDown')).toEqual({ type: 'pan', dx: 0, dy: 100 })
+    expect(key('ArrowLeft')).toEqual({ type: 'pan', dx: -100, dy: 0 })
+    expect(key('ArrowRight')).toEqual({ type: 'pan', dx: 100, dy: 0 })
+  })
+
+  it('shift+left/right rotates bearing by 15° (ccw / cw)', () => {
+    expect(key('ArrowLeft', true)).toEqual({ type: 'rotate', delta: -15 })
+    expect(key('ArrowRight', true)).toEqual({ type: 'rotate', delta: 15 })
+  })
+
+  it('shift+up/down tilts pitch by 10°', () => {
+    expect(key('ArrowUp', true)).toEqual({ type: 'pitch', delta: 10 })
+    expect(key('ArrowDown', true)).toEqual({ type: 'pitch', delta: -10 })
+  })
+
+  it('PageUp/PageDown zoom by one level', () => {
+    expect(key('PageUp')).toEqual({ type: 'zoom', delta: 1 })
+    expect(key('PageDown')).toEqual({ type: 'zoom', delta: -1 })
+  })
+
+  it('+/− zoom, including the unshifted =/_ variants', () => {
+    expect(key('+')).toEqual({ type: 'zoom', delta: 1 })
+    expect(key('=')).toEqual({ type: 'zoom', delta: 1 })
+    expect(key('-')).toEqual({ type: 'zoom', delta: -1 })
+    expect(key('_')).toEqual({ type: 'zoom', delta: -1 })
+  })
+
+  it('n/u/r map to north, top-down, reset (case-insensitive)', () => {
+    expect(key('n')).toEqual({ type: 'north' })
+    expect(key('N')).toEqual({ type: 'north' })
+    expect(key('u')).toEqual({ type: 'topDown' })
+    expect(key('U')).toEqual({ type: 'topDown' })
+    expect(key('r')).toEqual({ type: 'reset' })
+    expect(key('R')).toEqual({ type: 'reset' })
+  })
+
+  it('returns null for keys that are not ours (caller must not preventDefault)', () => {
+    for (const k of ['a', 'Escape', 'Enter', ' ', 'Tab', 'Home', 'End', '1', 'F5']) {
+      expect(key(k)).toBeNull()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyMapKeyAction — camera calls, relative to the current camera state
+// ---------------------------------------------------------------------------
+describe('applyMapKeyAction', () => {
+  const makeCamera = (state = { zoom: 10, bearing: 30, pitch: 20 }): MapCamera => ({
+    panBy: vi.fn(),
+    easeTo: vi.fn(),
+    getZoom: () => state.zoom,
+    getBearing: () => state.bearing,
+    getPitch: () => state.pitch,
+  })
+
+  const apply = (action: MapKeyAction, cam = makeCamera()) => {
+    applyMapKeyAction(cam, action)
+    return cam
+  }
+
+  it('pan calls panBy with the pixel offset', () => {
+    const cam = apply({ type: 'pan', dx: 100, dy: 0 })
+    expect(cam.panBy).toHaveBeenCalledWith([100, 0], { duration: 100 })
+    expect(cam.easeTo).not.toHaveBeenCalled()
+  })
+
+  it('zoom eases relative to the current zoom', () => {
+    const cam = apply({ type: 'zoom', delta: 1 })
+    expect(cam.easeTo).toHaveBeenCalledWith({ zoom: 11, duration: 300 })
+  })
+
+  it('rotate eases relative to the current bearing', () => {
+    const cam = apply({ type: 'rotate', delta: -15 })
+    expect(cam.easeTo).toHaveBeenCalledWith({ bearing: 15, duration: 300 })
+  })
+
+  it('pitch eases relative to the current pitch (easeTo clamps out-of-range)', () => {
+    const cam = apply({ type: 'pitch', delta: 10 })
+    expect(cam.easeTo).toHaveBeenCalledWith({ pitch: 30, duration: 300 })
+  })
+
+  it('north/topDown/reset ease to absolute targets', () => {
+    expect(apply({ type: 'north' }).easeTo).toHaveBeenCalledWith({ bearing: 0, duration: 400 })
+    expect(apply({ type: 'topDown' }).easeTo).toHaveBeenCalledWith({ pitch: 0, duration: 400 })
+    expect(apply({ type: 'reset' }).easeTo).toHaveBeenCalledWith({ bearing: 0, pitch: 0, duration: 400 })
+  })
+})

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -9,6 +9,7 @@ import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
 import { isPhotoMarkerVisible, isMarkerVisibleOnMap } from './photoLayers/markerVisibility'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
+import { applyMapKeyAction, interpretMapKey } from './keyboardNav'
 import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
@@ -249,22 +250,34 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
     }
   }, [onCompareVariants, clearPhotoSelection])
 
-  // `N` resets the map to north (Google-Earth style). Suppressed while typing
-  // in a field (marker-name inputs live in popups) and for modifier combos
-  // (e.g. Ctrl/Cmd+N "new window").
+  // Google-Earth-style keyboard navigation (client request 2026-07): arrows
+  // pan, Shift+arrows rotate/tilt, PageUp/PageDown and +/− zoom, N north-up,
+  // U top-down, R reset — full key map in keyboardNav.ts. Window-level (not
+  // the built-in canvas handler, which is disabled below via keyboard={false})
+  // so it works no matter where focus sits — users click side panels
+  // constantly and Google Earth keys "just work" without clicking the map
+  // first. Suppressed while typing in a field (marker-name inputs live in
+  // popups) and for modifier combos (e.g. Ctrl/Cmd+N "new window"). Key
+  // auto-repeat is intentionally allowed — holding an arrow keeps panning,
+  // matching Google Earth.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'n' && e.key !== 'N') return
       if (e.ctrlKey || e.metaKey || e.altKey) return
       const el = e.target as HTMLElement | null
       const tag = el?.tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || el?.isContentEditable) return
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return
+      const action = interpretMapKey({ key: e.key, shiftKey: e.shiftKey })
+      if (!action) return
+      const map = mapRef.current?.getMap()
+      if (!map) return
+      // Claim the key only once we know we'll act on it — stops the browser
+      // from also scrolling a panel on PageUp/PageDown or arrows.
       e.preventDefault()
-      resetNorth()
+      applyMapKeyAction(map, action)
     }
     window.addEventListener('keydown', onKey)
     return () => { window.removeEventListener('keydown', onKey) }
-  }, [resetNorth])
+  }, [])
 
   // Attach native DnD listeners on the canvas to support custom marker drops
   useEffect(() => {
@@ -541,6 +554,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
       mapStyle={mapStyle}
       mapboxAccessToken={mapboxAccessToken}
       preserveDrawingBuffer
+      // Built-in keyboard handler off: it only works while the canvas has
+      // focus and would double-handle keys next to our window-level
+      // Google-Earth-style handler above (see keyboardNav.ts).
+      keyboard={false}
       initialViewState={{ longitude: 14.42076, latitude: 50.08804, zoom: 6 }}
       style={{ width: '100%', height: '100%' }}
       onLoad={() => setIsMapLoaded(true)}

--- a/frontend/map-corridors/src/map/MapProviderView.tsx
+++ b/frontend/map-corridors/src/map/MapProviderView.tsx
@@ -9,7 +9,7 @@ import { shouldClearActivePhoto } from '../activePhoto/activePhoto'
 import { isPhotoMarkerVisible, isMarkerVisibleOnMap } from './photoLayers/markerVisibility'
 import { captureMapForPrint } from '../utils/mapCapture'
 import type { PrintCaptureResult } from '../utils/mapCapture'
-import { applyMapKeyAction, interpretMapKey } from './keyboardNav'
+import { applyMapKeyAction, interpretMapKey, shouldIgnoreMapKey } from './keyboardNav'
 import type { PhotoFlag, PhotoLabel, PhotoMarker, GroundMarkerCallbacks } from '../types/markers'
 import { ALL_PHOTO_LABELS, GROUND_MARKER_TYPES } from '../types/markers'
 import { CaptureDotsLayer } from './photoLayers/CaptureDotsLayer'
@@ -146,8 +146,8 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   const [bearing, setBearing] = useState(0)
   const isRotated = Math.abs(((bearing % 360) + 360) % 360) > 0.5
   // Google-Earth-style "reset to north": animate bearing back to 0. easeTo
-  // picks the shortest rotation path automatically. Shared by the compass
-  // button and the `N` shortcut below.
+  // picks the shortest rotation path automatically. Used by the compass
+  // button; the `N` shortcut goes through keyboardNav's equivalent action.
   const resetNorth = useCallback(() => {
     mapRef.current?.getMap()?.easeTo({ bearing: 0, duration: 400 })
   }, [])
@@ -262,10 +262,10 @@ export const MapProviderView = forwardRef<MapProviderViewHandle, {
   // matching Google Earth.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.ctrlKey || e.metaKey || e.altKey) return
-      const el = e.target as HTMLElement | null
-      const tag = el?.tagName
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el?.isContentEditable) return
+      // Full gate (typing, modifiers, defaultPrevented, open MUI popups /
+      // dialogs) lives in keyboardNav.ts so it's unit-testable — see
+      // shouldIgnoreMapKey's doc comment for why each case exists.
+      if (shouldIgnoreMapKey(e)) return
       const action = interpretMapKey({ key: e.key, shiftKey: e.shiftKey })
       if (!action) return
       const map = mapRef.current?.getMap()

--- a/frontend/map-corridors/src/map/keyboardNav.ts
+++ b/frontend/map-corridors/src/map/keyboardNav.ts
@@ -30,6 +30,34 @@ const BEARING_STEP_DEG = 15
 const PITCH_STEP_DEG = 10
 const ZOOM_STEP = 1
 
+/**
+ * True when a keydown must NOT drive the map. Checked before interpretMapKey
+ * so the map never steals keys that belong to another interaction (PR #111
+ * review findings F1/F2):
+ *
+ * - `defaultPrevented` — some component already claimed the key (MUI Select/
+ *   MenuList call preventDefault on arrows/Enter/Space but do NOT stop
+ *   propagation, so the event still reaches our window listener);
+ * - Ctrl/Cmd/Alt combos — browser & system shortcuts (Ctrl+N, Alt+arrows, …);
+ * - typing targets — inputs, textareas, selects, contentEditable;
+ * - open MUI popups — Select dropdowns, menus, and dialogs render as
+ *   divs/lis with ARIA roles (never native <select>/<dialog> elements), and
+ *   their type-ahead letters (n/u/r would re-orient the map!) and
+ *   focus-trapped arrow keys must win over map navigation while open.
+ */
+export function shouldIgnoreMapKey(
+  e: Pick<KeyboardEvent, 'defaultPrevented' | 'ctrlKey' | 'metaKey' | 'altKey' | 'target'>,
+): boolean {
+  if (e.defaultPrevented) return true
+  if (e.ctrlKey || e.metaKey || e.altKey) return true
+  const el = e.target instanceof HTMLElement ? e.target : null
+  if (!el) return false
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable) return true
+  if (el.closest('[role="dialog"], [role="menu"], [role="listbox"], [role="combobox"]')) return true
+  return false
+}
+
 export type MapKeyAction =
   | { type: 'pan'; dx: number; dy: number }
   | { type: 'zoom'; delta: number }

--- a/frontend/map-corridors/src/map/keyboardNav.ts
+++ b/frontend/map-corridors/src/map/keyboardNav.ts
@@ -1,0 +1,144 @@
+/**
+ * Google-Earth-style keyboard navigation for the corridors map
+ * (client request 2026-07: "replicate Google Earth controls — arrow keys,
+ * Page Up / Page Down, …").
+ *
+ * Key map (mirrors Google Earth Pro, with step sizes borrowed from
+ * mapbox-gl's built-in KeyboardHandler so the feel matches other GL maps):
+ *
+ *   Arrows              pan 100 px
+ *   Shift + Left/Right  rotate bearing ∓15° (counter-clockwise / clockwise)
+ *   Shift + Up/Down     tilt pitch +10° / −10°
+ *   PageUp / PageDown   zoom in / out by 1 level
+ *   + / −               zoom in / out by 1 level
+ *   N                   face north (bearing → 0)
+ *   U                   look top-down (pitch → 0)
+ *   R                   reset view (north + top-down)
+ *
+ * Split into a pure `interpretMapKey` (key event → action) and
+ * `applyMapKeyAction` (action → camera call) so the key map is unit-testable
+ * without a real mapbox-gl Map. The window-level listener lives in
+ * MapProviderView — mapbox-gl's own KeyboardHandler only works while the
+ * canvas has focus, which it almost never has in this app (users click side
+ * panels constantly), so the built-in handler is disabled and this module
+ * owns all map keys.
+ */
+
+// Step sizes = mapbox-gl KeyboardHandler defaults (100 px / 15° / 10° / 1 zoom).
+const PAN_STEP_PX = 100
+const BEARING_STEP_DEG = 15
+const PITCH_STEP_DEG = 10
+const ZOOM_STEP = 1
+
+export type MapKeyAction =
+  | { type: 'pan'; dx: number; dy: number }
+  | { type: 'zoom'; delta: number }
+  | { type: 'rotate'; delta: number }
+  | { type: 'pitch'; delta: number }
+  | { type: 'north' }
+  | { type: 'topDown' }
+  | { type: 'reset' }
+
+/** The subset of KeyboardEvent the key map needs — keeps tests dependency-free. */
+export type MapKeyInput = {
+  key: string
+  shiftKey: boolean
+}
+
+/**
+ * Map a key press to a camera action, or null when the key isn't ours.
+ * Returns null (never throws) for unknown keys so the caller can fall through
+ * without preventDefault-ing keys that belong to the browser or other UI.
+ * Modifier gating (Ctrl/Cmd/Alt combos, typing in inputs) is the caller's
+ * job — this function only sees keys that are already eligible.
+ */
+export function interpretMapKey(input: MapKeyInput): MapKeyAction | null {
+  const { key, shiftKey } = input
+
+  switch (key) {
+    // Shift+arrows rotate/tilt (Google Earth & mapbox-gl convention);
+    // plain arrows pan. Screen-space pan: dy < 0 moves the view north.
+    case 'ArrowUp':
+      return shiftKey ? { type: 'pitch', delta: PITCH_STEP_DEG } : { type: 'pan', dx: 0, dy: -PAN_STEP_PX }
+    case 'ArrowDown':
+      return shiftKey ? { type: 'pitch', delta: -PITCH_STEP_DEG } : { type: 'pan', dx: 0, dy: PAN_STEP_PX }
+    case 'ArrowLeft':
+      return shiftKey ? { type: 'rotate', delta: -BEARING_STEP_DEG } : { type: 'pan', dx: -PAN_STEP_PX, dy: 0 }
+    case 'ArrowRight':
+      return shiftKey ? { type: 'rotate', delta: BEARING_STEP_DEG } : { type: 'pan', dx: PAN_STEP_PX, dy: 0 }
+
+    case 'PageUp':
+      return { type: 'zoom', delta: ZOOM_STEP }
+    case 'PageDown':
+      return { type: 'zoom', delta: -ZOOM_STEP }
+
+    // '=' is the physical '+' key unshifted on most layouts — Google Earth
+    // (and mapbox-gl) accept it so users don't have to press Shift to zoom.
+    case '+':
+    case '=':
+      return { type: 'zoom', delta: ZOOM_STEP }
+    case '-':
+    case '_':
+      return { type: 'zoom', delta: -ZOOM_STEP }
+
+    case 'n':
+    case 'N':
+      return { type: 'north' }
+    case 'u':
+    case 'U':
+      return { type: 'topDown' }
+    case 'r':
+    case 'R':
+      return { type: 'reset' }
+
+    default:
+      return null
+  }
+}
+
+/**
+ * The camera surface `applyMapKeyAction` drives — structurally satisfied by
+ * a real mapbox-gl Map, and trivially mockable in tests.
+ */
+export type MapCamera = {
+  panBy: (offset: [number, number], options?: { duration?: number }) => unknown
+  easeTo: (options: { zoom?: number; bearing?: number; pitch?: number; duration?: number }) => unknown
+  getZoom: () => number
+  getBearing: () => number
+  getPitch: () => number
+}
+
+/**
+ * Apply a key action to the map camera. Returns nothing.
+ * Short ease durations keep held-key auto-repeat feeling continuous (each
+ * repeat retargets the in-flight ease) instead of stuttering step-by-step.
+ * Out-of-range zoom/pitch targets are safe — easeTo clamps to the map's
+ * min/max internally, so no clamping here.
+ */
+export function applyMapKeyAction(map: MapCamera, action: MapKeyAction): void {
+  switch (action.type) {
+    case 'pan':
+      map.panBy([action.dx, action.dy], { duration: 100 })
+      break
+    case 'zoom':
+      map.easeTo({ zoom: map.getZoom() + action.delta, duration: 300 })
+      break
+    case 'rotate':
+      map.easeTo({ bearing: map.getBearing() + action.delta, duration: 300 })
+      break
+    case 'pitch':
+      map.easeTo({ pitch: map.getPitch() + action.delta, duration: 300 })
+      break
+    case 'north':
+      // Same 400 ms ease the compass button uses; easeTo picks the shortest
+      // rotation path automatically.
+      map.easeTo({ bearing: 0, duration: 400 })
+      break
+    case 'topDown':
+      map.easeTo({ pitch: 0, duration: 400 })
+      break
+    case 'reset':
+      map.easeTo({ bearing: 0, pitch: 0, duration: 400 })
+      break
+  }
+}


### PR DESCRIPTION
## What

Client request: replicate Google Earth's keyboard controls on the corridors map ("arrow keys, page up/pg dn etc.").

The map now answers the full Google Earth key set **regardless of focus** — users click side panels constantly, and mapbox-gl's built-in keyboard handler only works while the canvas itself is focused, which is why keys previously appeared dead.

| Key | Action |
|-----|--------|
| ← ↑ ↓ → | Pan 100 px |
| Shift + ← / → | Rotate bearing ∓15° |
| Shift + ↑ / ↓ | Tilt pitch ±10° |
| Page Up / Page Down | Zoom ±1 level |
| + / − (incl. = / _) | Zoom ±1 level |
| N | Face north |
| U | Look straight down (pitch 0) |
| R | Reset view (north + top-down) |

Step sizes match mapbox-gl's built-in KeyboardHandler defaults; the key layout matches Google Earth Pro. Held keys auto-repeat for continuous movement (short ease durations chain smoothly).

## Implementation

- `keyboardNav.ts` — pure `interpretMapKey` (key → action) + `applyMapKeyAction` (action → camera call against a minimal `MapCamera` interface), fully unit-tested without a real map.
- `MapProviderView` — one window-level keydown listener replaces the previous N-only handler. Skipped while typing (input/textarea/select/contentEditable) and for Ctrl/Cmd/Alt combos; `preventDefault` only once a key is claimed. Built-in mapbox-gl keyboard handler disabled (`keyboard={false}`) to avoid double-handling when the canvas does have focus.
- No conflicts with existing key handlers (compare modal: 1/2/3 + Esc; preview modal: Esc; drag-cancel: Esc — all disjoint).
- Documented in USER_MANUAL.md + USER_MANUAL.cs.md (new section 3.5) and CHANGELOG.

## Testing

- 774 tests pass (12 new in `keyboardNav.test.ts`), `tsc --noEmit` clean
- Manual pass in the desktop app recommended: hold-to-pan smoothness, rotate/tilt on Mapbox styles, and that raster styles (Mapy.cz) ignore tilt gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)