### PR TITLE
chore(release): 2.29.0 changelog roll-up + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This file tracks the **Windows desktop bundle** (tagged `desktop-v*`). Sub-app
 changes (Photo Helper, Map Corridors) reach end users only when bundled into a
 new desktop release.
 
-## [Unreleased]
+## [2.29.0] - 2026-07-20
 
 ### Fixed
 - **Map Corridors:** fixed **Print map** failing with *"Image data too large"*
@@ -19,14 +19,21 @@ new desktop release.
   and the resulting PNG blew past the desktop app's transfer limit. The
   exported image is now always exactly A4 at 300 DPI regardless of display
   scaling, and it travels to the save dialog as raw bytes instead of an
-  inflated base64 string.
+  inflated base64 string. ([#110])
 
 ### Added
 - **Map Corridors:** the map now answers **Google Earth keyboard controls**
   regardless of where you last clicked — arrow keys pan, **Shift+←/→** rotates,
   **Shift+↑/↓** tilts, **Page Up/Page Down** and **+/−** zoom, **N** faces
   north, **U** looks straight down, **R** resets the view. Hold a key to keep
-  moving.
+  moving. Keys never interfere with typing or open dialogs/dropdowns. ([#111])
+
+[#110]: https://github.com/lbehounek/AirQ-Competition-Helpers/pull/110
+[#111]: https://github.com/lbehounek/AirQ-Competition-Helpers/pull/111
+
+## [2.28.0] - 2026-06-30
+
+### Added
 - **Guided onboarding tour.** The launcher, Map Corridors and the Photo Editor
   now walk new organizers through the whole workflow — starting with the basics
   (load route & photos → sort track/turning → split the sets → send → lay out &

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airq/desktop",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "AirQ Competition Helpers - Desktop App for FAI Rally Flying Competitions",
   "main": "main.js",
   "author": "AirQ Competition Helpers",


### PR DESCRIPTION
Release bookkeeping for desktop-v2.29.0:

- New **[2.29.0]** section: print-size fix (#110) + Google Earth keyboard navigation (#111)
- Backfills the missing **[2.28.0]** section (onboarding tour shipped 2026-06-30 but its entry was stranded under Unreleased)
- `frontend/desktop/package.json` version → 2.29.0 (CI derives the release version from the tag; this keeps the file consistent)

Docs-only + version bump — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)